### PR TITLE
manifest readiness update for odh-operator v2

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -14,13 +14,6 @@ generatorOptions:
 
 vars:
   - fieldref:
-      fieldPath: metadata.namespace
-    name: mesh-namespace
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: odh-model-controller-parameters
-  - fieldref:
       fieldPath: data.odh-model-controller
     name: odh-model-controller
     objref:

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,5 +1,29 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../default
   - ../prometheus
+  - ../overlays/odh
+
+namespace: opendatahub
+configMapGenerator:
+  - envs:
+      - params.env
+    name: odh-model-controller-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - fieldref:
+      fieldPath: metadata.namespace
+    name: mesh-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.odh-model-controller
+    name: odh-model-controller
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -14,6 +14,20 @@ generatorOptions:
 
 vars:
   - fieldref:
+      fieldPath: metadata.namespace
+    name: mesh-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.monitoring-namespace
+    name: monitoring-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
       fieldPath: data.odh-model-controller
     name: odh-model-controller
     objref:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,1 +1,2 @@
+monitoring-namespace=opendatahub
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,0 +1,1 @@
+odh-model-controller=quay.io/opendatahub/odh-model-controller:fast

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,8 +1,3 @@
 bases:
   - ../rbac
   - ../manager
-  - ../crd/external
-
-# Adds namespace to all resources.
-namespace: odh-model-controller-system
-

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
   - manager.yaml
-  - namespace.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -9,8 +8,3 @@ configMapGenerator:
   - files:
       - controller_manager_config.yaml
     name: manager-config
-
-images:
-- name: controller
-  newName: quay.io/opendatahub/odh-model-controller
-  newTag: stable

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../crd/external
+  - ../../manager/namespace.yaml

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../default
+
+patchesStrategicMerge:
+  - odh_model_controller_manager_patch.yaml
+
+configurations:
+  - params.yaml

--- a/config/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/config/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-model-controller
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - args:
+            - --leader-elect
+            - "--monitoring-namespace"
+            - "$(MONITORING_NS)"
+          image: $(odh-model-controller) 
+          env:
+            - name: MONITORING_NS
+              value: kserve
+          name: manager

--- a/config/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/config/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -14,5 +14,5 @@ spec:
           image: $(odh-model-controller) 
           env:
             - name: MONITORING_NS
-              value: kserve
+              value: $(monitoring-namespace)
           name: manager

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,0 +1,7 @@
+varReference:
+  - path: metadata/name
+    kind: ClusterRoleBinding
+    apiGroup: authorization.openshift.io
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment
+    apiVersion: apps/v1

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,7 +1,7 @@
 varReference:
   - path: metadata/name
     kind: ClusterRoleBinding
-    apiGroup: authorization.openshift.io
+    apiGroup: rbac.authorization.k8s.io/v1
   - path: spec/template/spec/containers[]/image
     kind: Deployment
     apiVersion: apps/v1

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,5 @@ resources:
   - auth_proxy_role.yaml
   - auth_proxy_role_binding.yaml
   - auth_proxy_client_clusterrole.yaml
+  - kserve_prometheus_clusterrole.yaml
+

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -214,3 +214,19 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+    - extensions
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - list
+    - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
   verbs:
   - create
   - delete

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: odh-model-controller-rolebinding
+  name: odh-model-controller-rolebinding-$(mesh-namespace)
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/main.go
+++ b/main.go
@@ -105,7 +105,6 @@ func main() {
 	var enableLeaderElection bool
 	var monitoringNS string
 	var probeAddr string
-	var kserveEnabled bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -113,9 +112,6 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&monitoringNS, "monitoring-namespace", "",
 		"The Namespace where the monitoring stack's Prometheus resides.")
-	flag.BoolVar(&kserveEnabled, "kserve-enabled", true,
-		"Enable Kserve Metrics. "+
-			"Enabling will disable modelmesh controllers and only create kserve monitoring controller.")
 
 	opts := zap.Options{
 		Development: true,
@@ -148,32 +144,29 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		os.Exit(1)
 	}
-	if !kserveEnabled {
-		setupLog.Info("ModelMesh deployment mode, skipping setup of kserve controllers.")
-		if err = (&controllers.StorageSecretReconciler{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("StorageSecret"),
-			Scheme: mgr.GetScheme(),
+	if err = (&controllers.StorageSecretReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("StorageSecret"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "StorageSecret")
+		os.Exit(1)
+	}
+
+	if monitoringNS != "" {
+		setupLog.Info("Monitoring namespace provided, setting up monitoring controller.")
+		if err = (&controllers.MonitoringReconciler{
+			Client:       mgr.GetClient(),
+			Log:          ctrl.Log.WithName("controllers").WithName("MonitoringReconciler"),
+			Scheme:       mgr.GetScheme(),
+			MonitoringNS: monitoringNS,
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "StorageSecret")
+			setupLog.Error(err, "unable to create controller", "controller", "MonitoringReconciler")
 			os.Exit(1)
 		}
-
-		if monitoringNS != "" {
-			setupLog.Info("Monitoring namespace provided, setting up monitoring controller.")
-			if err = (&controllers.MonitoringReconciler{
-				Client:       mgr.GetClient(),
-				Log:          ctrl.Log.WithName("controllers").WithName("MonitoringReconciler"),
-				Scheme:       mgr.GetScheme(),
-				MonitoringNS: monitoringNS,
-			}).SetupWithManager(mgr); err != nil {
-				setupLog.Error(err, "unable to create controller", "controller", "MonitoringReconciler")
-				os.Exit(1)
-			}
-		} else {
-			setupLog.Info("Monitoring namespace not provided, skipping setup of monitoring controller. To enable " +
-				"monitoring for ModelServing, please provide a monitoring namespace via the (--monitoring-namespace) flag.")
-		}
+	} else {
+		setupLog.Info("Monitoring namespace not provided, skipping setup of monitoring controller. To enable " +
+			"monitoring for ModelServing, please provide a monitoring namespace via the (--monitoring-namespace) flag.")
 	}
 
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- copied over the latest odh-model-controller manifests from `odh-manifests/odh-model-controller` and put them in `config/`  
- created `overlays/odh` and `overlays/dev` to handle the ODH overlays and also have an overlay option for local development 
- removed the need to have 2 copies of odh-model-controller manifests for kserve and modelmesh 
- - this is done by removing the need to have a `kserve-enabled` flag, thus the same set of manifests can be used by both serving stacks 


## Testing 
Follow testing instructions on https://github.com/opendatahub-io/modelmesh-serving/pull/237 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
