### PR TITLE
Parametrize public ingress gateway in-cluster hostname

### DIFF
--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -36,8 +36,15 @@ const (
 
 	// IstioGatewayNameAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
 	// to specify the Istio Gateway resource to use when publicly exposing models/ISVCs, in `namespace/name` format.
+	// Models that are configured to be publicly exposed would be associated with this Istio Gateway.
 	// This annotation may be set automatically by the `odh-project-controller`.
-	IstioGatewayNameAnnotation = "opendatahub.io/service-mesh-gw"
+	IstioGatewayNameAnnotation = "service-mesh.opendatahub.io/public-gateway-name"
+
+	// IstioGatewayInternalHostAnnotation is the Kubernetes annotation key set by the end-user on Namespaces
+	// to specify the hostname of the Istio Ingress Gateway that is publicly exposed. Models that are configured to
+	// be publicly exposed would be associated with this hostname.
+	// This annotation may be set automatically by the `odh-project-controller`.
+	IstioGatewayInternalHostAnnotation = "service-mesh.opendatahub.io/public-gateway-host-internal"
 
 	// VirtualServiceForTrafficSplitAnnotation is the Kubernetes annotation set by the controller on InferenceService
 	// resources to record the VirtualService name that is related to an InferenceService group (model-tag) and was

--- a/controllers/testdata/deploy/test-namespace-servicemesh.yaml
+++ b/controllers/testdata/deploy/test-namespace-servicemesh.yaml
@@ -5,6 +5,8 @@ metadata:
     modelmesh-enabled: "true"
   annotations:
     opendatahub.io/service-mesh: "true"
-    opendatahub.io/service-mesh-gw: "opendatahub/odh-gateway"
+    service-mesh.opendatahub.io/public-gateway-name: "opendatahub/odh-gateway"
+    service-mesh.opendatahub.io/public-gateway-host-external: "public.gw.com"
+    service-mesh.opendatahub.io/public-gateway-host-internal: "ingress.istio-system.svc.cluster.local"
   name: test
 spec:

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1.yaml
@@ -37,7 +37,7 @@ spec:
       uri: /vmodel-route/ns-dssnm/onnx-mnist/infer
     route:
     - destination:
-        host: istio-ingressgateway.istio-system.svc.cluster.local
+        host: ingress.istio-system.svc.cluster.local
         port:
           number: 80
       headers:

--- a/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1v2.yaml
+++ b/controllers/testdata/results/example-onnx-mnist-virtualservice-split-v1v2.yaml
@@ -46,7 +46,7 @@ spec:
       uri: /vmodel-route/ns-dssnm/onnx-mnist/infer
     route:
     - destination:
-        host: istio-ingressgateway.istio-system.svc.cluster.local
+        host: ingress.istio-system.svc.cluster.local
         port:
           number: 80
       headers:
@@ -55,7 +55,7 @@ spec:
             x-vmodel: example-onnx-mnist-v1
       weight: 50
     - destination:
-        host: istio-ingressgateway.istio-system.svc.cluster.local
+        host: ingress.istio-system.svc.cluster.local
         port:
           number: 80
       headers:

--- a/docs/quickstart-traffic-splitting.md
+++ b/docs/quickstart-traffic-splitting.md
@@ -76,8 +76,15 @@ This `odh-model-controller` quick start demonstrates how to use the ModelMesh fr
 1. Enable ODH Service Mesh features in the `modelmesh-serving` namespace:
 
     ~~~
-    kubectl label namespace modelmesh-serving opendatahub.io/service-mesh=true
+    kubectl annotate namespace modelmesh-serving opendatahub.io/service-mesh=true
     ~~~
+
+1. Annotate the modelmesh-serving namespace to use the Istio Gateway:
+
+   ~~~
+   kubectl annotate namespace modelmesh-serving service-mesh.opendatahub.io/public-gateway-name=opendatahub/odh-gateway
+   kubectl annotate namespace modelmesh-serving service-mesh.opendatahub.io/public-gateway-host-internal=istio-ingressgateway.istio-system.svc.cluster.local
+   ~~~
 
 1. To simulate the deployment of two models, you deploy the SKLearn MNIST sample model twice. 
 

--- a/docs/traffic-splitting.md
+++ b/docs/traffic-splitting.md
@@ -75,7 +75,8 @@ Add the following annotations to your namespace to configure the Istio
 Gateway to use to expose the Inference Services created the namespace:
 
 ```shell
-kubectl annotate ns modelmesh-apps opendatahub.io/service-mesh-gw=gateway-namespace-name/gateway-resource-name
+kubectl annotate ns modelmesh-apps service-mesh.opendatahub.io/public-gateway-name=gateway-namespace-name/gateway-resource-name
+kubectl annotate ns modelmesh-apps service-mesh.opendatahub.io/public-gateway-host-internal=in-cluster-gateway.namespace.svc.cluster.local
 ```
 
 > :bulb: When installing the whole ODH platform, these annotations should be 


### PR DESCRIPTION
This removes the hardcoded `istio-ingressgateway.istio-system.svc.cluster.local` hostname used in VirtualServices. Instead, the hostname is fetched from an annotation on the Namespace.

## Testing

Follow the updated quickstart: https://github.com/israel-hdez/odh-model-controller/blob/1cd1ef6e082714236c3aacac5bb137c4187e8923/docs/quickstart-traffic-splitting.md

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
