### PR TITLE
Implement traffic splitting

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - serving.kserve.io

--- a/controllers/inferenceservice_virtualservice.go
+++ b/controllers/inferenceservice_virtualservice.go
@@ -18,8 +18,8 @@ package controllers
 import (
 	"context"
 	"reflect"
+	"strconv"
 
-	predictorv1 "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
 	inferenceservicev1 "github.com/kserve/modelmesh-serving/apis/serving/v1beta1"
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -29,38 +29,217 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewInferenceServiceVirtualService defines the desired VirtualService object
 func NewInferenceServiceVirtualService(inferenceservice *inferenceservicev1.InferenceService) *virtualservicev1.VirtualService {
+	grpcRoute := &v1alpha3.HTTPRoute{
+		Match: []*v1alpha3.HTTPMatchRequest{{
+			Method: &v1alpha3.StringMatch{MatchType: &v1alpha3.StringMatch_Exact{Exact: "POST"}},
+			Headers: map[string]*v1alpha3.StringMatch{
+				"content-type": {MatchType: &v1alpha3.StringMatch_Prefix{Prefix: "application/grpc"}},
+				"mm-vmodel-id": {MatchType: &v1alpha3.StringMatch_Exact{Exact: inferenceservice.Name}},
+			},
+		}},
+		Route: []*v1alpha3.HTTPRouteDestination{
+			{
+				Destination: &v1alpha3.Destination{
+					Host: "modelmesh-serving." + inferenceservice.Namespace + ".svc.cluster.local",
+					Port: &v1alpha3.PortSelector{
+						Number: 8033,
+					},
+				},
+			},
+		},
+	}
+
+	httpRoute := &v1alpha3.HTTPRoute{
+		Match: []*v1alpha3.HTTPMatchRequest{{
+			Uri: &v1alpha3.StringMatch{
+				MatchType: &v1alpha3.StringMatch_Exact{
+					Exact: "/modelmesh/" + inferenceservice.Namespace + "/v2/models/" + inferenceservice.Name + "/infer",
+				},
+			},
+		}},
+		Rewrite: &v1alpha3.HTTPRewrite{
+			Uri: "/v2/models/" + inferenceservice.Name + "/infer",
+		},
+		Route: []*v1alpha3.HTTPRouteDestination{{
+			Destination: &v1alpha3.Destination{
+				Host: "modelmesh-serving." + inferenceservice.Namespace + ".svc.cluster.local",
+				Port: &v1alpha3.PortSelector{
+					Number: 8008,
+				},
+			},
+		}},
+	}
+
 	return &virtualservicev1.VirtualService{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{Name: inferenceservice.Name, Namespace: inferenceservice.Namespace, Labels: map[string]string{"inferenceservice-name": inferenceservice.Name}},
 		Spec: v1alpha3.VirtualService{
 			Hosts: []string{"*"},
-			Http: []*v1alpha3.HTTPRoute{{
-				Match: []*v1alpha3.HTTPMatchRequest{{
-					Uri: &v1alpha3.StringMatch{
-						MatchType: &v1alpha3.StringMatch_Prefix{
-							Prefix: "/modelmesh/" + inferenceservice.Namespace + "/",
-						},
-					},
-				}},
-				Rewrite: &v1alpha3.HTTPRewrite{
-					Uri: "/",
-				},
-				Route: []*v1alpha3.HTTPRouteDestination{{
-					Destination: &v1alpha3.Destination{
-						Host: "modelmesh-serving." + inferenceservice.Namespace + ".svc.cluster.local",
-						Port: &v1alpha3.PortSelector{
-							Number: 8008,
-						},
-					},
-				}},
-			}},
+			Http:  []*v1alpha3.HTTPRoute{grpcRoute, httpRoute},
 		},
 		Status: v1alpha1.IstioStatus{},
 	}
+}
+
+func buildTrafficSplittingGrpcRoute(vmodel string, validISvcs []inferenceservicev1.InferenceService) (*v1alpha3.HTTPRoute, error) {
+	servingNamespace := validISvcs[0].Namespace
+
+	grpcDestinations := make([]*v1alpha3.HTTPRouteDestination, len(validISvcs), len(validISvcs))
+	for idx, isvc := range validISvcs {
+		grpcDestination := v1alpha3.HTTPRouteDestination{
+			Destination: &v1alpha3.Destination{
+				Host: "modelmesh-serving." + servingNamespace + ".svc.cluster.local",
+				Port: &v1alpha3.PortSelector{
+					Number: 8033,
+				},
+			},
+			Headers: &v1alpha3.Headers{
+				Request: &v1alpha3.Headers_HeaderOperations{
+					Set: map[string]string{"mm-vmodel-id": isvc.Name},
+				},
+			},
+		}
+
+		if percentStr, ok := isvc.Annotations["serving.kserve.io/canaryTrafficPercent"]; ok {
+			percent, parseErr := strconv.ParseInt(percentStr, 10, 32)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			grpcDestination.Weight = int32(percent)
+		}
+
+		grpcDestinations[idx] = &grpcDestination
+	}
+
+	return &v1alpha3.HTTPRoute{
+		Name: "grpc-routing",
+		Match: []*v1alpha3.HTTPMatchRequest{{
+			Method: &v1alpha3.StringMatch{MatchType: &v1alpha3.StringMatch_Exact{Exact: "POST"}},
+			Headers: map[string]*v1alpha3.StringMatch{
+				"content-type": {MatchType: &v1alpha3.StringMatch_Prefix{Prefix: "application/grpc"}},
+				"mm-vmodel-id": {MatchType: &v1alpha3.StringMatch_Exact{Exact: vmodel}},
+			},
+		}},
+		Route: grpcDestinations,
+	}, nil
+}
+
+func buildTrafficSplittingHttpRoute(vmodel string, validISvcs []inferenceservicev1.InferenceService) (*v1alpha3.HTTPRoute, error) {
+	servingNamespace := validISvcs[0].Namespace
+
+	splitRoutes := make([]*v1alpha3.HTTPRouteDestination, len(validISvcs), len(validISvcs))
+	for idx, isvc := range validISvcs {
+		split := v1alpha3.HTTPRouteDestination{
+			Destination: &v1alpha3.Destination{
+				Host: "istio-ingressgateway.istio-system.svc.cluster.local",
+				Port: &v1alpha3.PortSelector{
+					Number: 80,
+				},
+			},
+			Headers: &v1alpha3.Headers{
+				Request: &v1alpha3.Headers_HeaderOperations{
+					Set: map[string]string{"x-vmodel": isvc.Name},
+				},
+			},
+		}
+
+		if percentStr, ok := isvc.Annotations["serving.kserve.io/canaryTrafficPercent"]; ok {
+			percent, parseErr := strconv.ParseInt(percentStr, 10, 32)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			split.Weight = int32(percent)
+		}
+
+		splitRoutes[idx] = &split
+	}
+
+	return &v1alpha3.HTTPRoute{
+		Match: []*v1alpha3.HTTPMatchRequest{{
+			Uri: &v1alpha3.StringMatch{
+				MatchType: &v1alpha3.StringMatch_Exact{
+					Exact: "/modelmesh/" + servingNamespace + "/v2/models/" + vmodel + "/infer",
+				},
+			},
+		}},
+		Rewrite: &v1alpha3.HTTPRewrite{
+			Uri: "/vmodel-route/" + servingNamespace + "/" + vmodel + "/infer",
+		},
+		Route: splitRoutes,
+	}, nil
+}
+
+func buildHttpRedirectionRoutes(vmodel string, validISvcs []inferenceservicev1.InferenceService) []*v1alpha3.HTTPRoute {
+	servingNamespace := validISvcs[0].Namespace
+
+	splitRedirectionRoutes := make([]*v1alpha3.HTTPRoute, len(validISvcs), len(validISvcs))
+	for idx, isvc := range validISvcs {
+		redirection := &v1alpha3.HTTPRoute{
+			Match: []*v1alpha3.HTTPMatchRequest{{
+				Uri: &v1alpha3.StringMatch{
+					MatchType: &v1alpha3.StringMatch_Exact{
+						Exact: "/vmodel-route/" + servingNamespace + "/" + vmodel + "/infer",
+					},
+				},
+				Headers: map[string]*v1alpha3.StringMatch{
+					"x-vmodel": {MatchType: &v1alpha3.StringMatch_Exact{Exact: isvc.Name}},
+				},
+			}},
+			Rewrite: &v1alpha3.HTTPRewrite{
+				Uri: "/v2/models/" + isvc.Name + "/infer",
+			},
+			Route: []*v1alpha3.HTTPRouteDestination{{
+				Destination: &v1alpha3.Destination{
+					Host: "modelmesh-serving." + servingNamespace + ".svc.cluster.local",
+					Port: &v1alpha3.PortSelector{
+						Number: 8008,
+					},
+				},
+			}},
+		}
+
+		splitRedirectionRoutes[idx] = redirection
+	}
+
+	return splitRedirectionRoutes
+}
+
+func buildTrafficSplittingVirtualService(vmodel string, validISvcs []inferenceservicev1.InferenceService) (*virtualservicev1.VirtualService, error) {
+	grpcRoute, err := buildTrafficSplittingGrpcRoute(vmodel, validISvcs)
+	if err != nil {
+		return nil, err
+	}
+
+	httpSplitRoute, err := buildTrafficSplittingHttpRoute(vmodel, validISvcs)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRedirectionRoutes := buildHttpRedirectionRoutes(vmodel, validISvcs)
+
+	allVsRoutes := []*v1alpha3.HTTPRoute{grpcRoute, httpSplitRoute}
+	allVsRoutes = append(allVsRoutes, httpRedirectionRoutes...)
+
+	return &virtualservicev1.VirtualService{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmodel + "-splitting",
+			Namespace: validISvcs[0].Namespace,
+			Annotations: map[string]string{
+				"serving.kserve.io/model-tag": vmodel,
+			},
+		},
+		Spec: v1alpha3.VirtualService{
+			Hosts: []string{"*"},
+			Http:  allVsRoutes,
+		},
+		Status: v1alpha1.IstioStatus{},
+	}, nil
 }
 
 // CompareInferenceServiceVirtualServices checks if two VirtualServices are equal, if not return false
