### PR TITLE
Revert "[Cherry-pick] fix: Remove NetworkPolicies created to relax SMCP policies"

### DIFF
--- a/controllers/reconcilers/kserve_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/kserve_inferenceservice_reconciler.go
@@ -161,6 +161,11 @@ func (r *KserveInferenceServiceReconciler) DeleteKserveMetricsResourcesIfNoKserv
 		if err := r.istioPeerAuthenticationReconciler.DeletePeerAuthentication(ctx, isvcNamespace); err != nil {
 			return err
 		}
+
+		log.V(1).Info("Deleting NetworkPolicy object for target namespace")
+		if err := r.networkPolicyReconciler.DeleteNetworkPolicy(ctx, isvcNamespace); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/controllers/reconcilers/kserve_networkpolicy_reconciler.go
+++ b/controllers/reconcilers/kserve_networkpolicy_reconciler.go
@@ -19,7 +19,11 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
+	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+	"k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,6 +37,7 @@ type KserveNetworkPolicyReconciler struct {
 	client               client.Client
 	scheme               *runtime.Scheme
 	networkPolicyHandler resources.NetworkPolicyHandler
+	deltaProcessor       processors.DeltaProcessor
 }
 
 func NewKServeNetworkPolicyReconciler(client client.Client, scheme *runtime.Scheme) *KserveNetworkPolicyReconciler {
@@ -40,13 +45,100 @@ func NewKServeNetworkPolicyReconciler(client client.Client, scheme *runtime.Sche
 		client:               client,
 		scheme:               scheme,
 		networkPolicyHandler: resources.NewNetworkPolicyHandler(client),
+		deltaProcessor:       processors.NewDeltaProcessor(),
 	}
 }
 
 func (r *KserveNetworkPolicyReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	return r.deleteNetworkPolicy(ctx, isvc.Namespace)
+
+	// Create Desired resource
+	desiredResource, err := r.createDesiredResource(isvc)
+	if err != nil {
+		return err
+	}
+
+	// Get Existing resource
+	existingResource, err := r.getExistingResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
+
+	// Process Delta
+	if err = r.processDelta(ctx, log, desiredResource, existingResource); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (r *KserveNetworkPolicyReconciler) deleteNetworkPolicy(ctx context.Context, isvcNamespace string) error {
+func (r *KserveNetworkPolicyReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	desiredNetworkPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: isvc.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/version":               "release-v1.9",
+				"networking.knative.dev/ingress-provider": "istio",
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{
+					From: []v1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"name": "openshift-user-workload-monitoring",
+								},
+							},
+						},
+					},
+				},
+			},
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+		},
+	}
+	return desiredNetworkPolicy, nil
+}
+
+func (r *KserveNetworkPolicyReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.NetworkPolicy, error) {
+	return r.networkPolicyHandler.FetchNetworkPolicy(ctx, log, types.NamespacedName{Name: networkPolicyName, Namespace: isvc.Namespace})
+}
+
+func (r *KserveNetworkPolicyReconciler) processDelta(ctx context.Context, log logr.Logger, desiredPod *v1.NetworkPolicy, existingPod *v1.NetworkPolicy) (err error) {
+	comparator := comparators.GetNetworkPolicyComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desiredPod, existingPod)
+
+	if !delta.HasChanges() {
+		log.V(1).Info("No delta found")
+		return nil
+	}
+
+	if delta.IsAdded() {
+		log.V(1).Info("Delta found", "create", desiredPod.GetName())
+		if err = r.client.Create(ctx, desiredPod); err != nil {
+			return
+		}
+	}
+	if delta.IsUpdated() {
+		log.V(1).Info("Delta found", "update", existingPod.GetName())
+		rp := existingPod.DeepCopy()
+		rp.Labels = desiredPod.Labels
+		rp.Spec = desiredPod.Spec
+
+		if err = r.client.Update(ctx, rp); err != nil {
+			return
+		}
+	}
+	if delta.IsRemoved() {
+		log.V(1).Info("Delta found", "delete", existingPod.GetName())
+		if err = r.client.Delete(ctx, existingPod); err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+func (r *KserveNetworkPolicyReconciler) DeleteNetworkPolicy(ctx context.Context, isvcNamespace string) error {
 	return r.networkPolicyHandler.DeleteNetworkPolicy(ctx, types.NamespacedName{Name: networkPolicyName, Namespace: isvcNamespace})
 }


### PR DESCRIPTION
Reverts opendatahub-io/odh-model-controller#138

This change [opendatahub-io/odh-model-controller#136](https://github.com/opendatahub-io/odh-model-controller/pull/136) together with https://github.com/opendatahub-io/opendatahub-operator/pull/798 break Serverless that expects these NP to be there. So we are reverting both [opendatahub-io/odh-model-controller#136](https://github.com/opendatahub-io/odh-model-controller/pull/136) and https://github.com/opendatahub-io/opendatahub-operator/pull/798. In the meantime, we'll work on short-term solution https://issues.redhat.com/browse/RHOAIENG-1955. See https://issues.redhat.com/browse/SRVKS-1189. 

For additional context, see Slack threads:
* https://redhat-internal.slack.com/archives/C065ARTVA80/p1705573610546289
* https://redhat-internal.slack.com/archives/C065ARTVA80/p1705331979411859
* https://redhat-internal.slack.com/archives/C067G701YP6/p1705496234916619