### PR TITLE
Add tls for all route options in ODH controler.

### DIFF
--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -73,6 +73,11 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
+	} else {
+		finalRoute.Spec.TLS = &routev1.TLSConfig{
+			Termination:                   routev1.TLSTerminationEdge,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		}
 	}
 
 	return finalRoute


### PR DESCRIPTION
## Description
This change will ensure all routes are tls enabled, regardless of whether auth is enabled or not.

## Testing Instructions 
1. Install ModelMesh via ODH [[1]](https://github.com/opendatahub-io/odh-manifests/tree/master/model-mesh#installation-process) 
2. Scale down ODH operator and odh controller
3. Deploy ODH controller from this PR branch locally or via a new image 
4. create serving run time + inference, ensure serving runtime has `enabled-route: true` annotation, but do not enable auth via `enable-auth` annotation
5. confirm the inference route is tls enabled, with `https` protocol

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
