### PR TITLE
add yq package into Dockerfile.develop

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -47,6 +47,10 @@ RUN microdnf install \
     python38 \
     nodejs && \
     pip3 install pre-commit && \
+# Install yq 4.x
+    set -eux; \
+    wget https://github.com/mikefarah/yq/releases/download/v4.33.3/yq_linux_amd64.tar.gz -O - |\
+    tar xz && mv yq_linux_amd64 /usr/local/bin/yq && \
 # Install go
     set -eux; \
     wget -qO go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \


### PR DESCRIPTION
## Description
Dockerfile.develop file in modelmesh-serving is updated. This is required to execute modelmesh-serving openshift ci
- add yq package into Dockerfile.develop