### PR TITLE
remove check for istio CRD installation

### DIFF
--- a/controllers/kserve_inferenceservice_controller.go
+++ b/controllers/kserve_inferenceservice_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8srbacv1 "k8s.io/api/rbac/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,33 +53,6 @@ const (
 	TelemetryCRD                       = "telemetries.telemetry.istio.io"
 	PeerAuthCRD                        = "peerauthentications.security.istio.io"
 )
-
-func (r *OpenshiftInferenceServiceReconciler) foundKserveDependenyCRDs(ctx context.Context) bool {
-
-	allCRDsFound := true
-	// Check if CRD for Telemetry is installed
-	crd := &apiextv1.CustomResourceDefinition{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: TelemetryCRD}, crd)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			allCRDsFound = false
-		} else {
-			allCRDsFound = false
-		}
-	}
-
-	// Check if CRD for PeerAuthentication is installed
-	err = r.Client.Get(ctx, client.ObjectKey{Name: PeerAuthCRD}, crd)
-	if err != nil {
-		if apierrs.IsNotFound(err) {
-			allCRDsFound = false
-		} else {
-			allCRDsFound = false
-		}
-	}
-
-	return allCRDsFound
-}
 
 func (r *OpenshiftInferenceServiceReconciler) ensurePrometheusRoleBinding(ctx context.Context, req ctrl.Request, ns string) error {
 	// Initialize logger format
@@ -500,12 +472,6 @@ func (r *OpenshiftInferenceServiceReconciler) DeleteKserveMetricsResourcesIfNoKs
 	// Initialize logger format
 	log := r.Log.WithValues("namespace", ns)
 
-	//Check if the dependent CRDs for Kserve are installed
-	if !r.foundKserveDependenyCRDs(ctx) {
-		log.Info("Missing Istio CRDs")
-		return nil
-	}
-
 	inferenceServiceList := &kservev1beta1.InferenceServiceList{}
 	err := r.List(ctx, inferenceServiceList, client.InNamespace(req.Namespace))
 	if err != nil {
@@ -623,12 +589,6 @@ func (r *OpenshiftInferenceServiceReconciler) ReconcileKserveInference(ctx conte
 
 	// Initialize logger format
 	log := r.Log.WithValues("InferenceService", inferenceService.Name, "namespace", inferenceService.Namespace)
-
-	//Check if the dependent CRDs for Kserve are installed
-	if !r.foundKserveDependenyCRDs(ctx) {
-		log.Info("Missing Istio CRDs")
-		return nil
-	}
 
 	//Create the metrics service and servicemonitor with OwnerReferences, as these are not common namespace-scope resources
 	log.Info("Reconciling Metrics Service for InferenceSercvice")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixes #75 
- Remove check for verifying Istio PeerAuthentication and Telemetry CRDs are installed 
   - This check was added to prevent a [failure](https://issues.redhat.com/browse/RHODS-11104) when odh-model-controller is deployed with modelmesh. 
   - This check is not needed as odh-model-controller is not `owning` PeerAuthentications and Telemetries anymore so the previous failure does not occur. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with ODH 2.1.0

#### Kserve test
- Install ODH 2.1.0 
- Follow pre-requisite installation for kserve+knative for caikit models
- Modify the default DSCInitialization to include `manifestsUri: >-
    https://github.com/VedantMahabaleshwarkar/odh-manifests/tarball/false_error_missing_crds`
   - This deploys the odh-model-controller image `quay.io/vedantm/odh-model-controller:latest` which is where the fix is
- Deploy a caikit model in any namespace and verify the namespace is added to the `default` ServiceMeshMemberRoll 

#### Modelmesh test
- Install ODH 2.1.0 
- Modify the default DSCInitialization to include `manifestsUri: >-
    https://github.com/VedantMahabaleshwarkar/odh-manifests/tarball/false_error_missing_crds`
   - This deploys the odh-model-controller image `quay.io/vedantm/odh-model-controller:latest` which is where the fix is
- Deploy a modelmesh compatible model in any namespace and verify the model deployment and the route creation are successful. 


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
