### PR TITLE
Fix RHODS-8873 (Make role name to be unique)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: odh-model-controller-role
 rules:
   - apiGroups:
       - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,8 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: odh-model-controller-role
 subjects:
   - kind: ServiceAccount
     name: odh-model-controller
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ClusterRole name was not unique so other operators can overwrite the ClusterRole.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**Test**
~~~
make deploy

oc get pod
NAME                                                         READY   STATUS    RESTARTS   AGE
odh-model-controller-odh-model-controller-685bfbf7d7-2mcgf   1/1     Running   0          11s
odh-model-controller-odh-model-controller-685bfbf7d7-jrq9g   1/1     Running   0          11s
odh-model-controller-odh-model-controller-685bfbf7d7-pbzw6   1/1     Running   0          11s
~~~

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
