### PR TITLE
feat: dynamically include authorino label selector

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,6 +53,12 @@ spec:
                   name: auth-refs
                   key: AUTH_AUDIENCE
                   optional: true
+            - name: AUTHORINO_LABEL
+              valueFrom:
+                configMapKeyRef:
+                  name: auth-refs
+                  key: AUTHORINO_LABEL
+                  optional: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/controllers/resources/template/authconfig_anonymous.yaml
+++ b/controllers/resources/template/authconfig_anonymous.yaml
@@ -2,7 +2,7 @@ apiVersion: authorino.kuadrant.io/v1beta2
 kind: AuthConfig
 metadata:
   labels:
-    security.opendatahub.io/authorization-group: default
+    {{ .AuthorinoLabel }}
 spec:
   hosts:
   - "UPDATED.RUNTIME"

--- a/controllers/resources/template/authconfig_userdefined.yaml
+++ b/controllers/resources/template/authconfig_userdefined.yaml
@@ -2,7 +2,7 @@ apiVersion: authorino.kuadrant.io/v1beta2
 kind: AuthConfig
 metadata:
   labels:
-    security.opendatahub.io/authorization-group: default
+    {{ .AuthorinoLabel }}
 spec:
   hosts:
   - "UPDATED.RUNTIME"

--- a/controllers/resources/unit_test.go
+++ b/controllers/resources/unit_test.go
@@ -1,0 +1,33 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Resources Suite")
+}


### PR DESCRIPTION
## Description

The Label is used in the AuthConfig templates and used as a label selector on the Authorino instance.

* Activated some AuthConfig handling unit tests that were previously missing a suite level

See related opendatahub-io/opendatahub-operator#904

## How Has This Been Tested?

Unit tests

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
