### PR TITLE
Remove kserve flag and update manifests 

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,5 +1,29 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../default
   - ../prometheus
+  - ../overlays/odh
+
+namespace: opendatahub
+configMapGenerator:
+  - envs:
+      - params.env
+    name: odh-model-controller-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - fieldref:
+      fieldPath: metadata.namespace
+    name: mesh-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.odh-model-controller
+    name: odh-model-controller
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,0 +1,1 @@
+odh-model-controller=quay.io/vedantm/odh-model-controller:remove-flag

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,8 +1,3 @@
 bases:
   - ../rbac
   - ../manager
-  - ../crd/external
-
-# Adds namespace to all resources.
-namespace: odh-model-controller-system
-

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
   - manager.yaml
-  - namespace.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -9,8 +8,3 @@ configMapGenerator:
   - files:
       - controller_manager_config.yaml
     name: manager-config
-
-images:
-- name: controller
-  newName: quay.io/opendatahub/odh-model-controller
-  newTag: stable

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../crd/external
+  - ../../manager/namespace.yaml

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../default
+
+patchesStrategicMerge:
+  - odh_model_controller_manager_patch.yaml
+
+configurations:
+  - params.yaml

--- a/config/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/config/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-model-controller
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - args:
+            - --leader-elect
+            - "--monitoring-namespace"
+            - "$(MONITORING_NS)"
+          image: $(odh-model-controller) 
+          env:
+            - name: MONITORING_NS
+              value: kserve
+          name: manager

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,0 +1,7 @@
+varReference:
+  - path: metadata/name
+    kind: ClusterRoleBinding
+    apiGroup: authorization.openshift.io
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment
+    apiVersion: apps/v1

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,5 @@ resources:
   - auth_proxy_role.yaml
   - auth_proxy_role_binding.yaml
   - auth_proxy_client_clusterrole.yaml
+  - kserve_prometheus_clusterrole.yaml
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Remove the need to have a `kserve-enabled` flag. This was needed as previously modelmesh and kserve could not co-exist. But now that they can we do not need this anymore 
- Update the odh-model-controller manifests in-repo (in config/) such that they match the manifests from `odh-manifests` for odh-model-controller

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
