### PR TITLE
add temp Job to delete old monitoring stack

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../default
+  - remove-deprecated-monitoring.yaml
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml

--- a/config/overlays/odh/remove-deprecated-monitoring.yaml
+++ b/config/overlays/odh/remove-deprecated-monitoring.yaml
@@ -1,0 +1,71 @@
+
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: remove-deprecated-monitoring
+  namespace: redhat-ods-applications
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: odh-model-controller
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+        - name: oc-cli
+          image: >-
+            registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: ["/bin/bash", "-c", "--"]
+          args:
+          - |
+            #check if namespace redhat-ods-monitoring exists 
+            monitoringnamespaceexists=$(oc get project redhat-ods-monitoring | grep redhat-ods-monitoring || echo "false")
+            if [[ $monitoringnamespaceexists != "false" ]]; then
+
+              # Initialize an array to store errors
+              errors=()
+
+              #delete prometheus operator deployment
+              prometheusoperatordeploymentexists=$(oc get deployments -o name -n redhat-ods-monitoring | grep rhods-prometheus-operator || echo "false")
+              if [[ $prometheusoperatordeploymentexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete deployment rhods-prometheus-operator -n redhat-ods-monitoring || errors+=("Failed to delete prometheus operator deployment")
+              fi 
+
+              #delete prometheus statefulset
+              prometheusstatefulsetexists=$(oc get statefulsets -o name -n redhat-ods-monitoring | grep prometheus-rhods-model-monitoring || echo "false")
+              if [[ $prometheusstatefulsetexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete statefulset prometheus-rhods-model-monitoring -n redhat-ods-monitoring || errors+=("Failed to delete prometheus statefulset")
+              fi 
+
+              #delete servicemonitor
+              federatedmetricsservicemonitorexists=$(oc get servicemonitors -o name -n redhat-ods-monitoring | grep modelmesh-federated-metrics || echo "false")
+              if [[ $federatedmetricsservicemonitorexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete servicemonitor modelmesh-federated-metrics -n redhat-ods-monitoring || errors+=("Failed to delete servicemonitor")
+              fi
+
+              # Check if there were any errors during deletion
+              if [ ${#errors[@]} -gt 0 ]; then
+                echo "Errors occurred during deletion:"
+                for error in "${errors[@]}"; do
+                  echo "- $error"
+                done
+                exit 1  # Exit with an error status
+              fi
+            fi
+            # if namespace redhat-ods-monitoring does not exist, do nothing  
+          resources:
+            limits:
+              memory: 800Mi
+            requests:
+              memory: 400Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      serviceAccount: odh-model-controller
+      dnsPolicy: ClusterFirst
+  backoffLimit: 4

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,22 @@ rules:
   - patch
   - update
   - watch
+#revert before 2.7 https://issues.redhat.com/browse/RHOAIENG-293
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - get
 - apiGroups:
   - maistra.io
   resources:


### PR DESCRIPTION
## Fixes: 
https://issues.redhat.com/browse/RHOAIENG-293 

## Context: 

The `model-monitoring` stack was deprecated in RHODS 2.5. This means that starting from 2.5, the RHODS Operator does not create the resources for `model-monitoring` during new installs. However, for upgrades from 2.4, the existing resources are not deleted. This PR adds a Job for RHODS 2.6 that deletes the resources from the `model-monitoring` stack that are no longer needed. 
Resources being deleted : 
- Deployment `rhods-prometheus-operator` 
- StatefulSet (containing 3 pods) `prometheus-rhods-model-monitoring` 
- ServiceMonitor `modelmesh-federated-metrics`

Note: This Job is a temporary addition for RHODS 2.6 ONLY, and will be reverted in 2.7 as it will not be needed anymore. 

## PR changes : 
- Added initContainer to odh-model-controller deployment to delete the resources mentioned above
- Added permissions to odh-model-controller-role to allow it the necessary privileges to perform the deletion
 
## Testing Instructions : 

#### Prerequisites 
- Install RHODS 2.4
- We install 2.4 because we want to test if the initContainer correctly deletes the resources created by the old monitoring stack. 
- I used RC3 build for 2.4 because I could not find a way to install the 2.4 version of the product from operatorhub. 
```
Catalog Source Images for 2.4 RC3 
Index image v4.11: registry-proxy.engineering.redhat.com/rh-osbs/iib:625499
Index image v4.12: registry-proxy.engineering.redhat.com/rh-osbs/iib:625502
Index image v4.13: registry-proxy.engineering.redhat.com/rh-osbs/iib:625517
Index image v4.14: registry-proxy.engineering.redhat.com/rh-osbs/iib:625527
Index image v4.15: registry-proxy.engineering.redhat.com/rh-osbs/iib:625532
``` 
[Instructions to install RC builds on clusters (doesn't work on ROSA):](https://docs.google.com/document/d/1DcnCV500nMrJFknWJXC6XAaylKlUY6XB4swltwiImKQ/edit#heading=h.uhu58j7scukc)   

#### Testing Steps
- Spin down RHODS Operator deployment to 0 in NS `redhat-ods-operator` 
   - We do this because we are testing the deletion of resources that are no longer watched by the operator starting from 2.5.0
   - For more context, the operator PR is [here](https://github.com/red-hat-data-services/rhods-operator/pull/151)
- Modify role `odh-model-controller-role` in NS `redhat-ods-applications` as per the rbac changes in PR 
   - Add `get`, `list`, `delete` permissions in apiGroup `apps` for resources `deployments`, `statefulsets` 
   - Add `get` permissions for apiGroup `project.openshift.io` for resources `projects` 
- Manually create a Job from the `remove-deprecated-monitoring.yaml` file in the PR
- Manually verify the following resources no longer exist in the cluster in the NS `redhat-ods-monitoring`
   - Deployment `rhods-prometheus-operator`
   - Statefulset `prometheus-rhods-model-monitoring`
   - ServiceMonitor `modelmesh-federated-metrics` 
 
- Success! :) 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
