### PR TITLE
update a logic to find data connection list

### DIFF
--- a/controllers/kserve_customcacert_controller.go
+++ b/controllers/kserve_customcacert_controller.go
@@ -96,7 +96,7 @@ func reconcileOpenDataHubGlobalCACertConfigMap() predicate.Predicate {
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			objectName := e.Object.GetName()
 			return checkOpenDataHubGlobalCertCAConfigMapName(objectName)
-		},		
+		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			objectName := e.ObjectNew.GetName()
 			return checkOpenDataHubGlobalCertCAConfigMapName(objectName)

--- a/controllers/storageconfig_controller.go
+++ b/controllers/storageconfig_controller.go
@@ -92,12 +92,11 @@ func (r *StorageSecretReconciler) reconcileSecret(secret *corev1.Secret,
 	}
 	err := r.List(ctx, dataConnectionSecretsList, opts...)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			log.Info("No data connections found in namespace ", secret.Namespace)
-			return nil
-		} else {
-			return err
-		}
+		return err
+	}
+	if len(dataConnectionSecretsList.Items) == 0 {
+		log.Info("No data connections found in namespace")
+		return nil
 	}
 
 	odhCustomCertData := ""
@@ -183,7 +182,7 @@ func reconcileOpenDataHubSecrets() predicate.Predicate {
 		CreateFunc: func(e event.CreateEvent) bool {
 			objectLabels := e.Object.GetLabels()
 			return checkOpenDataHubLabel(objectLabels)
-		},		
+		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			objectLabels := e.Object.GetLabels()
 			return checkOpenDataHubLabel(objectLabels)

--- a/controllers/storageconfig_controller.go
+++ b/controllers/storageconfig_controller.go
@@ -96,6 +96,10 @@ func (r *StorageSecretReconciler) reconcileSecret(secret *corev1.Secret,
 	}
 	if len(dataConnectionSecretsList.Items) == 0 {
 		log.Info("No data connections found in namespace")
+		if err := r.deleteStorageSecret(ctx, secret.Namespace, log); err != nil {
+			log.Error(err, "Failed to delete the storage-config secret")
+			return err
+		}
 		return nil
 	}
 
@@ -225,5 +229,24 @@ func (r *StorageSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (r *StorageSecretReconciler) deleteStorageSecret(ctx context.Context, namespace string, log logr.Logger) error {
+	foundStorageSecret := &corev1.Secret{}
+
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      constants.DefaultStorageConfig,
+		Namespace: namespace,
+	}, foundStorageSecret)
+
+	if err == nil && foundStorageSecret.Labels["opendatahub.io/managed"] == "true" {
+		log.Info("Deleting StorageSecret")
+		err = r.Delete(ctx, foundStorageSecret)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
The logic to find Data Connection list was wrong so even though there is no data connection, it keeps creating `storage-config` .  Moreover, if there is no data connection, it should delete `storage-config` when the `storage-config` secret has label `opendatahub.io/managed: true`

Setup(refer this :https://github.com/opendatahub-io/odh-model-controller/pull/166)
1. install kserve
2. create a DS ns

Test
~~~
# Check if storage-config secret is NOT created
oc get secret storage-config

# Create a dataconnection
cat <<EOF |oc apply -f -
kind: Secret
apiVersion: v1
metadata:
  name: aws-connection-minio
  labels:
    opendatahub.io/dashboard: 'true'
    opendatahub.io/managed: 'true'
  annotations:
    opendatahub.io/connection-type: s3
    openshift.io/display-name: minio
stringData:
  AWS_ACCESS_KEY_ID: admin
  AWS_DEFAULT_REGION: us-east-1
  AWS_S3_BUCKET: modelmesh-example-models
  AWS_S3_ENDPOINT: https://minio.minio.svc:9000
  AWS_SECRET_ACCESS_KEY: password
EOF

# Check if storage-config secret created
oc get secret storage-config

# Clear data connection
oc delete secret aws-connection-minio

# Check if storage-config secret deleted
oc get secret storage-config

~~~