### PR TITLE
Fixes vulnerabilities on the otelhttp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,13 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-// remove when upgrade to controller-runtime 0.15.xor apimachinery to 0.27.x
-// Fixes github.com/elazarl/goproxy Denial of Service (DoS)
-// This dependency was remove from apimachinery 0.27.0
-replace k8s.io/apimachinery => k8s.io/apimachinery v0.27.0
+replace (
+	// remove when upgrade to controller-runtime 0.15.x or apimachinery to 0.27.x
+	// Fixes github.com/elazarl/goproxy Denial of Service (DoS)
+	// This dependency was removed from apimachinery 0.27.0
+	 k8s.io/apimachinery => k8s.io/apimachinery v0.27.0
+	// Fixes CVE-2022-21698 and CVE-2023-45142
+	// this dependency comes from k8s.io/component-base@v0.26.4 and k8s.io/apiextensions-apiserver@v0.26.4
+	// before removing it make sure that the next version of the related k8s dependencies contains the fix
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
+)


### PR DESCRIPTION
chore: Fixes the following vulnerabilities in the go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp dependency:
- [CVE-2022-21698](https://www.cve.org/CVERecord?id=CVE-2022-21698) / [CVE-2023-45142](https://www.cve.org/CVERecord?id=CVE-2023-45142): Allocation of Resources Without Limits or Throttling

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
