### PR TITLE
Set Env to define POD_NAMESPACE

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,6 +42,11 @@ spec:
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
odh-model-controller should aware about the namespace in which controller pod is running. `POD_NAMESPACE` is the env which read by controller for it. `POD_NAMESPACE` is used by  odh-model-controller while creating the generic route to read `inferenceservice-config` configmap to read ingress configurations.
https://github.com/opendatahub-io/odh-model-controller/blob/main/controllers/reconcilers/kserve_route_reconciler.go#L77

With this PR I am initializing the `POD_NAMESPACE` env. It is required for https://github.com/opendatahub-io/odh-model-controller/issues/67

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
It could be tested with https://github.com/opendatahub-io/odh-model-controller/pull/100

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
