### PR TITLE
Add the grpc route creation option

### DIFF
--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -178,25 +178,23 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileRoute(inferenceservice *i
 
 	desiredServingRuntime := r.findSupportingRuntimeForISvc(ctx, log, inferenceservice)
 
-	// optionsList allows for creation of both grpc and http/s routes if desired
+	// optionsList allows for creation of both grpc and http/s routes as desired
 	var optionsList [2]string
 
 	createRoute, enableAuth, enableGrpc := false, false, false
+
+	// If routes need to be exposed, then enable both grpc and http/s
 	if desiredServingRuntime.Annotations["enable-route"] == "true" {
 		createRoute = true
-	}
-	if desiredServingRuntime.Annotations["enable-http"] == "true" {
+		enableGrpc = true
+		optionsList[1] = "grpc"
+
 		if desiredServingRuntime.Annotations["enable-auth"] == "true" {
 			enableAuth = true
 			optionsList[0] = "https"
 		} else {
 			optionsList[0] = "http"
 		}
-	}
-
-	if desiredServingRuntime.Annotations["enable-grpc"] == "true" {
-		enableGrpc = true
-		optionsList[1] = "grpc"
 	}
 
 	for _, v := range optionsList {

--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -38,14 +38,16 @@ const (
 	modelmeshServiceName     = "modelmesh-serving"
 	modelmeshAuthServicePort = 8443
 	modelmeshServicePort     = 8008
+	modelmeshGrpcPort        = 8033
 )
 
 // NewInferenceServiceRoute defines the desired route object
-func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceService, enableAuth bool) *routev1.Route {
+func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceService, enableAuth bool, enableGrpc bool) *routev1.Route {
 
+	// create a http route
 	finalRoute := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      inferenceservice.Name,
+			Name:      inferenceservice.Name + "-http",
 			Namespace: inferenceservice.Namespace,
 			Labels: map[string]string{
 				"inferenceservice-name": inferenceservice.Name,
@@ -62,13 +64,19 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 			},
 			WildcardPolicy: routev1.WildcardPolicyNone,
 			Path:           "/v2/models/" + inferenceservice.Name,
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+			},
 		},
 		Status: routev1.RouteStatus{
 			Ingress: []routev1.RouteIngress{},
 		},
 	}
 
