### PR TITLE
Fix CI/fvt

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -17,7 +17,7 @@
 ###############################################################################
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
-ARG GOLANG_VERSION=1.18.9
+ARG GOLANG_VERSION=1.19.10
 ARG OPENSHIFT_VERSION=4.9
 ARG KUSTOMIZE_VERSION=4.5.2
 ARG KUBEBUILDER_VERSION=v3.3.0


### PR DESCRIPTION
## Description
Move to go1.19, as required by Ginkgo
