### PR TITLE
Remove PodMonitor from Namespace level and implement PodMonitor for e…

### DIFF
--- a/controllers/reconcilers/kserve_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/kserve_inferenceservice_reconciler.go
@@ -29,6 +29,7 @@ type KserveInferenceServiceReconciler struct {
 	routeReconciler                   *KserveRouteReconciler
 	metricsServiceReconciler          *KserveMetricsServiceReconciler
 	metricsServiceMonitorReconciler   *KserveMetricsServiceMonitorReconciler
+	metricsPodMonitorReconciler       *KserveMetricsPodMonitorReconciler
 	prometheusRoleBindingReconciler   *KservePrometheusRoleBindingReconciler
 	istioSMMRReconciler               *KserveIstioSMMRReconciler
 	istioTelemetryReconciler          *KserveIstioTelemetryReconciler
@@ -45,6 +46,7 @@ func NewKServeInferenceServiceReconciler(client client.Client, scheme *runtime.S
 		routeReconciler:                   NewKserveRouteReconciler(client, scheme),
 		metricsServiceReconciler:          NewKServeMetricsServiceReconciler(client, scheme),
 		metricsServiceMonitorReconciler:   NewKServeMetricsServiceMonitorReconciler(client, scheme),
+		metricsPodMonitorReconciler:       NewKServeMetricsPodMonitorReconciler(client, scheme),
 		prometheusRoleBindingReconciler:   NewKServePrometheusRoleBindingReconciler(client, scheme),
 		istioTelemetryReconciler:          NewKServeIstioTelemetryReconciler(client, scheme),
 		istioServiceMonitorReconciler:     NewKServeIstioServiceMonitorReconciler(client, scheme),
@@ -77,6 +79,7 @@ func (r *KserveInferenceServiceReconciler) Reconcile(ctx context.Context, log lo
 		return err
 	}
 
+	// Remove KserveIstioPodMonitorReconciler from subsequent release
 	log.V(1).Info("Creating Istio PodMonitor for target namespace")
 	if err := r.istioPodMonitorReconciler.Reconcile(ctx, log, isvc); err != nil {
 		return err
@@ -105,6 +108,11 @@ func (r *KserveInferenceServiceReconciler) Reconcile(ctx context.Context, log lo
 
 	log.V(1).Info("Reconciling Metrics ServiceMonitor for InferenceService")
 	if err := r.metricsServiceMonitorReconciler.Reconcile(ctx, log, isvc); err != nil {
+		return err
+	}
+
+	log.V(1).Info("Reconciling Metrics PodMonitor for InferenceService")
+	if err := r.metricsPodMonitorReconciler.Reconcile(ctx, log, isvc); err != nil {
 		return err
 	}
 

--- a/controllers/reconcilers/kserve_podmonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_podmonitor_reconciler.go
@@ -19,28 +19,27 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
 	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	istioPodMonitorName = "istio-proxies-monitor"
-)
-
-type KserveIstioPodMonitorReconciler struct {
+type KserveMetricsPodMonitorReconciler struct {
 	client            client.Client
 	scheme            *runtime.Scheme
 	podMonitorHandler resources.PodMonitorHandler
 	deltaProcessor    processors.DeltaProcessor
 }
 
-func NewKServeIstioPodMonitorReconciler(client client.Client, scheme *runtime.Scheme) *KserveIstioPodMonitorReconciler {
-	return &KserveIstioPodMonitorReconciler{
+func NewKServeMetricsPodMonitorReconciler(client client.Client, scheme *runtime.Scheme) *KserveMetricsPodMonitorReconciler {
+	return &KserveMetricsPodMonitorReconciler{
 		client:            client,
 		scheme:            scheme,
 		podMonitorHandler: resources.NewPodMonitorHandler(client),
@@ -48,7 +47,7 @@ func NewKServeIstioPodMonitorReconciler(client client.Client, scheme *runtime.Sc
 	}
 }
 
-func (r *KserveIstioPodMonitorReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+func (r *KserveMetricsPodMonitorReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
 
 	// Create Desired resource
 	desiredResource, err := r.createDesiredResource(isvc)
@@ -69,15 +68,37 @@ func (r *KserveIstioPodMonitorReconciler) Reconcile(ctx context.Context, log log
 	return nil
 }
 
-func (r *KserveIstioPodMonitorReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.PodMonitor, error) {
-	return nil, nil
+func (r *KserveMetricsPodMonitorReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.PodMonitor, error) {
+	desiredPodMonitor := &v1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getMetricsPodMonitorName(isvc),
+			Namespace: isvc.Namespace,
+		},
+		Spec: v1.PodMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					constants.InferenceServicePodLabelKey: isvc.Name,
+				},
+			},
+			PodMetricsEndpoints: []v1.PodMetricsEndpoint{
+				{
+					Path:     "/stats/prometheus",
+					Interval: "30s",
+				},
+			},
+		},
+	}
+	if err := ctrl.SetControllerReference(isvc, desiredPodMonitor, r.scheme); err != nil {
+		return nil, err
+	}
+	return desiredPodMonitor, nil
 }
 
-func (r *KserveIstioPodMonitorReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.PodMonitor, error) {
-	return r.podMonitorHandler.FetchPodMonitor(ctx, log, types.NamespacedName{Name: istioPodMonitorName, Namespace: isvc.Namespace})
+func (r *KserveMetricsPodMonitorReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.PodMonitor, error) {
+	return r.podMonitorHandler.FetchPodMonitor(ctx, log, types.NamespacedName{Name: getMetricsPodMonitorName(isvc), Namespace: isvc.Namespace})
 }
 
-func (r *KserveIstioPodMonitorReconciler) processDelta(ctx context.Context, log logr.Logger, desiredPod *v1.PodMonitor, existingPod *v1.PodMonitor) (err error) {
+func (r *KserveMetricsPodMonitorReconciler) processDelta(ctx context.Context, log logr.Logger, desiredPod *v1.PodMonitor, existingPod *v1.PodMonitor) (err error) {
 	comparator := comparators.GetPodMonitorComparator()
 	delta := r.deltaProcessor.ComputeDelta(comparator, desiredPod, existingPod)
 
@@ -110,6 +131,6 @@ func (r *KserveIstioPodMonitorReconciler) processDelta(ctx context.Context, log 
 	return nil
 }
 
-func (r *KserveIstioPodMonitorReconciler) DeletePodMonitor(ctx context.Context, isvcNamespace string) error {
-	return r.podMonitorHandler.DeletePodMonitor(ctx, types.NamespacedName{Name: istioPodMonitorName, Namespace: isvcNamespace})
+func getMetricsPodMonitorName(isvc *kservev1beta1.InferenceService) string {
+	return isvc.Name + "-monitor"
 }


### PR DESCRIPTION
…ach KServe isvc.


<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently PodMonitor for KServe isvc is monitoring all pod in the namespace which causes issue in ModelMesh monitor. With this PR I had change the behaviour of PodMonitor to just monitor pods of KServe isvc. It should fix https://github.com/opendatahub-io/odh-model-controller/issues/125

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