@@ -129,6 +308,79 @@ func DeepCompare(a, b interface{}) bool {
 	}
 }
 
+func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(namespace, vmodel string, existentVs *virtualservicev1.VirtualService, ctx context.Context) (*virtualservicev1.VirtualService, error) {
+
+	// Get list of InferenceServices tagged with `model-tag`
+	taggedISvcs := &inferenceservicev1.InferenceServiceList{}
+	err := r.List(ctx, taggedISvcs, client.InNamespace(namespace), client.MatchingLabels{"serving.kserve.io/model-tag": vmodel})
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out ISVC that are being deleted
+	var validISvcs []inferenceservicev1.InferenceService
+	for _, isvc := range taggedISvcs.Items {
+		if isvc.ObjectMeta.DeletionTimestamp.IsZero() {
+			validISvcs = append(validISvcs, isvc)
+		}
+	}
+
+	// If there are no non-deleted ISVCs, delete the VirtualService for traffic splitting
+	if len(validISvcs) == 0 && len(existentVs.Name) != 0 {
+		err = r.Delete(ctx, existentVs, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	// Build the VirtualService for traffic splitting
+	desiredVirtualService, err := buildTrafficSplittingVirtualService(vmodel, validISvcs)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Something should control if the route is created or not. What criteria to use?
+	desiredVirtualService.Spec.Gateways = []string{"opendatahub/odh-gateway"} // TODO get actual gateway to be used
+
+	// Create the VirtualService if it does not already exist
+	if len(existentVs.Name) == 0 {
+		// Create the VirtualService in the Openshift cluster
+		err = r.Create(ctx, desiredVirtualService)
+		if err != nil && !apierrs.IsAlreadyExists(err) {
+			return nil, err
+		}
+
+		return desiredVirtualService, nil
+	} else {
+		desiredVirtualService.Name = existentVs.Name
+		if !CompareInferenceServiceVirtualServices(desiredVirtualService, existentVs) {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				currentVs := &virtualservicev1.VirtualService{}
+				// Get the last VirtualService revision
+				getLastVSErr := r.Get(ctx, types.NamespacedName{
+					Name:      desiredVirtualService.Name,
+					Namespace: namespace,
+				}, currentVs)
+				if getLastVSErr != nil {
+					return getLastVSErr
+				}
+
+				currentVs.Spec = *desiredVirtualService.Spec.DeepCopy()
+				currentVs.ObjectMeta.Labels = desiredVirtualService.ObjectMeta.Labels
+				currentVs.ObjectMeta.Annotations = desiredVirtualService.ObjectMeta.Annotations
+				return r.Update(ctx, currentVs)
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return desiredVirtualService, nil
+	}
+}
+
 // Reconcile will manage the creation, update and deletion of the VirtualService returned
 // by the newVirtualService function
 func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferenceservice *inferenceservicev1.InferenceService,
@@ -136,16 +388,7 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferences
 	// Initialize logger format
 	log := r.Log.WithValues("inferenceservice", inferenceservice.Name, "namespace", inferenceservice.Namespace)
 
-	desiredServingRuntime := &predictorv1.ServingRuntime{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      *inferenceservice.Spec.Predictor.Model.Runtime,
-		Namespace: inferenceservice.Namespace,
-	}, desiredServingRuntime)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			log.Info("Serving Runtime ", *inferenceservice.Spec.Predictor.Model.Runtime, " desired by ", inferenceservice.Name, "was not found in namespace")
-		}
-	}
+	desiredServingRuntime := r.findSupportingRuntimeForISvc(ctx, log, inferenceservice)
 
 	// Generate the desired VirtualService and expose externally if enabled
 	desiredVirtualService := newVirtualService(inferenceservice)
