### PR TITLE
Refactoring constants and remove hard-coded Istio gateway

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -16,8 +16,8 @@ limitations under the License.
 package controllers
 
 const (
-	// EnableServiceMeshLabel is the Kubernetes label that must be set to "true" in a namespace to enable Service Mesh features.
-	EnableServiceMeshLabel = "opendatahub.io/service-mesh"
+	// EnableServiceMeshAnnotation is the Kubernetes annotation that must be set to "true" in a namespace to enable Service Mesh features.
+	EnableServiceMeshAnnotation = "opendatahub.io/service-mesh"
 
 	// InferenceServiceFinalizerName is the name of the finalizer that is added to InferenceService CRs to do proper clean-up
 	// of objects created by the controller. For now, this is for ensuring that Istio VirtualServices for traffic splitting
@@ -35,14 +35,9 @@ const (
 	InferenceServiceSplitPercentAnnotation = "serving.kserve.io/canaryTrafficPercent"
 
 	// IstioGatewayNameAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
-	// to specify the name (wihtout namespace) of the Istio Gateway resource to use when publicly exposing models/ISVCs.
+	// to specify the Istio Gateway resource to use when publicly exposing models/ISVCs, in `namespace/name` format.
 	// This annotation may be set automatically by the `odh-project-controller`.
-	IstioGatewayNameAnnotation = "maistra.io/gateway-name"
-
-	// IstioGatewayNamespaceAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
-	// to specify the Namespace of the Istio Gateway resource to use when publicly exposing models/ISVCs.
-	// This annotation may be set automatically by the `odh-project-controller`.
-	IstioGatewayNamespaceAnnotation = "maistra.io/gateway-namespace"
+	IstioGatewayNameAnnotation = "opendatahub.io/service-mesh-gw"
 
 	// VirtualServiceForTrafficSplitAnnotation is the Kubernetes annotation set by the controller on InferenceService
 	// resources to record the VirtualService name that is related to an InferenceService group (model-tag) and was

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -1,0 +1,51 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+const (
+	// EnableServiceMeshLabel is the Kubernetes label that must be set to "true" in a namespace to enable Service Mesh features.
+	EnableServiceMeshLabel = "opendatahub.io/service-mesh"
+
+	// InferenceServiceFinalizerName is the name of the finalizer that is added to InferenceService CRs to do proper clean-up
+	// of objects created by the controller. For now, this is for ensuring that Istio VirtualServices for traffic splitting
+	// are properly removed when no longer needed.
+	InferenceServiceFinalizerName = "serving.opendatahub.io/finalizer"
+
+	// InferenceServiceModelTagLabel is the Kubernetes label or annotation set on resources to record the tag grouping
+	// together a set of InferenceServices. At the moment, this is being set by the end-user in InferenceService CRs to specify
+	// the group name of several of ISVCs, and set by the controller on VirtualServices as a cross-reference for proper
+	// clean-up of resources when the group vanishes.
+	InferenceServiceModelTagLabel = "serving.kserve.io/model-tag"
+
+	// InferenceServiceSplitPercentAnnotation is the Kubernetes annotation set by the end-user on InferenceService resources
+	// to configure the percentage of traffic that should go to the InferenceService when part of a group.
+	InferenceServiceSplitPercentAnnotation = "serving.kserve.io/canaryTrafficPercent"
+
+	// IstioGatewayNameAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
+	// to specify the name (wihtout namespace) of the Istio Gateway resource to use when publicly exposing models/ISVCs.
+	// This annotation may be set automatically by the `odh-project-controller`.
+	IstioGatewayNameAnnotation = "maistra.io/gateway-name"
+
+	// IstioGatewayNamespaceAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
+	// to specify the Namespace of the Istio Gateway resource to use when publicly exposing models/ISVCs.
+	// This annotation may be set automatically by the `odh-project-controller`.
+	IstioGatewayNamespaceAnnotation = "maistra.io/gateway-namespace"
+
+	// VirtualServiceForTrafficSplitAnnotation is the Kubernetes annotation set by the controller on InferenceService
+	// resources to record the VirtualService name that is related to an InferenceService group (model-tag) and was
+	// created to control traffic splitting.
+	VirtualServiceForTrafficSplitAnnotation = "serving.opendatahub.io/vs-traffic-splitting"
+)

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -86,7 +86,7 @@ func (r *OpenshiftInferenceServiceReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 
-	isServiceMeshEnabled, _ := strconv.ParseBool(namespace.Labels[EnableServiceMeshLabel])
+	isServiceMeshEnabled, _ := strconv.ParseBool(namespace.Annotations[EnableServiceMeshAnnotation])
 
 	// Finalizer, to delete VS for traffic splitting
 	if inferenceservice.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/controllers/inferenceservice_controller_test.go
+++ b/controllers/inferenceservice_controller_test.go
@@ -166,7 +166,7 @@ var _ = Describe("The Openshift model controller", func() {
 				err = cli.Get(ctx, types.NamespacedName{Name: isvc.Name, Namespace: namespace.Name}, isvc)
 				Expect(err).ToNot(HaveOccurred())
 
-				isvc.Labels["serving.kserve.io/model-tag"] = "onnx-second"
+				isvc.Labels[InferenceServiceModelTagLabel] = "onnx-second"
 				err = cli.Update(ctx, isvc)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -199,7 +199,7 @@ var _ = Describe("The Openshift model controller", func() {
 
 				// Create second InferenceService with bad canary traffic percentage
 				err = convertToStructuredResource(InferenceServiceWithTag2, namespace.Name, isvc, opts)
-				isvc.Annotations["serving.kserve.io/canaryTrafficPercent"] = "10"
+				isvc.Annotations[InferenceServiceSplitPercentAnnotation] = "10"
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cli.Create(ctx, isvc)).Should(Succeed())
 

--- a/controllers/inferenceservice_virtualservice.go
+++ b/controllers/inferenceservice_virtualservice.go
@@ -328,10 +328,12 @@ func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(n
 	}
 
 	// If there are no non-deleted ISVCs, delete the VirtualService for traffic splitting
-	if len(validISvcs) == 0 && len(existentVs.Name) != 0 {
-		err = r.Delete(ctx, existentVs, client.PropagationPolicy(metav1.DeletePropagationBackground))
-		if err != nil {
-			return nil, err
+	if len(validISvcs) == 0 {
+		if len(existentVs.Name) != 0 {
+			err = r.Delete(ctx, existentVs, client.PropagationPolicy(metav1.DeletePropagationBackground))
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return nil, nil

--- a/controllers/inferenceservice_virtualservice.go
+++ b/controllers/inferenceservice_virtualservice.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	virtualservicev1 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,7 +47,7 @@ func NewInferenceServiceVirtualService(inferenceservice *inferenceservicev1.Infe
 		Route: []*v1alpha3.HTTPRouteDestination{
 			{
 				Destination: &v1alpha3.Destination{
-					Host: "modelmesh-serving." + inferenceservice.Namespace + ".svc.cluster.local",
+					Host: internalModelMeshFQDN(inferenceservice.Namespace),
 					Port: &v1alpha3.PortSelector{
 						Number: 8033,
 					},
@@ -68,7 +69,7 @@ func NewInferenceServiceVirtualService(inferenceservice *inferenceservicev1.Infe
 		},
 		Route: []*v1alpha3.HTTPRouteDestination{{
 			Destination: &v1alpha3.Destination{
-				Host: "modelmesh-serving." + inferenceservice.Namespace + ".svc.cluster.local",
+				Host: internalModelMeshFQDN(inferenceservice.Namespace),
 				Port: &v1alpha3.PortSelector{
 					Number: 8008,
 				},
@@ -94,7 +95,7 @@ func buildTrafficSplittingGrpcRoute(modelTag string, validISvcs []inferenceservi
 	for idx, isvc := range validISvcs {
 		grpcDestination := v1alpha3.HTTPRouteDestination{
 			Destination: &v1alpha3.Destination{
-				Host: "modelmesh-serving." + servingNamespace + ".svc.cluster.local",
+				Host: internalModelMeshFQDN(servingNamespace),
 				Port: &v1alpha3.PortSelector{
 					Number: 8033,
 				},
@@ -106,7 +107,7 @@ func buildTrafficSplittingGrpcRoute(modelTag string, validISvcs []inferenceservi
 			},
 		}
 
-		if percentStr, ok := isvc.Annotations["serving.kserve.io/canaryTrafficPercent"]; ok {
+		if percentStr, ok := isvc.Annotations[InferenceServiceSplitPercentAnnotation]; ok {
 			percent, parseErr := strconv.ParseInt(percentStr, 10, 32)
 			if parseErr != nil {
 				return nil, parseErr
@@ -149,7 +150,7 @@ func buildTrafficSplittingHttpRoute(modelTag string, validISvcs []inferenceservi
 			},
 		}
 
-		if percentStr, ok := isvc.Annotations["serving.kserve.io/canaryTrafficPercent"]; ok {
+		if percentStr, ok := isvc.Annotations[InferenceServiceSplitPercentAnnotation]; ok {
 			percent, parseErr := strconv.ParseInt(percentStr, 10, 32)
 			if parseErr != nil {
 				return nil, parseErr
@@ -196,7 +197,7 @@ func buildHttpRedirectionRoutes(modelTag string, validISvcs []inferenceservicev1
 			},
 			Route: []*v1alpha3.HTTPRouteDestination{{
 				Destination: &v1alpha3.Destination{
-					Host: "modelmesh-serving." + servingNamespace + ".svc.cluster.local",
+					Host: internalModelMeshFQDN(servingNamespace),
 					Port: &v1alpha3.PortSelector{
 						Number: 8008,
 					},
@@ -232,7 +233,7 @@ func buildTrafficSplittingVirtualService(modelTag string, validISvcs []inference
 			Name:      modelTag + "-splitting",
 			Namespace: validISvcs[0].Namespace,
 			Annotations: map[string]string{
-				"serving.kserve.io/model-tag": modelTag,
+				InferenceServiceModelTagLabel: modelTag,
 			},
 		},
 		Spec: v1alpha3.VirtualService{
@@ -309,11 +310,11 @@ func DeepCompare(a, b interface{}) bool {
 	}
 }
 
-func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(namespace, modelTag string, existentVs *virtualservicev1.VirtualService, ctx context.Context) (*virtualservicev1.VirtualService, error) {
+func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(namespace *v1.Namespace, modelTag string, existentVs *virtualservicev1.VirtualService, ctx context.Context) (*virtualservicev1.VirtualService, error) {
 
 	// Get list of InferenceServices tagged with `model-tag`
 	taggedISvcs := &inferenceservicev1.InferenceServiceList{}
-	err := r.List(ctx, taggedISvcs, client.InNamespace(namespace), client.MatchingLabels{"serving.kserve.io/model-tag": modelTag})
+	err := r.List(ctx, taggedISvcs, client.InNamespace(namespace.Name), client.MatchingLabels{InferenceServiceModelTagLabel: modelTag})
 	if err != nil {
 		return nil, err
 	}
@@ -340,14 +341,14 @@ func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(n
 	if len(validISvcs) > 1 {
 		canarySum := int64(0)
 		for _, isvc := range validISvcs {
-			if percentStr, ok := isvc.Annotations["serving.kserve.io/canaryTrafficPercent"]; ok {
+			if percentStr, ok := isvc.Annotations[InferenceServiceSplitPercentAnnotation]; ok {
 				percent, parseErr := strconv.ParseInt(percentStr, 10, 32)
 				if parseErr != nil {
 					return nil, parseErr
 				}
 				canarySum += percent
 			} else {
-				return nil, fmt.Errorf("cannot configure traffic splitting for model-tag <%s> because InferenceService <%s> does not have the serving.kserve.io/canaryTrafficPercent annotation", modelTag, isvc.Name)
+				return nil, fmt.Errorf("cannot configure traffic splitting for model-tag <%s> because InferenceService <%s> does not have the %s annotation", modelTag, isvc.Name, InferenceServiceSplitPercentAnnotation)
 			}
 		}
 
@@ -363,7 +364,11 @@ func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(n
 	}
 
 	// TODO: Something should control if the route is created or not. What criteria to use?
-	desiredVirtualService.Spec.Gateways = []string{"opendatahub/odh-gateway"} // TODO get actual gateway to be used
+	var findGatewayErr error
+	desiredVirtualService.Spec.Gateways, findGatewayErr = getIstioGatewaysForNamespace(namespace)
+	if findGatewayErr != nil {
+		return nil, findGatewayErr
+	}
 
 	// Create the VirtualService if it does not already exist
 	if len(existentVs.Name) == 0 {
@@ -382,7 +387,7 @@ func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(n
 				// Get the last VirtualService revision
 				getLastVSErr := r.Get(ctx, types.NamespacedName{
 					Name:      desiredVirtualService.Name,
-					Namespace: namespace,
+					Namespace: namespace.Name,
 				}, currentVs)
 				if getLastVSErr != nil {
 					return getLastVSErr
@@ -404,7 +409,7 @@ func (r *OpenshiftInferenceServiceReconciler) updateTrafficSplitVirtualService(n
 
 // Reconcile will manage the creation, update and deletion of the VirtualService returned
 // by the newVirtualService function
-func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferenceservice *inferenceservicev1.InferenceService,
+func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(namespace *v1.Namespace, inferenceservice *inferenceservicev1.InferenceService,
 	ctx context.Context, newVirtualService func(service *inferenceservicev1.InferenceService) *virtualservicev1.VirtualService) error {
 	// Initialize logger format
 	log := r.Log.WithValues("inferenceservice", inferenceservice.Name, "namespace", inferenceservice.Namespace)
@@ -414,7 +419,11 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferences
 	// Generate the desired VirtualService and expose externally if enabled
 	desiredVirtualService := newVirtualService(inferenceservice)
 	if desiredServingRuntime.Annotations["enable-route"] == "true" {
-		desiredVirtualService.Spec.Gateways = []string{"opendatahub/odh-gateway"} //TODO get actual gateway to be used
+		var findGatewayErr error
+		desiredVirtualService.Spec.Gateways, findGatewayErr = getIstioGatewaysForNamespace(namespace)
+		if findGatewayErr != nil {
+			return findGatewayErr
+		}
 	}
 
 	// Create the VirtualService if it does not already exist
@@ -476,20 +485,20 @@ func (r *OpenshiftInferenceServiceReconciler) reconcileVirtualService(inferences
 
 // ReconcileVirtualService will manage the creation, update and deletion of the
 // VirtualService when the Predictor is reconciled
-func (r *OpenshiftInferenceServiceReconciler) ReconcileVirtualService(
+func (r *OpenshiftInferenceServiceReconciler) ReconcileVirtualService(namespace *v1.Namespace,
 	inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
-	return r.reconcileVirtualService(inferenceservice, ctx, NewInferenceServiceVirtualService)
+	return r.reconcileVirtualService(namespace, inferenceservice, ctx, NewInferenceServiceVirtualService)
 }
 
 func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
-	inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
+	namespace *v1.Namespace, inferenceservice *inferenceservicev1.InferenceService, ctx context.Context) error {
 	// Initialize logger format
 	log := r.Log.WithValues("inferenceservice", inferenceservice.Name, "namespace", inferenceservice.Namespace)
 	log.Info("Reconciling traffic splitting")
 
 	// Fetch associated VirtualService, if there is one
 	associatedVs := &virtualservicev1.VirtualService{}
-	if vsName, vsOk := inferenceservice.Annotations["serving.opendatahub.io/vs-traffic-splitting"]; vsOk {
+	if vsName, vsOk := inferenceservice.Annotations[VirtualServiceForTrafficSplitAnnotation]; vsOk {
 		err := r.Get(ctx, types.NamespacedName{
 			Name:      vsName,
 			Namespace: inferenceservice.Namespace,
@@ -505,11 +514,11 @@ func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
 
 	var isvcModelTag, vsModelTag string
 
-	if tag, tagOk := inferenceservice.Labels["serving.kserve.io/model-tag"]; tagOk {
+	if tag, tagOk := inferenceservice.Labels[InferenceServiceModelTagLabel]; tagOk {
 		isvcModelTag = tag
 	}
 
-	if tag, tagOk := associatedVs.Annotations["serving.kserve.io/model-tag"]; tagOk {
+	if tag, tagOk := associatedVs.Annotations[InferenceServiceModelTagLabel]; tagOk {
 		vsModelTag = tag
 	}
 
@@ -521,7 +530,7 @@ func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
 	//      Here we deal with removing the ISVC from the old group
 	if len(associatedVs.Name) != 0 {
 		if len(isvcModelTag) == 0 || isvcModelTag != vsModelTag {
-			resultingVs, err := r.updateTrafficSplitVirtualService(inferenceservice.Namespace, vsModelTag, associatedVs, ctx)
+			resultingVs, err := r.updateTrafficSplitVirtualService(namespace, vsModelTag, associatedVs, ctx)
 			if err != nil {
 				log.Error(err, "Unable to update associated old VirtualService for traffic splitting", "model-tag", vsModelTag, "virtualService", associatedVs.Name)
 				return err
@@ -547,7 +556,7 @@ func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
 	//      VirtualService is updated.
 	vsNameToAssociate := ""
 	if len(isvcModelTag) != 0 {
-		resultingVs, err := r.updateTrafficSplitVirtualService(inferenceservice.Namespace, isvcModelTag, associatedVs, ctx)
+		resultingVs, err := r.updateTrafficSplitVirtualService(namespace, isvcModelTag, associatedVs, ctx)
 		if err != nil {
 			log.Error(err, "Unable to create or update the VirtualService for traffic splitting", "model-tag", isvcModelTag, "virtualService", associatedVs.Name)
 			return err
@@ -559,10 +568,10 @@ func (r *OpenshiftInferenceServiceReconciler) ReconcileTrafficSplitting(
 	}
 
 	// Update annotation of the InferenceService to store/remove the virtual service name for traffic splitting
-	if vsName := inferenceservice.Annotations["serving.opendatahub.io/vs-traffic-splitting"]; vsNameToAssociate != vsName {
-		inferenceservice.ObjectMeta.Annotations["serving.opendatahub.io/vs-traffic-splitting"] = vsNameToAssociate
+	if vsName := inferenceservice.Annotations[VirtualServiceForTrafficSplitAnnotation]; vsNameToAssociate != vsName {
+		inferenceservice.ObjectMeta.Annotations[VirtualServiceForTrafficSplitAnnotation] = vsNameToAssociate
 		if len(vsNameToAssociate) == 0 {
-			delete(inferenceservice.ObjectMeta.Annotations, "serving.opendatahub.io/vs-traffic-splitting")
+			delete(inferenceservice.ObjectMeta.Annotations, VirtualServiceForTrafficSplitAnnotation)
 		}
 		updateIsvcErr := r.Update(ctx, inferenceservice)
 		if updateIsvcErr != nil {

--- a/controllers/testdata/deploy/test-namespace-servicemesh.yaml
+++ b/controllers/testdata/deploy/test-namespace-servicemesh.yaml
@@ -3,9 +3,8 @@ kind: Namespace
 metadata:
   labels:
     modelmesh-enabled: "true"
-    opendatahub.io/service-mesh: "true"
   annotations:
-    maistra.io/gateway-namespace: "opendatahub"
-    maistra.io/gateway-name: "odh-gateway"
+    opendatahub.io/service-mesh: "true"
+    opendatahub.io/service-mesh-gw: "opendatahub/odh-gateway"
   name: test
 spec:

--- a/controllers/testdata/deploy/test-namespace-servicemesh.yaml
+++ b/controllers/testdata/deploy/test-namespace-servicemesh.yaml
@@ -4,5 +4,8 @@ metadata:
   labels:
     modelmesh-enabled: "true"
     opendatahub.io/service-mesh: "true"
+  annotations:
+    maistra.io/gateway-namespace: "opendatahub"
+    maistra.io/gateway-name: "odh-gateway"
   name: test
 spec:

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,41 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"errors"
+	v1 "k8s.io/api/core/v1"
+)
+
+// internalModelMeshFQDN returns the fully quallified domain name of the modelmesh-serving Kubernetes
+// service that is created in a namespace for reaching ModelMesh-pods.
+func internalModelMeshFQDN(namespace string) string {
+	return "modelmesh-serving." + namespace + ".svc.cluster.local"
+}
+
+// getIstioGatewaysForNamespace returns the list of gateways that should be associated to a
+// VirtualService to publicly expose InferenceServices living in the specified namespace.
+func getIstioGatewaysForNamespace(namespace *v1.Namespace) ([]string, error) {
+	if gatewayNamespace, gwNsOk := namespace.Annotations[IstioGatewayNamespaceAnnotation]; gwNsOk {
+		if gatewayName, gwNameOk := namespace.Annotations[IstioGatewayNameAnnotation]; gwNameOk {
+			return []string{gatewayNamespace + "/" + gatewayName}, nil
+		} else {
+			return []string{}, errors.New("the " + IstioGatewayNameAnnotation + " annotation is not set on the namespace")
+		}
+	} else {
+		return []string{}, errors.New("the " + IstioGatewayNamespaceAnnotation + " annotation is not set on the namespace")
+	}
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -29,13 +29,9 @@ func internalModelMeshFQDN(namespace string) string {
 // getIstioGatewaysForNamespace returns the list of gateways that should be associated to a
 // VirtualService to publicly expose InferenceServices living in the specified namespace.
 func getIstioGatewaysForNamespace(namespace *v1.Namespace) ([]string, error) {
-	if gatewayNamespace, gwNsOk := namespace.Annotations[IstioGatewayNamespaceAnnotation]; gwNsOk {
-		if gatewayName, gwNameOk := namespace.Annotations[IstioGatewayNameAnnotation]; gwNameOk {
-			return []string{gatewayNamespace + "/" + gatewayName}, nil
-		} else {
-			return []string{}, errors.New("the " + IstioGatewayNameAnnotation + " annotation is not set on the namespace")
-		}
+	if gatewayName, gwNameOk := namespace.Annotations[IstioGatewayNameAnnotation]; gwNameOk {
+		return []string{gatewayName}, nil
 	} else {
-		return []string{}, errors.New("the " + IstioGatewayNamespaceAnnotation + " annotation is not set on the namespace")
+		return []string{}, errors.New("the " + IstioGatewayNameAnnotation + " annotation is not set on the namespace")
 	}
 }

--- a/docs/traffic-splitting.md
+++ b/docs/traffic-splitting.md
@@ -22,21 +22,19 @@ At the moment, the Service Mesh control plane must be installed in the
 `istio-system` namespace. In this same namespace you must deploy an Ingress 
 Gateway named `istio-ingressgateway`.
 
-Once you have the Service Mesh installed, you must create a namespace named
-`opendatahub`. This namespace must be part of the Service Mesh. If you are
-using Istio, the namespace should be part of the Mesh without doing anything
-(you should _not_ enable sidecar auto-injection). If you are using OSSM, 
-make sure that the namespace is included in your `ServiceMeshMemberRoll` 
-resource.
+> :warning: NOTE: Most likely, the `istio-ingressgateway` hard names is going 
+> to be configurable via some mechanism once the traffic splitting feature is
+> stabilized.
 
-In this `opendatahub` namespace you must create the following Gateway:
+Once you have the Service Mesh installed, you must create a Gateway. This is 
+the Gateway that will be used to publicly expose models. The following is an 
+example of a Gateway:
 
 ```yaml
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: odh-gateway
-  namespace: opendatahub
 spec:
   selector:
     istio: ingressgateway
@@ -49,12 +47,15 @@ spec:
       protocol: HTTP
 ```
 
-> :warning: NOTE: Most likely, the mentioned hard names are going to be 
-> configurable via some mechanism once the traffic splitting feature is 
-> stabilized.
-
-> :bulb: NOTE: Some of these configs may be handled by the 
+> :bulb: NOTE: When installing the whole ODH platform, the Gateway creation 
+> may be handled by the
 > [odh-project-controller](https://github.com/maistra/odh-project-controller).
+
+> :warning: If you are using OSSM, make sure that the namespace where the 
+> Gateway is created is part of the Mesh; i.e. the namespace is included in 
+> your `ServiceMeshMemberRoll` resource. This also may be handled by the 
+> [odh-project-controller](https://github.com/maistra/odh-project-controller)
+> when installing the whole ODH platform.
 
 ## ModelMesh preparation
 
@@ -69,6 +70,17 @@ label with the following command:
 ```shell
 kubectl label ns modelmesh-apps opendatahub.io/service-mesh=true
 ```
+
+Add the following annotations to your namespace to configure the Istio 
+Gateway to use to expose the Inference Services created the namespace:
+
+```shell
+kubectl annotate ns modelmesh-apps maistra.io/gateway-namespace=gateway-namespace-name
+kubectl annotate ns modelmesh-apps maistra.io/gateway-name=gateway-resource-name
+```
+
+> :bulb: When installing the whole ODH platform, these annotations should be 
+> set automatically by the [odh-project-controller](https://github.com/maistra/odh-project-controller).
 
 In this namespace, you can create your ServingRuntimes as normally. The only 
 additional requirement is that all your ServingRuntimes **must** be 

--- a/docs/traffic-splitting.md
+++ b/docs/traffic-splitting.md
@@ -63,20 +63,19 @@ As usual, you will need a namespace to host your ServingRuntimes, your
 models and your applications. This namespace must be part of the Service
 Mesh, although you should _not_ enable sidecar auto-injection.
 In order to fully enable ODH-managed Service Mesh features,
-you must add the `opendatahub.io/service-mesh=true` label to the namespace.
+you must add the `opendatahub.io/service-mesh=true` annotation to the namespace.
 For example, if your namespace is named `modelmesh-apps` you can add the
 label with the following command:
 
 ```shell
-kubectl label ns modelmesh-apps opendatahub.io/service-mesh=true
+kubectl annotate ns modelmesh-apps opendatahub.io/service-mesh=true
 ```
 
 Add the following annotations to your namespace to configure the Istio 
 Gateway to use to expose the Inference Services created the namespace:
 
 ```shell
-kubectl annotate ns modelmesh-apps maistra.io/gateway-namespace=gateway-namespace-name
-kubectl annotate ns modelmesh-apps maistra.io/gateway-name=gateway-resource-name
+kubectl annotate ns modelmesh-apps opendatahub.io/service-mesh-gw=gateway-namespace-name/gateway-resource-name
 ```
 
 > :bulb: When installing the whole ODH platform, these annotations should be 


### PR DESCRIPTION
## Description
* Extract hard-coded strings to constants.go
* Extract building the ModelMesh service host to the internalModelMeshFQDN func in utils.go
* Remove the hard-coded `opendatahub/odh-gateway` Istio gateway name and resolve it in the findIstioGatewaysForNamespace func in utils.go, effectively making it configurable.

## How Has This Been Tested?
Verified by running unit tests.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- N/A Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