+	// if secure route is selected, create the https route
 	if enableAuth {
+		finalRoute.ObjectMeta.Name = inferenceservice.Name + "-https"
 		finalRoute.Spec.Port = &routev1.RoutePort{
 			TargetPort: intstr.FromInt(modelmeshAuthServicePort),
 		}
@@ -76,9 +84,16 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
-	} else {
+	}
+
+	// if grpc is selected, create a grpc route
+	if enableGrpc {
+		finalRoute.ObjectMeta.Name = inferenceservice.Name + "-grpc"
+		finalRoute.Spec.Port = &routev1.RoutePort{
+			TargetPort: intstr.FromInt(modelmeshGrpcPort),
+		}
 		finalRoute.Spec.TLS = &routev1.TLSConfig{
-			Termination:                   routev1.TLSTerminationEdge,
+			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
 	}
@@ -157,83 +172,109 @@ func (r *OpenshiftInferenceServiceReconciler) findSupportingRuntimeForISvc(ctx c
 // Reconcile will manage the creation, update and deletion of the route returned
 // by the newRoute function
 func (r *OpenshiftInferenceServiceReconciler) reconcileRoute(inferenceservice *inferenceservicev1.InferenceService,
-	ctx context.Context, newRoute func(service *inferenceservicev1.InferenceService, enableAuth bool) *routev1.Route) error {
+	ctx context.Context, newRoute func(service *inferenceservicev1.InferenceService, enableAuth bool, enableGrpc bool) *routev1.Route) error {
 	// Initialize logger format
 	log := r.Log.WithValues("inferenceservice", inferenceservice.Name, "namespace", inferenceservice.Namespace)
 
 	desiredServingRuntime := r.findSupportingRuntimeForISvc(ctx, log, inferenceservice)
 
-	enableAuth := true
-	if desiredServingRuntime.Annotations["enable-auth"] != "true" {
-		enableAuth = false
-	}
-	createRoute := true
-	if desiredServingRuntime.Annotations["enable-route"] != "true" {
-		createRoute = false
-	}
+	// optionsList allows for creation of both grpc and http/s routes if desired
+	var optionsList [2]string
 
-	// Generate the desired route
-	desiredRoute := newRoute(inferenceservice, enableAuth)
-
-	// Create the route if it does not already exist
-	foundRoute := &routev1.Route{}
-	justCreated := false
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      desiredRoute.Name,
-		Namespace: inferenceservice.Namespace,
-	}, foundRoute)
-	if err != nil {
-		if !createRoute {
-			log.Info("Serving runtime does not have 'enable-route' annotation set to 'True'. Skipping route creation")
-			return nil
-		}
-		if apierrs.IsNotFound(err) {
-			log.Info("Creating Route")
-			// Add .metatada.ownerReferences to the route to be deleted by the
-			// Kubernetes garbage collector if the predictor is deleted
-			err = ctrl.SetControllerReference(inferenceservice, desiredRoute, r.Scheme)
-			if err != nil {
-				log.Error(err, "Unable to add OwnerReference to the Route")
-				return err
-			}
-			// Create the route in the Openshift cluster
-			err = r.Create(ctx, desiredRoute)
-			if err != nil && !apierrs.IsAlreadyExists(err) {
-				log.Error(err, "Unable to create the Route")
-				return err
-			}
-			justCreated = true
+	createRoute, enableAuth, enableGrpc := false, false, false
+	if desiredServingRuntime.Annotations["enable-route"] == "true" {
+		createRoute = true
+	}
+	if desiredServingRuntime.Annotations["enable-http"] == "true" {
+		if desiredServingRuntime.Annotations["enable-auth"] == "true" {
+			enableAuth = true
+			optionsList[0] = "https"
 		} else {
-			log.Error(err, "Unable to fetch the Route")
-			return err
+			optionsList[0] = "http"
 		}
 	}
 
-	if !createRoute {
-		log.Info("Serving Runtime does not have 'enable-route' annotation set to 'True'. Deleting existing route")
-		return r.Delete(ctx, foundRoute)
+	if desiredServingRuntime.Annotations["enable-grpc"] == "true" {
+		enableGrpc = true
+		optionsList[1] = "grpc"
 	}
-	// Reconcile the route spec if it has been manually modified
-	if !justCreated && !CompareInferenceServiceRoutes(*desiredRoute, *foundRoute) {
-		log.Info("Reconciling Route")
-		// Retry the update operation when the ingress controller eventually
-		// updates the resource version field
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			// Get the last route revision
-			if err := r.Get(ctx, types.NamespacedName{
-				Name:      desiredRoute.Name,
-				Namespace: inferenceservice.Namespace,
-			}, foundRoute); err != nil {
+
+	for _, v := range optionsList {
+
+		// Check which route to create
+		if v == "http" || v == "https" {
+			enableGrpc = false
+		} else if v == "grpc" {
+			enableAuth, enableGrpc = false, true
+		} else {
+			continue
+		}
+
+		// Generate the desired routes
+		desiredRoute := newRoute(inferenceservice, enableAuth, enableGrpc)
+
+		// Create the route if it does not already exist
+		foundRoute := &routev1.Route{}
+		justCreated := false
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      desiredRoute.Name,
+			Namespace: inferenceservice.Namespace,
+		}, foundRoute)
+
+		if err != nil {
+			if !createRoute {
+				log.Info("Serving runtime does not have 'enable-route' annotation set to 'True'. Skipping route creation")
+				return nil
+			}
+			if apierrs.IsNotFound(err) {
+				log.Info("Creating Route")
+				// Add .metatada.ownerReferences to the route to be deleted by the
+				// Kubernetes garbage collector if the predictor is deleted
+				err = ctrl.SetControllerReference(inferenceservice, desiredRoute, r.Scheme)
+				if err != nil {
+					log.Error(err, "Unable to add OwnerReference to the Route")
+					return err
+				}
+				// Create the route in the Openshift cluster
+				err = r.Create(ctx, desiredRoute)
+				if err != nil && !apierrs.IsAlreadyExists(err) {
+					log.Error(err, "Unable to create the Route")
+					return err
+				}
+				justCreated = true
+			} else {
+				log.Error(err, "Unable to fetch the Route")
 				return err
 			}
-			// Reconcile labels and spec field
-			foundRoute.Spec = desiredRoute.Spec
-			foundRoute.ObjectMeta.Labels = desiredRoute.ObjectMeta.Labels
-			return r.Update(ctx, foundRoute)
-		})
-		if err != nil {
-			log.Error(err, "Unable to reconcile the Route")
-			return err
+		}
+
+		if !createRoute {
+			log.Info("Serving Runtime does not have 'enable-route' annotation set to 'True'. Deleting existing route")
+			return r.Delete(ctx, foundRoute)
+		}
+
+		// Reconcile the route spec if it has been manually modified
+		if !justCreated && !CompareInferenceServiceRoutes(*desiredRoute, *foundRoute) {
+			log.Info("Reconciling Route")
+			// Retry the update operation when the ingress controller eventually
+			// updates the resource version field
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				// Get the last route revision
+				if err := r.Get(ctx, types.NamespacedName{
+					Name:      desiredRoute.Name,
+					Namespace: inferenceservice.Namespace,
+				}, foundRoute); err != nil {
+					return err
+				}
+				// Reconcile labels and spec field
+				foundRoute.Spec = desiredRoute.Spec
+				foundRoute.ObjectMeta.Labels = desiredRoute.ObjectMeta.Labels
+				return r.Update(ctx, foundRoute)
+			})
+			if err != nil {
+				log.Error(err, "Unable to reconcile the Route")
+				return err
+			}
 		}
 	}
 
@@ -241,7 +282,7 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileRoute(inferenceservice *i
 }
 
 // ReconcileRoute will manage the creation, update and deletion of the
-// TLS route when the predictor is reconciled
+// TLS route wheoptionsList[v]n the predictor is reconciled
 func (r *OpenshiftInferenceServiceReconciler) ReconcileRoute(
 	inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
 	return r.reconcileRoute(inferenceservice, ctx, NewInferenceServiceRoute)

--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -91,6 +91,7 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 		finalRoute.Spec.Port = &routev1.RoutePort{
 			TargetPort: intstr.FromInt(modelmeshGrpcPort),
 		}
+		finalRoute.Spec.Path = ""
 		finalRoute.Spec.TLS = &routev1.TLSConfig{
 			Termination:                   routev1.TLSTerminationPassthrough,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,

--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -47,7 +47,7 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 	// create a http route
 	finalRoute := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      inferenceservice.Name + "-http",
+			Name:      inferenceservice.Name,
 			Namespace: inferenceservice.Namespace,
 			Labels: map[string]string{
 				"inferenceservice-name": inferenceservice.Name,
@@ -76,7 +76,6 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 
 	// if secure route is selected, create the https route
 	if enableAuth {
-		finalRoute.ObjectMeta.Name = inferenceservice.Name + "-https"
 		finalRoute.Spec.Port = &routev1.RoutePort{
 			TargetPort: intstr.FromInt(modelmeshAuthServicePort),
 		}

--- a/controllers/inferenceservice_route.go
+++ b/controllers/inferenceservice_route.go
@@ -92,7 +92,7 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 			TargetPort: intstr.FromInt(modelmeshGrpcPort),
 		}
 		finalRoute.Spec.TLS = &routev1.TLSConfig{
-			Termination:                   routev1.TLSTerminationReencrypt,
+			Termination:                   routev1.TLSTerminationPassthrough,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Addressing [RHODS-6401](https://issues.redhat.com//browse/RHODS-6401) : https://issues.redhat.com/browse/RHODS-6401 

## How Has This Been Tested?
The port creation has been tested and is created as expected.
To test it, below are commands to follow in your terminal. 

First, an image needs to be build. A personal quay repo can be used if desired -- `selbi` will need to change to yours. Alternatively, one can use a ready image that was already build (`quay.io/selbi/odh-model-controller:grpc-v3`)
To re-create the image:
```
git clone https://github.com/heyselbi/odh-model-controller.git
cd odh-model-controller
git checkout rhods-6401-grpc
podman build -t quay.io/selbi/odh-model-controller:grpc-v4 .
podman push quay.io/selbi/odh-model-controller:grpc-v4
cd ../
```
Now deploy the new image with modelmesh-serving. First, login to your cluster (oc login...). **If you skipped image building part and decided to use the ready image, change the image tag from `:grpc-v4` to `:grpc-v3`.
```
git clone git@github.com:opendatahub-io/modelmesh-serving.git
git checkout release-v0.11.0-alpha
cd modelmesh-serving/opendatahub/odh-manifests/model-mesh
sed -i 's/opendatahub\/odh-model-controller:v0.11.0-alpha/selbi\/odh-model-controller:grpc-v4/' base/params.env
oc new-project opendatahub
kustomize build ./base  | oc apply -f -
```
Go to your cluster, and make sure that all pods are Running in opendatahub namespace. Or you can check with cli:
```
[selbi@fedora modelmesh-serving]$ oc get pods -n opendatahub
NAME                                    READY   STATUS    RESTARTS   AGE
etcd-5bc65bd9cf-9bshv                   1/1     Running   0          3m26s
modelmesh-controller-d49b698fc-8jppp    1/1     Running   0          3m26s
modelmesh-controller-d49b698fc-qjrld    1/1     Running   0          3m26s
modelmesh-controller-d49b698fc-wg92c    1/1     Running   0          3m26s
odh-model-controller-697d49b9bb-g2ppw   1/1     Running   0          26s
odh-model-controller-697d49b9bb-wn56p   1/1     Running   0          36s
odh-model-controller-697d49b9bb-xn5s4   1/1     Running   0          16s
```
Check that the image running in odh-model-controller is the one built earlier:
```
[selbi@fedora modelmesh-serving]$ oc get deployment/odh-model-controller -o wide
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE     CONTAINERS   IMAGES                                       SELECTOR
odh-model-controller   3/3     3            3           5m58s   manager      quay.io/selbi/odh-model-controller:grpc-v4   app.kubernetes.io/managed-by=odh-model-controller,app.kubernetes.io/part-of=model-mesh,control-plane=odh-model-controller
```

Now we deploy a sample servingRuntime with sample inferenceService.
```
oc new-project testing
oc label namespace testing "modelmesh-enabled=true" --overwrite=true || echo "Failed to apply modelmesh-enabled label."
oc apply -f ../../../quickstart/openvino-serving-runtime.yaml
oc apply -f ../../../quickstart/openvino-inference-service.yaml
```
Check that two routes are created:
```
[selbi@fedora model-mesh]$ oc get routes
NAME                      HOST/PORT                                                               PATH                            SERVICES            PORT   TERMINATION            WILDCARD
example-onnx-mnist        example-onnx-mnist-testing.apps.selbishka.dev.datahub.redhat.com        /v2/models/example-onnx-mnist   modelmesh-serving   8443   reencrypt/Redirect     None
example-onnx-mnist-grpc   example-onnx-mnist-grpc-testing.apps.selbishka.dev.datahub.redhat.com                                   modelmesh-serving   8033   passthrough/Redirect   None
```
To clean up:
```
oc delete -f ../../../quickstart/openvino-inference-service.yaml
oc delete -f ../../../quickstart/openvino-serving-runtime.yaml
oc delete project testing
oc project opendatahub
kustomize build ./base  | oc delete -f -
oc delete project opendatahub
```
One might ask a great question, does this gRPC port do what a gRPC port is supposed to do (aka does it function as a gRPC port). One can find that answer in another PR: https://github.com/opendatahub-io/modelmesh-serving/pull/106 :) 

PS. Ignore the failing openshift-ci. It is not working properly in odh-model-controller overall yet.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
