### PR TITLE
Fix docker-build in Makefile to use Containerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build . -f ./Containerfile -t ${IMG}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
docker-build target in Makefile failed because this repository uses Containerfile instead of Dockerfile.
In order to fix this, -f option need to be added

## How Has This Been Tested?
`make docker-build`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
