### PR TITLE
Add anti-affinity rules to manager pod

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi8/go-toolset:1.17 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,8 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= odh-model-controller:latest
+IMG ?= quay.io/${USER}/odh-model-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
-
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
@@ -41,7 +34,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 external-manifests: 
 	go get github.com/kserve/modelmesh-serving

--- a/README.md
+++ b/README.md
@@ -29,36 +29,13 @@ Run the following command to execute them:
 make test
 ```
 
-### Run locally
-
-Install the CRD from the [KServe modelmesh-serving](../modelmesh-serving-controller) repository as a requirement.
-
-When running the controller locally, the [admission webhook](./config/webhook)
-will be running in your local machine. The requests made by the Openshift API
-have to be redirected to the local port.
-
-This will be solved by deploying the [Ktunnel
-application](https://github.com/omrikiei/ktunnel) in your cluster instead of the
-controller manager, it will create a reverse tunnel between the cluster and your
-local machine:
-
-```shell
-make deploy-dev -e K8S_NAMESPACE=<YOUR_NAMESPACE>
-```
-
-Run the controller locally:
-
-```shell
-make run -e K8S_NAMESPACE=<YOUR_NAMESPACE>
-```
-
 ### Deploy local changes
 
 Build a new image with your local changes and push it to `<YOUR_IMAGE>` (by
-default `quay.io/opendatahub/odh-model-controller`).
+default `quay.io/${USER}/odh-model-controller:latest`).
 
 ```shell
-make image -e IMG=<YOUR_IMAGE>
+make -e IMG=<YOUR_IMAGE> docker-build docker-push
 ```
 
 Deploy the manager using the image in your registry:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,6 +18,18 @@ spec:
         control-plane: odh-model-controller
         app: odh-model-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - odh-model-controller
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
## Description

Since the manager pod has 3 replicas, the anti-affinity rules are added to prefer (not require) scheduling the replicas in different worker nodes, rather than having replicas on the same node.

Additionally, fixes to the `README.md`, `Makefile` and `Containerfile` are done.

## How Has This Been Tested?

By building and deploying:
```shell
make build
make docker-build docker-push
make deploy
```

Then, ensure that the manager pods are started as expected on different nodes (when possible):

```sh
oc get pods -n odh-model-controller-system -o wide
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
