### PR TITLE
fix the need to have istio crds for modelmesh reconciliation

### DIFF
--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -24,8 +24,6 @@ import (
 	kservev1beta1 "github.com/kserve/modelmesh-serving/apis/serving/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	istiosecv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
-	telemetryv1alpha1 "istio.io/client-go/pkg/apis/telemetry/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	authv1 "k8s.io/api/rbac/v1"
@@ -116,11 +114,9 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
 		Owns(&authv1.ClusterRoleBinding{}).
-		Owns(&istiosecv1beta1.PeerAuthentication{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&monitoringv1.PodMonitor{}).
-		Owns(&telemetryv1alpha1.Telemetry{}).
 		Watches(&source.Kind{Type: &predictorv1.ServingRuntime{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 				r.Log.Info("Reconcile event triggered by serving runtime: " + o.GetName())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,10 +25,8 @@ import (
 	inferenceservicev1 "github.com/kserve/modelmesh-serving/apis/serving/v1beta1"
 	mf "github.com/manifestival/manifestival"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	corev1 "k8s.io/api/core/v1"
-	k8srbacv1 "k8s.io/api/rbac/v1"
-
 	"go.uber.org/zap/zapcore"
+	k8srbacv1 "k8s.io/api/rbac/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix odh-model-controller expecting istio `PeerAuthentication` and `Telemetry` CRDs even when they are not needed for modelmesh. 
Intended to be tested with the accompanying PR to [odh-manifests](https://github.com/opendatahub-io/odh-manifests/pull/922)



## How Has This Been Tested?
- Install ODH operator from the `stable` channel. 
- Copy the [odh-core kfdef](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/odh-core.yaml) 
- Change the manifest uri in the kfdef to `https://github.com/VedantMahabaleshwarkar/odh-manifests/tarball/crd_fix` 
- Add a parameter to modelmesh kustomizeConfig as follows 
```
  - kustomizeConfig:
      parameters:
      - name: monitoring-namespace
        value: opendatahub
      - name: odh-model-controller
        value: quay.io/vedantm/odh-model-controller:latest
      repoRef:
        name: manifests
        path: model-mesh
    name: model-mesh
  ```
- Install the kfdef 
- Create a OVMS model and verify it is successfully created
- Verify odh-model-controller is not Crashlooping 

### Operator v2 
- In the DSCInit CR, use `manifestsUri: https://github.com/VedantMahabaleshwarkar/odh-manifests/tarball/https://github.com/VedantMahabaleshwarkar/odh-manifests/tree/crd_fix_custom_image`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