@@ -156,7 +399,7 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferences
 	// Create the VirtualService if it does not already exist
 	foundVirtualService := &virtualservicev1.VirtualService{}
 	justCreated := false
-	err = r.Get(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Name:      desiredVirtualService.Name,
 		Namespace: inferenceservice.Namespace,
 	}, foundVirtualService)
@@ -215,4 +458,94 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferences
 func (r *OpenshiftInferenceServiceReconciler) ReconcileVirtualService(
 	inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
 	return r.reconcileVirtualService(inferenceservice, ctx, NewInferenceServiceVirtualService)
+}
+
+func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
+	inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
+	// Initialize logger format
+	log := r.Log.WithValues("inferenceservice", inferenceservice.Name, "namespace", inferenceservice.Namespace)
+	log.Info("Reconciling traffic splitting")
+
+	// Fetch associated VirtualService, if there is one
+	associatedVs := &virtualservicev1.VirtualService{}
+	if vsName, vsOk := inferenceservice.Annotations["serving.opendatahub.io/vs-traffic-splitting"]; vsOk {
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      vsName,
+			Namespace: inferenceservice.Namespace,
+		}, associatedVs)
+
+		if err != nil && !apierrs.IsNotFound(err) {
+			log.Error(err, "Error getting associated VirtualService", "virtualService", vsName)
+			return err
+		}
+
+		log.Info("Associated VirtualService found", "virtualService", vsName)
+	}
+
+	var isvcModelTag, vsModelTag string
+
+	if tag, tagOk := inferenceservice.Labels["serving.kserve.io/model-tag"]; tagOk {
+		isvcModelTag = tag
+	}
+
+	if tag, tagOk := associatedVs.Annotations["serving.kserve.io/model-tag"]; tagOk {
+		vsModelTag = tag
+	}
+
+	// If there is an associated (old) VirtualService, it must be updated in two cases:
+	// - When the ISVC has a blank model-tag
+	//    - This means that the ISVC was un-tagged (i.e. removed from the group)
+	// - When the ISVC has a tag that is NOT equal to the VS tag
+	//    - This means that the ISVC was re-tagged. It should be removed from a group and added to another one.
+	//      Here we deal with removing the ISVC from the old group
+	if len(associatedVs.Name) != 0 {
+		if len(isvcModelTag) == 0 || isvcModelTag != vsModelTag {
+			resultingVs, err := r.updateTrafficSplitVirtualService(inferenceservice.Namespace, vsModelTag, associatedVs, ctx)
+			if err != nil {
+				log.Error(err, "Unable to update associated old VirtualService for traffic splitting", "model-tag", vsModelTag, "virtualService", associatedVs.Name)
+				return err
+			}
+
+			if resultingVs == nil {
+				log.Info("VirtualService for traffic splitting was deleted", "model-tag", vsModelTag, "virtualService", associatedVs.Name)
+			}
+
+			// Unset associatedVs as it no longer is tied to the isvc
+			associatedVs = &virtualservicev1.VirtualService{}
+		}
+	}
+
+	// If the ISVC has model-tag, a VirtualService must be created or updated in these cases:
+	// - When the ISVC is being deleted
+	//    - This should cause removal of the ISVC from the traffic split
+	//	  - If this ISVC was the last one in the group, the VirtualService should be deleted
+	// - When the ISVC was created or updated
+	//    - If the ISVC got a model-tag, a VirtualService is going to be created if it does not exist.
+	//      When a VirtualService for the group already exists, it is updated to add the ISVC to the split.
+	//    - There is also the case when the traffic split precentages are adjusted. The existent
+	//      VirtualService is updated.
+	vsNameToAssociate := ""
+	if len(isvcModelTag) != 0 {
+		resultingVs, err := r.updateTrafficSplitVirtualService(inferenceservice.Namespace, isvcModelTag, associatedVs, ctx)
+		if err != nil {
+			log.Error(err, "Unable to create or update the VirtualService for traffic splitting", "model-tag", isvcModelTag, "virtualService", associatedVs.Name)
+			return err
+		}
+
+		vsNameToAssociate = resultingVs.Name
+	}
+
+	// Update annotation of the InferenceService to store/remove the virtual service name for traffic splitting
+	if vsName := inferenceservice.Annotations["serving.opendatahub.io/vs-traffic-splitting"]; vsNameToAssociate != vsName {
+		inferenceservice.ObjectMeta.Annotations["serving.opendatahub.io/vs-traffic-splitting"] = vsNameToAssociate
+		if len(vsNameToAssociate) == 0 {
+			delete(inferenceservice.ObjectMeta.Annotations, "serving.opendatahub.io/vs-traffic-splitting")
+		}
+		updateIsvcErr := r.Update(ctx, inferenceservice)
+		if updateIsvcErr != nil {
+			return updateIsvcErr
+		}
+	}
+
+	return nil
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -73,10 +73,14 @@ const (
 	ServingRuntimeNoRoutePath1        = "./testdata/deploy/test-openvino-serving-runtime-1-no-route.yaml"
 	InferenceService1                 = "./testdata/deploy/openvino-inference-service-1.yaml"
 	InferenceServiceNoRuntime         = "./testdata/deploy/openvino-inference-service-no-runtime.yaml"
+	InferenceServiceWithTag1          = "./testdata/deploy/openvino-inference-service-with-model-tag-1.yaml"
+	InferenceServiceWithTag2          = "./testdata/deploy/openvino-inference-service-with-model-tag-2.yaml"
 	ExpectedRoutePath                 = "./testdata/results/example-onnx-mnist-route.yaml"
 	ExpectedRouteNoRuntimePath        = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
 	ExpectedVirtualServiceRoutePath   = "./testdata/results/example-onnx-mnist-virtualservice-route.yaml"
 	ExpectedVirtualServiceNoRoutePath = "./testdata/results/example-onnx-mnist-virtualservice-no-route.yaml"
+	ExpectedVsSplitV1                 = "./testdata/results/example-onnx-mnist-virtualservice-split-v1.yaml"
+	ExpectedVsSplitV1V2               = "./testdata/results/example-onnx-mnist-virtualservice-split-v1v2.yaml"
 	timeout                           = time.Second * 5
 	interval                          = time.Millisecond * 10
 )

