### PR TITLE
Quickstart for traffic splitting

### DIFF
--- a/docs/quickstart-traffic-splitting.md
+++ b/docs/quickstart-traffic-splitting.md
@@ -1,0 +1,190 @@
+# Traffic splitting quickstart
+
+This quickstart guide enumerates the steps needed for using ModelMesh with
+traffic splitting. Please, note that this results in a demo/experimental setup.
+
+## Prerequisites
+
+Since `odh-model-controller` is a companion controller
+for [modelmesh-serving](https://github.com/opendatahub-io/modelmesh-serving),
+you must first install it. Please, follow
+[ModelMesh serving quickstart's installation section](https://github.com/opendatahub-io/modelmesh-serving/blob/main/docs/quickstart.md#1-install-modelmesh-serving).
+
+## Install a Service Mesh
+
+If you are using OpenShift, you can use
+the [deploy.ossm.sh](../scripts/deploy.ossm.sh) script to quickly install
+OpenShift Service Mesh (OSSM). If you are using ROSA, there are a few lines in
+the script that you will need to uncomment.
+
+If you are using another Kubernetes flavor (or also OpenShift), you can
+use [Istio](https://istio.io/). Use the installation method that better suits
+your needs. You must install `istiod` and `istio-ingressgateway` components. If
+you are
+[installing with `istioctl`](https://istio.io/latest/docs/setup/install/istioctl/),
+installing with the command `istioctl install` will provide a setup with these
+components.
+
+Once the Service Mesh is installed:
+
+1. Create a namespace named `opendatahub`:
+
+    `kubectl create namespace opendatahub`
+
+1. Create the `odh-gateway` in the `opendatahub` namespace:
+
+    ```shell
+    kubectl apply -f - <<EOF
+    apiVersion: networking.istio.io/v1beta1
+    kind: Gateway
+    metadata:
+      name: odh-gateway
+      namespace: opendatahub
+    spec:
+      selector:
+        istio: ingressgateway
+      servers:
+      - hosts:
+        - '*'
+        port:
+          name: http
+          number: 80
+          protocol: HTTP
+    EOF
+    ```
+
+## Install ODH-Model-Controller
+
+As noted in the prerequisites, make sure you install `modelmesh-serving` first.
+Then, install `odh-model-controller`:
+
+```shell
+# Clone the odh-model-controller repository
+git clone https://github.com/opendatahub-io/odh-model-controller.git
+# Enter into the cloned code path
+cd odh-model-controller
+# Deploy odh-model-controller
+make deploy -e IMG=quay.io/edgarhz/odh-model-controller:service-mesh-integration
+```
+
+## Enable ODH Service Mesh features
+
+If
+you [installed ModelMesh with the quickstart instructions](https://github.com/opendatahub-io/modelmesh-serving/blob/main/docs/quickstart.md#1-install-modelmesh-serving)
+(as mentioned in the [Prerequisites](#prerequisites)) you will deploy models in
+the `modelmesh-serving` namespace, because this is the namespace where the
+ServingRuntimes are available.
+
+1. If you are using OSSM, enrol both the `opendatahub` and
+   this `modelmesh-serving` namespaces in the mesh:
+
+    ```shell
+    kubectl apply -f - <<EOF
+    apiVersion: maistra.io/v1
+    kind: ServiceMeshMemberRoll
+    metadata:
+      name: default
+      namespace: istio-system
+    spec:
+      members:
+      - modelmesh-serving
+      - opendatahub
+    EOF
+    ```
+
+1. Enable ODH Service Mesh features in the `modelmesh-serving` namespace:
+
+    `kubectl label namespace modelmesh-serving opendatahub.io/service-mesh=true`
+
+## Deploy two models
+
+For this quickstart, the same SKLearn MNIST sample
+model [as in `modelmesh-serving` quickstart](https://github.com/opendatahub-io/modelmesh-serving/blob/main/docs/quickstart.md#2-deploy-a-model)
+is going to be used. The same model is going to be deployed twice, to simulate
+two versions of the model
+
+1. Allow route creation in the ServingRuntime
+
+   `kubectl annotate servingruntime -n modelmesh-serving mlserver-0.x enable-route=true`
+
+1. Create two InferenceServices deploying the SKLearn MNIST sample model.
+
+  ```shell
+  kubectl apply -n modelmesh-serving -f - <<EOF
+  apiVersion: serving.kserve.io/v1beta1
+  kind: InferenceService
+  metadata:
+    name: mnist-v1
+    annotations:
+      serving.kserve.io/deploymentMode: ModelMesh
+      serving.kserve.io/canaryTrafficPercent: "50"
+    labels:
+      serving.kserve.io/model-tag: mnist
+  spec:
+    predictor:
+      model:
+        modelFormat:
+          name: sklearn
+        storage:
+          key: localMinIO
+          path: sklearn/mnist-svm.joblib
+  ---
+  apiVersion: serving.kserve.io/v1beta1
+  kind: InferenceService
+  metadata:
+    name: mnist-v2
+    annotations:
+      serving.kserve.io/deploymentMode: ModelMesh
+      serving.kserve.io/canaryTrafficPercent: "50"
+    labels:
+      serving.kserve.io/model-tag: mnist
+  spec:
+    predictor:
+      model:
+        modelFormat:
+          name: sklearn
+        storage:
+          key: localMinIO
+          path: sklearn/mnist-svm.joblib
+  EOF
+  ```
+
+> :bulb: Notice that both InferenceServices are labeled
+> with `serving.kserve.io/model-tag: mnist`, and annotated
+> with `serving.kserve.io/canaryTrafficPercent: "50"`. This is what enables a
+> split of 50% traffic to each model.
+
+## Perform an inference request
+
+1. Start a port-forward session to the Ingress Gateway of the Service Mesh:
+
+   `kubectl port-forward service/istio-ingressgateway 8080:80 -n istio-system`
+
+1. Try a REST infer request:
+
+   ```shell
+   curl -X POST -k http://localhost:8080/modelmesh/modelmesh-serving/v2/models/mnist/infer -d '{"inputs": [{ "name": "predict", "shape": [1, 64], "datatype": "FP32", "data": [0.0, 0.0, 1.0, 11.0, 14.0, 15.0, 3.0, 0.0, 0.0, 1.0, 13.0, 16.0, 12.0, 16.0, 8.0, 0.0, 0.0, 8.0, 16.0, 4.0, 6.0, 16.0, 5.0, 0.0, 0.0, 5.0, 15.0, 11.0, 13.0, 14.0, 0.0, 0.0, 0.0, 0.0, 2.0, 12.0, 16.0, 13.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 16.0, 16.0, 6.0, 0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 16.0, 7.0, 0.0, 0.0, 0.0, 0.0, 11.0, 13.0, 12.0, 1.0, 0.0]}]}'
+   ```
+
+1. Try a GRPC infer request.
+
+   ```shell
+   grpcurl \
+    -plaintext \
+    -rpc-header "mm-vmodel-id: mnist" \
+    -proto ./grpc_predict_v2.proto \
+    -d '{ "inputs": [{ "name": "predict", "shape": [1, 64], "datatype": "FP32", "contents": { "fp32_contents": [0.0, 0.0, 1.0, 11.0, 14.0, 15.0, 3.0, 0.0, 0.0, 1.0, 13.0, 16.0, 12.0, 16.0, 8.0, 0.0, 0.0, 8.0, 16.0, 4.0, 6.0, 16.0, 5.0, 0.0, 0.0, 5.0, 15.0, 11.0, 13.0, 14.0, 0.0, 0.0, 0.0, 0.0, 2.0, 12.0, 16.0, 13.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 16.0, 16.0, 6.0, 0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 16.0, 7.0, 0.0, 0.0, 0.0, 0.0, 11.0, 13.0, 12.0, 1.0, 0.0] }}]}' \
+    localhost:8080 \
+    inference.GRPCInferenceService.ModelInfer
+   ```
+
+   > :bulb: Note: The `grpc_predict_v2.proto` file
+   > [can be downloaded from KServe's repository](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/grpc_predict_v2.proto)
+
+Notice that both in the REST and the GRPC case, the request goes to the `mnist`
+model, which is the `model-tag` specified in both InferenceServices as a label.
+This is what triggers the traffic split routing. By doing the infer request
+repeatedly, the response should be alternating between the `mnist-v1` and
+the `mnist-v2` models. You can notice this by looking at the `model_name`
+attribute in the JSON response.
+

--- a/scripts/deploy.ossm.sh
+++ b/scripts/deploy.ossm.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+waitforpodlabeled() {
+  local ns=${1?namespace is required}; shift
+  local podlabel=${1?pod label is required}; shift
+
+  echo "Waiting for pod -l $podlabel to be created"
+  until oc get pod -n "$ns" -l $podlabel -o=jsonpath='{.items[0].metadata.name}' >/dev/null 2>&1; do
+    sleep 1
+  done
+}
+
+waitpodready() {
+  local ns=${1?namespace is required}; shift
+  local podlabel=${1?pod label is required}; shift
+
+  waitforpodlabeled "$ns" "$podlabel"
+  echo "Waiting for pod -l $podlabel to become ready"
+  kubectl wait --for=condition=ready --timeout=180s pod -n $ns -l $podlabel
+}
+
+
+# Deploy Distributed tracing operator (Jaeger)
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-distributed-tracing
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-distributed-tracing
+  namespace: openshift-distributed-tracing
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-product
+  namespace: openshift-distributed-tracing
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+waitpodready "openshift-distributed-tracing" "name=jaeger-operator"
+
+# Deploy Kiali operator
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali-ossm
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kiali-ossm
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+waitpodready "openshift-operators" "app=kiali-operator"
+
+# Deploy OSSM operator
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+waitpodready "openshift-operators" "name=istio-operator"
+
+# Install OSSM
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+  version: v2.3
+  tracing:
+    type: Jaeger
+    sampling: 10000
+# Uncomment if on ROSA
+#  security:
+#    identity:
+#      type: ThirdParty
+  addons:
+    jaeger:
+      name: jaeger
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+      name: kiali
+    grafana:
+      enabled: true
+EOF
+
+# Waiting for OSSM minimum start
+waitpodready "istio-system" "app=istiod"
+
+echo -e "\n  OSSM has partially started and should be fully ready soon."


### PR DESCRIPTION
* Add deploy.ossm.sh script to quickly deploy OSSM in an OpenShift cluster
* Add quickstart-traffic-splitting.md with instructions to try traffic splitting.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- N/A Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
