### PR TITLE
support no reconciliation for rawdeployments

### DIFF
--- a/controllers/kserve_inferenceservice_controller_authconfig_test.go
+++ b/controllers/kserve_inferenceservice_controller_authconfig_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
@@ -43,6 +44,11 @@ var _ = When("InferenceService is created", func() {
 			},
 		}
 		Expect(cli.Create(ctx, namespace)).Should(Succeed())
+		inferenceServiceConfig := &corev1.ConfigMap{}
+		Expect(convertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
+		if err := cli.Create(ctx, inferenceServiceConfig); err != nil && !errors.IsAlreadyExists(err) {
+			Fail(err.Error())
+		}
 	})
 	Context("when not ready", func() {
 		BeforeEach(func() {

--- a/controllers/reconcilers/kserve_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/kserve_inferenceservice_reconciler.go
@@ -148,7 +148,7 @@ func (r *KserveInferenceServiceReconciler) DeleteKserveMetricsResourcesIfNoKserv
 		if err != nil {
 			return err
 		}
-		if isvcDeploymentMode == utils.Serverless {
+		if isvcDeploymentMode != utils.Serverless {
 			inferenceServiceList.Items = append(inferenceServiceList.Items[:i], inferenceServiceList.Items[i+1:]...)
 		}
 	}

--- a/controllers/reconcilers/kserve_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/kserve_inferenceservice_reconciler.go
@@ -57,8 +57,12 @@ func NewKServeInferenceServiceReconciler(client client.Client, scheme *runtime.S
 	}
 }
 
-func (r *KserveInferenceServiceReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+func (r *KserveInferenceServiceReconciler) ReconcileRawDeployment(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	log.V(1).Info("No Reconciliation to be done for inferenceservice as it is using RawDeployment mode")
+	return nil
+}
 
+func (r *KserveInferenceServiceReconciler) ReconcileServerless(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
 	//  Resource created per namespace
 	log.V(1).Info("Verifying that the default ServiceMeshMemberRoll has the target namespace")
 	if err := r.istioSMMRReconciler.Reconcile(ctx, log, isvc); err != nil {
@@ -140,7 +144,11 @@ func (r *KserveInferenceServiceReconciler) DeleteKserveMetricsResourcesIfNoKserv
 
 	for i := len(inferenceServiceList.Items) - 1; i >= 0; i-- {
 		inferenceService := inferenceServiceList.Items[i]
-		if utils.IsDeploymentModeForIsvcModelMesh(&inferenceService) {
+		isvcDeploymentMode, err := utils.GetDeploymentModeForIsvc(ctx, r.client, &inferenceService)
+		if err != nil {
+			return err
+		}
+		if isvcDeploymentMode == utils.Serverless {
 			inferenceServiceList.Items = append(inferenceServiceList.Items[:i], inferenceServiceList.Items[i+1:]...)
 		}
 	}

--- a/controllers/reconcilers/mm_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/mm_inferenceservice_reconciler.go
@@ -17,6 +17,7 @@ package reconcilers
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
@@ -67,7 +68,11 @@ func (r *ModelMeshInferenceServiceReconciler) DeleteModelMeshResourcesIfNoMMIsvc
 
 	for i := len(inferenceServiceList.Items) - 1; i >= 0; i-- {
 		inferenceService := inferenceServiceList.Items[i]
-		if !utils.IsDeploymentModeForIsvcModelMesh(&inferenceService) {
+		isvcDeploymentMode, err := utils.GetDeploymentModeForIsvc(ctx, r.client, &inferenceService)
+		if err != nil {
+			return err
+		}
+		if isvcDeploymentMode == utils.ModelMesh {
 			inferenceServiceList.Items = append(inferenceServiceList.Items[:i], inferenceServiceList.Items[i+1:]...)
 		}
 	}

--- a/controllers/reconcilers/mm_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/mm_inferenceservice_reconciler.go
@@ -72,7 +72,7 @@ func (r *ModelMeshInferenceServiceReconciler) DeleteModelMeshResourcesIfNoMMIsvc
 		if err != nil {
 			return err
 		}
-		if isvcDeploymentMode == utils.ModelMesh {
+		if isvcDeploymentMode != utils.ModelMesh {
 			inferenceServiceList.Items = append(inferenceServiceList.Items[:i], inferenceServiceList.Items[i+1:]...)
 		}
 	}

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -37,6 +37,8 @@ func GetDeploymentModeForIsvc(ctx context.Context, cli client.Client, isvc *kser
 			return Serverless, nil
 		case string(RawDeployment):
 			return RawDeployment, nil
+		default:
+			return "", fmt.Errorf("the deployment mode '%s' of the Inference Service is invalid", value)
 		}
 	} else {
 		// ISVC does not specifically set deployment mode using an annotation, determine the default from configmap
@@ -54,13 +56,17 @@ func GetDeploymentModeForIsvc(ctx context.Context, cli client.Client, isvc *kser
 			return "", fmt.Errorf("error retrieving value for key 'deploy' from configmap %s. %w", KserveConfigMapName, err)
 		}
 		defaultDeploymentMode := deployData["defaultDeploymentMode"]
-		if defaultDeploymentMode == string(Serverless) {
+		switch defaultDeploymentMode {
+		case string(ModelMesh):
+			return ModelMesh, nil
+		case string(Serverless):
 			return Serverless, nil
-		} else {
+		case string(RawDeployment):
 			return RawDeployment, nil
+		default:
+			return "", fmt.Errorf("the deployment mode '%s' of the Inference Service is invalid", defaultDeploymentMode)
 		}
 	}
-	return "", nil
 }
 
 func IsNil(i any) bool {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -1,22 +1,66 @@
 package utils
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"reflect"
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type IsvcDeploymentMode string
+
+var (
+	Serverless    IsvcDeploymentMode = "Serverless"
+	RawDeployment IsvcDeploymentMode = "RawDeployment"
+	ModelMesh     IsvcDeploymentMode = "ModelMesh"
 )
 
 const (
-	inferenceServiceDeploymentModeAnnotation      = "serving.kserve.io/deploymentMode"
-	inferenceServiceDeploymentModeAnnotationValue = "ModelMesh"
+	inferenceServiceDeploymentModeAnnotation = "serving.kserve.io/deploymentMode"
+	KserveConfigMapName                      = "inferenceservice-config"
 )
 
-func IsDeploymentModeForIsvcModelMesh(isvc *kservev1beta1.InferenceService) bool {
+func GetDeploymentModeForIsvc(ctx context.Context, cli client.Client, isvc *kservev1beta1.InferenceService) (IsvcDeploymentMode, error) {
+
+	// If ISVC specifically sets deployment mode using an annotation, return bool depending on value
 	value, exists := isvc.Annotations[inferenceServiceDeploymentModeAnnotation]
-	if exists && value == inferenceServiceDeploymentModeAnnotationValue {
-		return true
+	if exists {
+		switch value {
+		case string(ModelMesh):
+			return ModelMesh, nil
+		case string(Serverless):
+			return Serverless, nil
+		case string(RawDeployment):
+			return RawDeployment, nil
+		}
+	} else {
+		// ISVC does not specifically set deployment mode using an annotation, determine the default from configmap
+		controllerNs := os.Getenv("POD_NAMESPACE")
+		inferenceServiceConfigMap := &corev1.ConfigMap{}
+		err := cli.Get(ctx, client.ObjectKey{
+			Namespace: controllerNs,
+			Name:      KserveConfigMapName,
+		}, inferenceServiceConfigMap)
+		if err != nil {
+			return "", fmt.Errorf("error getting configmap 'inferenceservice-config'. %w", err)
+		}
+		var deployData map[string]interface{}
+		if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["deploy"]), &deployData); err != nil {
+			return "", fmt.Errorf("error retrieving value for key 'deploy' from configmap %s. %w", KserveConfigMapName, err)
+		}
+		defaultDeploymentMode := deployData["defaultDeploymentMode"]
+		if defaultDeploymentMode == string(Serverless) {
+			return Serverless, nil
+		} else {
+			return RawDeployment, nil
+		}
 	}
-	return false
+	return "", nil
 }
 
 func IsNil(i any) bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes : https://issues.redhat.com/browse/RHOAIENG-3243 
This PR disables the current reconciliation process for Kserve InferenceServices if the deployment mode is `RawDeployment`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
#### Testing Prerequisites 
- Install ODH Operator
- Create the following DSC 
```
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    modelregistry:
      managementState: Removed
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Managed
    modelmeshserving:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/opendatahub-io/modelmesh-serving/tarball/main'
          - contextDir: config
            sourcePath: ''
            uri: >-
              https://github.com/VedantMahabaleshwarkar/odh-model-controller/tarball/rawdeployments_test
      managementState: Managed
    datasciencepipelines:
      managementState: Removed
```

#### Scenario 1 : RawDeployment mode is specified in the ISVC 
- Create an ISVC for Kserve and explicitly use RawDeployment mode in the ISVC 
   - This can be done by adding the following annotation to the ISVC `serving.kserve.io/deploymentMode: RawDeployment` 
- Check ODH model controller logs for the following 
```
INFO controllers.InferenceService Reconciling InferenceService for Kserve in mode RawDeployment {"InferenceService": "ISVC_NAME", "namespace": "ISVC_NAMESPACE"}
DEBUG controllers.InferenceService No Reconciliation to be done for inferenceservice as it is using RawDeployment mode {"InferenceService": "ISVC_NAME", "namespace": "ISVC_NAMESPACE", "inferenceservice": "ISVC_NAME"}
```

#### Scenario 2 : ISVC does not explicitly set deployment mode but Kserve default mode is RawDeployment 
- Scale ODH Operator down to 0 (to prevent reconciliation of configmap `inferenceservice-config`) 
- Edit configmap `inferenceservice` in NS `opendatahub` as follows : 
```
  deploy: |-
    {
      "defaultDeploymentMode": "RawDeployment"
    }
``` 
- Create the same ISVC as scenario 1 but without the annotation for RawDeployment 
- Verify same ODH Model Controller logs as scenario 1


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