--- a/controllers/testdata/deploy/openvino-inference-service-with-model-tag-1.yaml
+++ b/controllers/testdata/deploy/openvino-inference-service-with-model-tag-1.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: example-onnx-mnist-v1
+  namespace: default
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+    serving.kserve.io/canaryTrafficPercent: "50"
+  labels:
+    serving.kserve.io/model-tag: onnx-mnist
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: onnx
+      storage:
+        key: testkey
+        path: /testpath/test

--- a/controllers/testdata/deploy/openvino-inference-service-with-model-tag-2.yaml
+++ b/controllers/testdata/deploy/openvino-inference-service-with-model-tag-2.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: example-onnx-mnist-v2
+  namespace: default
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+    serving.kserve.io/canaryTrafficPercent: "50"
+  labels:
+    serving.kserve.io/model-tag: onnx-mnist
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: onnx
+      storage:
+        key: testkey
+        path: /testpath/test

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-no-route.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-no-route.yaml
@@ -10,10 +10,23 @@ spec:
   - '*'
   http:
   - match:
+    - method:
+        exact: POST
+      headers:
+        content-type:
+          prefix: application/grpc
+        mm-vmodel-id:
+          exact: example-onnx-mnist
+    route:
+    - destination:
+        host: modelmesh-serving.ns-dssnm.svc.cluster.local
+        port:
+          number: 8033
+  - match:
     - uri:
