### PR TITLE
[RHOAIENG-4191] - odh-model-controller should tolerate missing Authorino

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - datasciencecluster.opendatahub.io
+  resources:
+  - datascienceclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -152,17 +152,19 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 			}))
 
 	// check if kserve is enabled, otherwise don't require Authorino.
-	enabled, err := utils.VerifyIfComponentIsEnabled(context.TODO(), r.client, "kserve")
+	enabled, err := utils.VerifyIfComponentIsEnabled(context.TODO(), r.client, utils.KserveAuthorinoComponent)
+	logMessage := "kserve service mesh component is enabled, Authorino is required"
 	if err != nil {
-		r.log.V(1).Error(err, "could not determine if kserve is enabled, default is enabled")
+		r.log.V(1).Error(err, "could not determine if kserve have service mesh enabled")
 		enabled = true
+		logMessage = "could not determine if kserve have service mesh enabled, Authorino integration will be enabled"
 	}
 
 	if enabled {
 		builder.Owns(&authorinov1beta2.AuthConfig{})
-		r.log.Info("kserve component is enabled, Authorino is required")
+		r.log.Info(logMessage)
 	} else {
-		r.log.Info("kserve component is disabled, ignoring Authorino requirement")
+		r.log.Info("kserve serving component is disabled, ignoring Authorino requirement")
 	}
 
 	err = builder.Complete(r)

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -122,7 +121,6 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&monitoringv1.PodMonitor{}).
-		Owns(&authorinov1beta2.AuthConfig{}).
 		Watches(&source.Kind{Type: &kservev1alpha1.ServingRuntime{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 				r.log.Info("Reconcile event triggered by serving runtime: " + o.GetName())
@@ -152,7 +150,22 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 				}
 				return reconcileRequests
 			}))
-	err := builder.Complete(r)
+
+	// check if kserve is enabled, otherwise don't require Authorino.
+	enabled, err := utils.VerifyIfComponentIsEnabled(context.TODO(), r.client, "kserve")
+	if err != nil {
+		r.log.V(1).Error(err, "could not determine if kserve is enabled, default is enabled")
+		enabled = true
+	}
+
+	if enabled {
+		builder.Owns(&authorinov1beta2.AuthConfig{})
+		r.log.Info("kserve component is enabled, Authorino is required")
+	} else {
+		r.log.Info("kserve component is disabled, ignoring Authorino requirement")
+	}
+
+	err = builder.Complete(r)
 	if err != nil {
 		return err
 	}

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -152,19 +152,17 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 			}))
 
 	// check if kserve is enabled, otherwise don't require Authorino.
-	enabled, err := utils.VerifyIfComponentIsEnabled(context.TODO(), r.client, utils.KserveAuthorinoComponent)
-	logMessage := "kserve service mesh component is enabled, Authorino is required"
+
+	isAuthorinoRequired, err := utils.VerifyIfComponentIsEnabled(context.TODO(), r.client, utils.KserveAuthorinoComponent)
 	if err != nil {
 		r.log.V(1).Error(err, "could not determine if kserve have service mesh enabled")
-		enabled = true
-		logMessage = "could not determine if kserve have service mesh enabled, Authorino integration will be enabled"
 	}
 
-	if enabled {
+	if isAuthorinoRequired {
 		builder.Owns(&authorinov1beta2.AuthConfig{})
-		r.log.Info(logMessage)
+		r.log.Info("kserve is enabled with Service Mesh, Authorino is a requirement")
 	} else {
-		r.log.Info("kserve serving component is disabled, ignoring Authorino requirement")
+		r.log.Info("didn't find kserve with service mesh, Authorino is not a requirement")
 	}
 
 	err = builder.Complete(r)

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -92,6 +92,15 @@ func VerifyIfComponentIsEnabled(ctx context.Context, cli client.Client, componen
 			// By Disabling ServiceMesh for RawDeployment, it should reflect on disabling
 			// the Authorino integration as well.
 			fields = []string{"spec", "components", "kserve", "serving", "managementState"}
+			kserveFields := []string{"spec", "components", "kserve", "managementState"}
+			serving, _, err := unstructured.NestedString(objectList.Items[0].Object, fields...)
+			kserve, _, err := unstructured.NestedString(objectList.Items[0].Object, kserveFields...)
+			if err != nil {
+				return false, fmt.Errorf("failed to retrieve the component [%s] status from %+v",
+					componentName, objectList.Items[0])
+			}
+
+			return (serving == "Managed" || serving == "Unmanaged") && kserve == "Managed", nil
 		}
 
 		val, _, err := unstructured.NestedString(objectList.Items[0].Object, fields...)

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func init() { //nolint:gochecknoinits //reason this way we ensure schemes are al
 // +kubebuilder:rbac:groups="",resources=namespaces;pods;services;endpoints,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=get;list;watch
 
 func getEnvAsBool(name string, defaultValue bool) bool {
 	valStr := os.Getenv(name)


### PR DESCRIPTION
This commit allows to run ODH without Authorino when KServe is Removed.

## Description

## How Has This Been Tested?
- Install the ODH Operator 2.8 through Operator Catalog.
- Create Default DSCI
- Create a DSC with the following content (KServe -> servinng - disabled):
```yaml
kind: DataScienceCluster
apiVersion: datasciencecluster.opendatahub.io/v1
metadata:
  labels:
    app.kubernetes.io/created-by: opendatahub-operator
    app.kubernetes.io/instance: default
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: datasciencecluster
    app.kubernetes.io/part-of: opendatahub-operator
  name: default-dsc
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Removed
        name: knative-serving
    modelregistry:
      managementState: Removed
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Managed
    modelmeshserving:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: >-
              https://github.com/spolti/odh-model-controller/tarball/RHOAIENG-4191-test
      managementState: Managed
    datasciencepipelines:
      managementState: Removed
```
- Note that the KServe - serving component is disabled, it should not log any error, instead, this message should be logged:
```
controllers.InferenceService    kserve service mesh component is enabled, Authorino is required.
```
- Next step, update the DCS setting `KServe`/serving to `Managed`, install the Service Mesh Operator and  **don't install the Authorino operator**, and watch the logs for the error:

```
2024-03-06T19:25:57Z	INFO	controllers.InferenceService	kserve component is enabled, Authorino is required
2024-03-06T19:26:33Z	ERROR	controller-runtime.source	if kind is a CRD, it should be installed before calling Start	{"kind": "AuthConfig.authorino.kuadrant.io", "error": "no matches for kind \"AuthConfig\" in version \"authorino.kuadrant.io/v1beta2\""}
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1.1
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/source/source.go:143
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtectionWithContext
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.27.0/pkg/util/wait/wait.go:154
k8s.io/apimachinery/pkg/util/wait.waitForWithContext
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.27.0/pkg/util/wait/wait.go:207
k8s.io/apimachinery/pkg/util/wait.poll
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.27.0/pkg/util/wait/poll.go:260
k8s.io/apimachinery/pkg/util/wait.PollImmediateUntilWithContext
	/opt/app-root/src/go/pkg/mod/k8s.io/apimachinery@v0.27.0/pkg/util/wait/poll.go:200
sigs.k8s.io/controller-runtime/pkg/source.(*Kind).Start.func1
	/opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/source/source.go:136

```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
