### PR TITLE
Implement simple logic for automatic ServingRuntime selection

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -59,15 +59,17 @@ var (
 )
 
 const (
-	WorkingNamespace    = "default"
-	MonitoringNS        = "monitoring-ns"
-	RoleBindingPath     = "./testdata/results/model-server-ns-role.yaml"
-	ServingRuntimePath1 = "./testdata/deploy/test-openvino-serving-runtime-1.yaml"
-	ServingRuntimePath2 = "./testdata/deploy/test-openvino-serving-runtime-2.yaml"
-	InferenceService1   = "./testdata/deploy/openvino-inference-service-1.yaml"
-	ExpectedRoutePath   = "./testdata/results/example-onnx-mnist-route.yaml"
-	timeout             = time.Second * 20
-	interval            = time.Millisecond * 10
+	WorkingNamespace           = "default"
+	MonitoringNS               = "monitoring-ns"
+	RoleBindingPath            = "./testdata/results/model-server-ns-role.yaml"
+	ServingRuntimePath1        = "./testdata/deploy/test-openvino-serving-runtime-1.yaml"
+	ServingRuntimePath2        = "./testdata/deploy/test-openvino-serving-runtime-2.yaml"
+	InferenceService1          = "./testdata/deploy/openvino-inference-service-1.yaml"
+	InferenceServiceNoRuntime  = "./testdata/deploy/openvino-inference-service-no-runtime.yaml"
+	ExpectedRoutePath          = "./testdata/results/example-onnx-mnist-route.yaml"
+	ExpectedRouteNoRuntimePath = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
+	timeout                    = time.Second * 20
+	interval                   = time.Millisecond * 10
 )
 
 func TestAPIs(t *testing.T) {

--- a/controllers/testdata/deploy/openvino-inference-service-no-runtime.yaml
+++ b/controllers/testdata/deploy/openvino-inference-service-no-runtime.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: example-onnx-mnist-no-runtime
+  namespace: default
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: onnx
+      storage:
+        key: testkey
+        path: /testpath/test

--- a/controllers/testdata/results/example-onnx-mnist-no-runtime-route.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-no-runtime-route.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: example-onnx-mnist-no-runtime
+  namespace: default
+  labels:
+    inferenceservice-name: "example-onnx-mnist-no-runtime"
+spec:
+  path: /v2/models/example-onnx-mnist-no-runtime
+  to:
+    kind: Service
+    name: modelmesh-serving
+    weight: 100
+  port:
+    targetPort: 8443
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
## Description
An InferenceService is allowed to omit specifying a runtime. This should lead to automatic selection of a ServingRuntime from an allowed pool of ServingRuntimes.

These changes implement the automatic selection of a ServingRuntime: if there are several runtimes available, order priority is by creation date (most recent first). If several runtimes have the same creation date, priority is by alphabetical order.

## How Has This Been Tested?
1. Creating one or more ServingRuntime resources, where one (or more) of theirs supportedModelFormats has `autoSelect: true`.
2. Then, create an InferenceService without specifying a `runtime`.
    * Test using a model format that would match an auto-selectable ServingRuntime
    * Test using a model format that would _not_ match any ServingRuntime

## Testing Instructions
Live build is here: quay.io/edgarhz/rhods-operator-live-catalog:1.23.0-7468

* Install rhods from the provided live build, or install the model controller from this PR.
* Create a ServingRuntime that has model formats with `autoSelect: true`
  * The [test-openvino-serving-runtime-1.yaml](https://github.com/opendatahub-io/odh-model-controller/blob/ab9590f6d9265f0fab31100610c35e971e354f34/controllers/testdata/deploy/test-openvino-serving-runtime-1.yaml#L29-L31) used in unit tests works.
* Create an InferenceService that does not specify a runtime
  * The [openvino-inference-service-no-runtime.yaml](https://github.com/opendatahub-io/odh-model-controller/pull/20/files#diff-f553173b111481bfa595c9980b989654e13d1879823f6a9bdc12a78189458d69) added in this PR works with the mentioned ServiceRuntime in the previous bullet.
* Check that a route is created correctly.
  * If you are using the two resources mentioned in the previous points, `oc get route -n default example-onnx-mnist-no-runtime` should return a result. This would indicate that the odh-model-controller is running OK (before this PR, it crashed).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