-        prefix: /modelmesh/ns-dssnm/
+        exact: /modelmesh/ns-dssnm/v2/models/example-onnx-mnist/infer
     rewrite:
-      uri: /
+      uri: /v2/models/example-onnx-mnist/infer
     route:
     - destination:
         host: modelmesh-serving.ns-dssnm.svc.cluster.local

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-route.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-route.yaml
@@ -12,10 +12,23 @@ spec:
   - '*'
   http:
   - match:
+    - method:
+        exact: POST
+      headers:
+        content-type:
+          prefix: application/grpc
+        mm-vmodel-id:
+          exact: example-onnx-mnist
+    route:
+    - destination:
+        host: modelmesh-serving.ns-dssnm.svc.cluster.local
+        port:
+          number: 8033
+  - match:
     - uri:
-        prefix: /modelmesh/ns-dssnm/
+        exact: /modelmesh/ns-dssnm/v2/models/example-onnx-mnist/infer
     rewrite:
-      uri: /
+      uri: /v2/models/example-onnx-mnist/infer
     route:
     - destination:
         host: modelmesh-serving.ns-dssnm.svc.cluster.local

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: onnx-mnist-splitting
+  namespace: ns-dssnm
+  annotations:
+    serving.kserve.io/model-tag: onnx-mnist
+spec:
+  gateways:
+  - opendatahub/odh-gateway
+  hosts:
+  - '*'
+  http:
+  - name: grpc-routing
+    match:
+    - method:
+        exact: POST
+      headers:
+        content-type:
+          prefix: application/grpc
+        mm-vmodel-id:
+          exact: onnx-mnist
+    route:
+    - destination:
+        host: modelmesh-serving.ns-dssnm.svc.cluster.local
+        port:
+          number: 8033
+      headers:
+        request:
+          set:
+            mm-vmodel-id: example-onnx-mnist-v1
+      weight: 50
+  - match:
+    - uri:
+        exact: /modelmesh/ns-dssnm/v2/models/onnx-mnist/infer
+    rewrite:
+      uri: /vmodel-route/ns-dssnm/onnx-mnist/infer
+    route:
+    - destination:
+        host: istio-ingressgateway.istio-system.svc.cluster.local
+        port:
+          number: 80
+      headers:
+        request:
+          set:
+            x-vmodel: example-onnx-mnist-v1
+      weight: 50
+  - match:
+      - uri:
+          exact: /vmodel-route/ns-dssnm/onnx-mnist/infer
+        headers:
+          x-vmodel:
+            exact: example-onnx-mnist-v1
+    rewrite:
+      uri: /v2/models/example-onnx-mnist-v1/infer
+    route:
+      - destination:
+          host: modelmesh-serving.ns-dssnm.svc.cluster.local
+          port:
+            number: 8008

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1v2.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1v2.yaml
@@ -1,0 +1,91 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: onnx-mnist-splitting
+  namespace: ns-dssnm
+  annotations:
+    serving.kserve.io/model-tag: onnx-mnist
+spec:
+  gateways:
+  - opendatahub/odh-gateway
+  hosts:
+  - '*'
+  http:
+  - name: grpc-routing
+    match:
+    - method:
+        exact: POST
+      headers:
+        content-type:
+          prefix: application/grpc
+        mm-vmodel-id:
+          exact: onnx-mnist
+    route:
+    - destination:
+        host: modelmesh-serving.ns-dssnm.svc.cluster.local
+        port:
+          number: 8033
+      headers:
+        request:
+          set:
+            mm-vmodel-id: example-onnx-mnist-v1
+      weight: 50
+    - destination:
+        host: modelmesh-serving.ns-dssnm.svc.cluster.local
+        port:
+          number: 8033
+      headers:
+        request:
+          set:
+            mm-vmodel-id: example-onnx-mnist-v2
+      weight: 50
+  - match:
+    - uri:
+        exact: /modelmesh/ns-dssnm/v2/models/onnx-mnist/infer
+    rewrite:
+      uri: /vmodel-route/ns-dssnm/onnx-mnist/infer
+    route:
+    - destination:
+        host: istio-ingressgateway.istio-system.svc.cluster.local
+        port:
+          number: 80
+      headers:
+        request:
+          set:
+            x-vmodel: example-onnx-mnist-v1
+      weight: 50
+    - destination:
+        host: istio-ingressgateway.istio-system.svc.cluster.local
+        port:
+          number: 80
+      headers:
+        request:
+          set:
+            x-vmodel: example-onnx-mnist-v2
+      weight: 50
+  - match:
+    - uri:
+        exact: /vmodel-route/ns-dssnm/onnx-mnist/infer
+      headers:
+        x-vmodel:
+          exact: example-onnx-mnist-v1
+    rewrite:
+      uri: /v2/models/example-onnx-mnist-v1/infer
+    route:
+      - destination:
+          host: modelmesh-serving.ns-dssnm.svc.cluster.local
+          port:
+            number: 8008
+  - match:
+    - uri:
+        exact: /vmodel-route/ns-dssnm/onnx-mnist/infer
+      headers:
+        x-vmodel:
+          exact: example-onnx-mnist-v2
+    rewrite:
+      uri: /v2/models/example-onnx-mnist-v2/infer
+    route:
+      - destination:
+          host: modelmesh-serving.ns-dssnm.svc.cluster.local
+          port:
+            number: 8008


### PR DESCRIPTION
Add support for configuring traffic splitting by using a Service Mesh

## Description
Traffic splitting support depends on Service Mesh. When a Service Mesh is enabled, VirtualServices are created to route traffic to ModelMesh and OpenShift Routes are no longer created.

It is possible to do infer requests to specific InferenceServices, like before/currently. Annotations and Labels are used to group more than one InferenceService to create a logical group where traffic splitting would be done, and to configure how much traffic should be routed to each service in the group.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
