### PR TITLE
Allow ModelMesh and KServe to run in same namespace.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,18 @@ metadata:
   name: odh-model-controller-role
 rules:
 - apiGroups:
+    - ""
+  resources:
+    - serviceaccounts
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
+    - delete
+- apiGroups:
   - ""
   resources:
   - configmaps
@@ -13,7 +25,6 @@ rules:
   - namespaces
   - pods
   - secrets
-  - serviceaccounts
   - services
   verbs:
   - create

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -120,7 +120,7 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		Watches(&source.Kind{Type: &networkingv1.NetworkPolicy{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 				r.log.Info("Reconcile event triggered by Network Policy: " + o.GetName())
-				return r.getReconcileRequestsOnUpdateOfServingRuntime(o)
+				return r.getReconcileRequestsOnUpdateOfNetworkPolicy(o)
 			}))
 	err := builder.Complete(r)
 	if err != nil {

--- a/controllers/kserve_inferenceservice_controller_test.go
+++ b/controllers/kserve_inferenceservice_controller_test.go
@@ -55,6 +55,21 @@ var _ = Describe("The Openshift Kserve model controller", func() {
 
 		})
 
+		//Context("Validate Openshift Monitoring Stack", func() {
+		//	It("Namespace should be added to SMMR", func() {
+		//		smmr := &v1.ServiceMeshMemberRoll{}
+		//		err := cli.Get(ctx, types.NamespacedName{Name: reconcilers.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace}, smmr)
+		//		Expect(err).NotTo(HaveOccurred())
+		//
+		//	})
+		//
+		//	It("Prometheus cluster role binding should be configured", func() {
+		//		smmr := &v1.ServiceMeshMemberRoll{}
+		//		err := cli.Get(ctx, types.NamespacedName{Name: reconcilers.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace}, smmr)
+		//		Expect(err).NotTo(HaveOccurred())
+		//	})
+		//})
+
 		It("With Kserve InferenceService a Route be created", func() {
 			inferenceService := &kservev1beta1.InferenceService{}
 			err := convertToStructuredResource(KserveInferenceServicePath1, inferenceService)

--- a/controllers/kserve_inferenceservice_controller_test.go
+++ b/controllers/kserve_inferenceservice_controller_test.go
@@ -55,21 +55,6 @@ var _ = Describe("The Openshift Kserve model controller", func() {
 
 		})
 
-		//Context("Validate Openshift Monitoring Stack", func() {
-		//	It("Namespace should be added to SMMR", func() {
-		//		smmr := &v1.ServiceMeshMemberRoll{}
-		//		err := cli.Get(ctx, types.NamespacedName{Name: reconcilers.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace}, smmr)
-		//		Expect(err).NotTo(HaveOccurred())
-		//
-		//	})
-		//
-		//	It("Prometheus cluster role binding should be configured", func() {
-		//		smmr := &v1.ServiceMeshMemberRoll{}
-		//		err := cli.Get(ctx, types.NamespacedName{Name: reconcilers.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace}, smmr)
-		//		Expect(err).NotTo(HaveOccurred())
-		//	})
-		//})
-
 		It("With Kserve InferenceService a Route be created", func() {
 			inferenceService := &kservev1beta1.InferenceService{}
 			err := convertToStructuredResource(KserveInferenceServicePath1, inferenceService)

--- a/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
@@ -83,6 +83,10 @@ func (r *KserveIstioPodMonitorReconciler) createDesiredResource(isvc *kservev1be
 						Key:      "istio-prometheus-ignore",
 						Operator: metav1.LabelSelectorOpDoesNotExist,
 					},
+					{
+						Key:      "modelmesh-service",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
 				},
 			},
 			PodMetricsEndpoints: []v1.PodMetricsEndpoint{

--- a/controllers/reconcilers/mm_controller_networkpolicy_reconciler.go
+++ b/controllers/reconcilers/mm_controller_networkpolicy_reconciler.go
@@ -1,0 +1,141 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
+	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
+	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+	"k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type MMControllerNetworkPolicyReconciler struct {
+	client               client.Client
+	scheme               *runtime.Scheme
+	networkPolicyHandler resources.NetworkPolicyHandler
+	deltaProcessor       processors.DeltaProcessor
+}
+
+func NewMMControllerNetworkPolicyReconciler(client client.Client, scheme *runtime.Scheme) *MMControllerNetworkPolicyReconciler {
+	return &MMControllerNetworkPolicyReconciler{
+		client:               client,
+		scheme:               scheme,
+		networkPolicyHandler: resources.NewNetworkPolicyHandler(client),
+		deltaProcessor:       processors.NewDeltaProcessor(),
+	}
+}
+
+func (r *MMControllerNetworkPolicyReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+
+	// Create Desired resource
+	desiredResource, err := r.createDesiredResource(isvc)
+	if err != nil {
+		return err
+	}
+
+	// Get Existing resource
+	existingResource, err := r.getExistingResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
+
+	// Process Delta
+	if err = r.processDelta(ctx, log, desiredResource, existingResource); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *MMControllerNetworkPolicyReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	desiredNetworkPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getMMControllerNetworkPolicyName(),
+			Namespace: isvc.Namespace,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					From: []v1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"kubernetes.io/metadata.name": constants.KServeNamespace,
+								},
+							},
+						},
+					},
+				},
+			},
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+		},
+	}
+	return desiredNetworkPolicy, nil
+}
+
+func (r *MMControllerNetworkPolicyReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	return r.networkPolicyHandler.FetchNetworkPolicy(ctx, log, types.NamespacedName{Name: getMMControllerNetworkPolicyName(), Namespace: isvc.Namespace})
+}
+
+func (r *MMControllerNetworkPolicyReconciler) processDelta(ctx context.Context, log logr.Logger, desiredPod *v1.NetworkPolicy, existingPod *v1.NetworkPolicy) (err error) {
+	comparator := comparators.GetNetworkPolicyComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desiredPod, existingPod)
+
+	if !delta.HasChanges() {
+		log.V(1).Info("No delta found")
+		return nil
+	}
+
+	if delta.IsAdded() {
+		log.V(1).Info("Delta found", "create", desiredPod.GetName())
+		if err = r.client.Create(ctx, desiredPod); err != nil {
+			return
+		}
+	}
+	if delta.IsUpdated() {
+		log.V(1).Info("Delta found", "update", existingPod.GetName())
+		rp := existingPod.DeepCopy()
+		rp.Labels = desiredPod.Labels
+		rp.Spec = desiredPod.Spec
+
+		if err = r.client.Update(ctx, rp); err != nil {
+			return
+		}
+	}
+	if delta.IsRemoved() {
+		log.V(1).Info("Delta found", "delete", existingPod.GetName())
+		if err = r.client.Delete(ctx, existingPod); err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+func getMMControllerNetworkPolicyName() string {
+	return "allow-from-" + constants.KServeNamespace + "-ns"
+}
+
+func (r *MMControllerNetworkPolicyReconciler) DeleteMMControllerNetworkPolicy(ctx context.Context, isvcNamespace string) error {
+	return r.networkPolicyHandler.DeleteNetworkPolicy(ctx, types.NamespacedName{Name: getMMControllerNetworkPolicyName(), Namespace: isvcNamespace})
+}

--- a/controllers/reconcilers/mm_route_networkpolicy_reconciler.go
+++ b/controllers/reconcilers/mm_route_networkpolicy_reconciler.go
@@ -1,0 +1,144 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
+	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
+	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+	"k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	modelMeshRouteNetworkPolicyName = "allow-modelmesh-route"
+)
+
+type MMRouteNetworkPolicyReconciler struct {
+	client               client.Client
+	scheme               *runtime.Scheme
+	networkPolicyHandler resources.NetworkPolicyHandler
+	deltaProcessor       processors.DeltaProcessor
+}
+
+func NewMMRouteNetworkPolicyReconciler(client client.Client, scheme *runtime.Scheme) *MMRouteNetworkPolicyReconciler {
+	return &MMRouteNetworkPolicyReconciler{
+		client:               client,
+		scheme:               scheme,
+		networkPolicyHandler: resources.NewNetworkPolicyHandler(client),
+		deltaProcessor:       processors.NewDeltaProcessor(),
+	}
+}
+
+func (r *MMRouteNetworkPolicyReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+
+	// Create Desired resource
+	desiredResource, err := r.createDesiredResource(isvc)
+	if err != nil {
+		return err
+	}
+
+	// Get Existing resource
+	existingResource, err := r.getExistingResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
+
+	// Process Delta
+	if err = r.processDelta(ctx, log, desiredResource, existingResource); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *MMRouteNetworkPolicyReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	desiredNetworkPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      modelMeshRouteNetworkPolicyName,
+			Namespace: isvc.Namespace,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"modelmesh-service": "modelmesh-serving",
+				},
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					From: []v1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"network.openshift.io/policy-group": "ingress",
+								},
+							},
+						},
+					},
+				},
+			},
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+		},
+	}
+	return desiredNetworkPolicy, nil
+}
+
+func (r *MMRouteNetworkPolicyReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	return r.networkPolicyHandler.FetchNetworkPolicy(ctx, log, types.NamespacedName{Name: modelMeshRouteNetworkPolicyName, Namespace: isvc.Namespace})
+}
+
+func (r *MMRouteNetworkPolicyReconciler) processDelta(ctx context.Context, log logr.Logger, desiredPod *v1.NetworkPolicy, existingPod *v1.NetworkPolicy) (err error) {
+	comparator := comparators.GetNetworkPolicyComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desiredPod, existingPod)
+
+	if !delta.HasChanges() {
+		log.V(1).Info("No delta found")
+		return nil
+	}
+
+	if delta.IsAdded() {
+		log.V(1).Info("Delta found", "create", desiredPod.GetName())
+		if err = r.client.Create(ctx, desiredPod); err != nil {
+			return
+		}
+	}
+	if delta.IsUpdated() {
+		log.V(1).Info("Delta found", "update", existingPod.GetName())
+		rp := existingPod.DeepCopy()
+		rp.Labels = desiredPod.Labels
+		rp.Spec = desiredPod.Spec
+
+		if err = r.client.Update(ctx, rp); err != nil {
+			return
+		}
+	}
+	if delta.IsRemoved() {
+		log.V(1).Info("Delta found", "delete", existingPod.GetName())
+		if err = r.client.Delete(ctx, existingPod); err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+func (r *MMRouteNetworkPolicyReconciler) DeleteMMRouteNetworkPolicy(ctx context.Context, isvcNamespace string) error {
+	return r.networkPolicyHandler.DeleteNetworkPolicy(ctx, types.NamespacedName{Name: modelMeshRouteNetworkPolicyName, Namespace: isvcNamespace})
+}


### PR DESCRIPTION
Solving following issue with this PR:
- https://github.com/opendatahub-io/odh-model-controller/issues/133
- https://github.com/opendatahub-io/odh-model-controller/issues/125
- https://github.com/opendatahub-io/odh-model-controller/issues/128
- https://github.com/opendatahub-io/odh-model-controller/issues/127

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
**Setup Env**
Please follow below instruction to setup your env:
https://gist.github.com/vaibhavjainwiz/61045727dfda727f7577a6f97ca46563

**Validate**

1. After above setup, verift both KServe and ModelMesh InferenceServices are running successfully.
2. There should not be any error in log of KServe controller/Model Controller and runtime pods.
3. Both isvc should be accessble using curl/grpc.
4. Now delete ModelMesh InferenceService, KServe isvc should be running without any error.
5. Now delete KServe isvc, all dependent resources should be deleted.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
