### PR TITLE
Prevent creation of KSVC if its namespace is not in the Mesh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
 external-manifests: 
 	go get github.com/kserve/modelmesh-serving

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,4 @@
 bases:
   - ../rbac
   - ../manager
+  - ../webhook

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,5 +74,18 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
       serviceAccountName: odh-model-controller
       terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: odh-model-controller-webhook-cert

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - manifests.yaml
+  - service.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating.odh-model-controller.opendatahub.io
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: odh-model-controller-webhook-service
+      path: /validate-serving-knative-dev-v1-service
+  failurePolicy: Fail
+  name: validating.ksvc.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - services
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: odh-model-controller-webhook-service
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: odh-model-controller-webhook-cert
+spec:
+  ports:
+    - port: 443
+      targetPort: webhook-server
+  selector:
+    control-plane: odh-model-controller

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -16,10 +16,14 @@ limitations under the License.
 package constants
 
 const (
+	InferenceServiceKind = "InferenceService"
+
 	IstioNamespace                   = "istio-system"
+	ServiceMeshMemberRollName        = "default"
 	IstioIngressService              = "istio-ingressgateway"
 	IstioIngressServiceHTTPPortName  = "http2"
 	IstioIngressServiceHTTPSPortName = "https"
+	IstioSidecarInjectAnnotationName = "sidecar.istio.io/inject"
 
 	LabelAuthGroup     = "security.opendatahub.io/authorization-group"
 	LabelEnableAuthODH = "security.opendatahub.io/enable-auth"

--- a/controllers/reconcilers/kserve_istio_smmr_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_smmr_reconciler.go
@@ -30,10 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	serviceMeshMemberRollName = "default"
-)
-
 type KserveIstioSMMRReconciler struct {
 	client         client.Client
 	scheme         *runtime.Scheme
@@ -72,7 +68,7 @@ func (r *KserveIstioSMMRReconciler) Reconcile(ctx context.Context, log logr.Logg
 }
 
 func (r *KserveIstioSMMRReconciler) createDesiredResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.ServiceMeshMemberRoll, error) {
-	desiredSMMR, err := r.smmrHandler.FetchSMMR(ctx, log, types.NamespacedName{Name: serviceMeshMemberRollName, Namespace: constants.IstioNamespace})
+	desiredSMMR, err := r.smmrHandler.FetchSMMR(ctx, log, types.NamespacedName{Name: constants.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace})
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +88,7 @@ func (r *KserveIstioSMMRReconciler) createDesiredResource(ctx context.Context, l
 	} else {
 		desiredSMMR = &v1.ServiceMeshMemberRoll{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      serviceMeshMemberRollName,
+				Name:      constants.ServiceMeshMemberRollName,
 				Namespace: constants.IstioNamespace,
 			},
 			Spec: v1.ServiceMeshMemberRollSpec{
@@ -106,7 +102,7 @@ func (r *KserveIstioSMMRReconciler) createDesiredResource(ctx context.Context, l
 }
 
 func (r *KserveIstioSMMRReconciler) getExistingResource(ctx context.Context, log logr.Logger) (*v1.ServiceMeshMemberRoll, error) {
-	return r.smmrHandler.FetchSMMR(ctx, log, types.NamespacedName{Name: serviceMeshMemberRollName, Namespace: constants.IstioNamespace})
+	return r.smmrHandler.FetchSMMR(ctx, log, types.NamespacedName{Name: constants.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace})
 }
 
 func (r *KserveIstioSMMRReconciler) processDelta(ctx context.Context, log logr.Logger, desiredSMMR *v1.ServiceMeshMemberRoll, existingSMMR *v1.ServiceMeshMemberRoll) (err error) {
@@ -143,5 +139,5 @@ func (r *KserveIstioSMMRReconciler) processDelta(ctx context.Context, log logr.L
 }
 
 func (r *KserveIstioSMMRReconciler) RemoveMemberFromSMMR(ctx context.Context, isvcNamespace string) error {
-	return r.smmrHandler.RemoveMemberFromSMMR(ctx, types.NamespacedName{Name: serviceMeshMemberRollName, Namespace: constants.IstioNamespace}, isvcNamespace)
+	return r.smmrHandler.RemoveMemberFromSMMR(ctx, types.NamespacedName{Name: constants.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace}, isvcNamespace)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -37,7 +36,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -45,6 +43,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/utils/init.go
+++ b/controllers/utils/init.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	authv1 "k8s.io/api/rbac/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	maistrav1 "maistra.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +32,7 @@ func RegisterSchemes(s *runtime.Scheme) {
 	utilruntime.Must(istiosecurityv1beta1.AddToScheme(s))
 	utilruntime.Must(telemetryv1alpha1.AddToScheme(s))
 	utilruntime.Must(maistrav1.SchemeBuilder.AddToScheme(s))
+	utilruntime.Must(knservingv1.AddToScheme(s))
 
 	// The following are related to Service Mesh, uncomment this and other
 	// similar blocks to use with Service Mesh

--- a/controllers/webhook/ksvc_validator.go
+++ b/controllers/webhook/ksvc_validator.go
@@ -1,0 +1,109 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	types2 "k8s.io/apimachinery/pkg/types"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
+	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+)
+
+// +kubebuilder:webhook:admissionReviewVersions=v1,path=/validate-serving-knative-dev-v1-service,mutating=false,failurePolicy=fail,groups="serving.knative.dev",resources=services,verbs=create,versions=v1,name=validating.ksvc.odh-model-controller.opendatahub.io,sideEffects=None
+
+type ksvcValidator struct {
+	client client.Client
+}
+
+func NewKsvcValidator(client client.Client) *ksvcValidator {
+	return &ksvcValidator{client: client}
+}
+
+func (v *ksvcValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	log := logf.FromContext(ctx).WithName("KsvcValidatingWebhook")
+	ksvc, ok := obj.(*knservingv1.Service)
+	if !ok {
+		return fmt.Errorf("expected a Knative Service but got a %T", obj)
+	}
+
+	log = log.WithValues("namespace", ksvc.Namespace, "ksvc", ksvc.Name)
+	log.Info("Validating Knative Service")
+
+	// If there is an explicit intent for not having a sidecar, skip validation
+	ksvcTemplateMeta := ksvc.Spec.Template.GetObjectMeta()
+	if ksvcTemplateMeta != nil {
+		if templateAnnotations := ksvcTemplateMeta.GetAnnotations(); templateAnnotations[constants.IstioSidecarInjectAnnotationName] == "false" {
+			log.V(1).Info("Skipping validation of Knative Service because there is an explicit intent to exclude it from the Service Mesh")
+			return nil
+		}
+	}
+
+	// Only validate the KSVC if it is owned by KServe controller
+	ksvcMetadata := ksvc.GetObjectMeta()
+	if ksvcMetadata == nil {
+		log.V(1).Info("Skipping validation of Knative Service because it does not have metadata")
+		return nil
+	}
+	ksvcOwnerReferences := ksvcMetadata.GetOwnerReferences()
+	if ksvcOwnerReferences == nil {
+		log.V(1).Info("Skipping validation of Knative Service because it does not have owner references")
+		return nil
+	}
+	isOwnedByKServe := false
+	for _, owner := range ksvcOwnerReferences {
+		if owner.Kind == constants.InferenceServiceKind {
+			if strings.Contains(owner.APIVersion, kservev1beta1.SchemeGroupVersion.Group) {
+				isOwnedByKServe = true
+			}
+		}
+	}
+	if !isOwnedByKServe {
+		log.V(1).Info("Skipping validation of Knative Service because it is not owned by KServe")
+		return nil
+	}
+
+	// Since the Ksvc is owned by an InferenceService, it is known that it is required to be
+	// in the Mesh. Thus, the involved namespace needs to be enrolled in the mesh.
+	// Go and check the ServiceMeshMemberRoll to verify that the namespace is already a
+	// member. If it is still not a member, reject creation of the Ksvc to prevent
+	// creation of a Pod that would not be in the Mesh.
+	smmrQuerier := resources.NewServiceMeshMemberRole(v.client)
+	smmr, fetchSmmrErr := smmrQuerier.FetchSMMR(ctx, log, types2.NamespacedName{Name: constants.ServiceMeshMemberRollName, Namespace: constants.IstioNamespace})
+	if fetchSmmrErr != nil {
+		log.Error(fetchSmmrErr, "Error when fetching ServiceMeshMemberRoll", "smmr.namespace", constants.IstioNamespace, "smmr.name", constants.ServiceMeshMemberRollName)
+		return fetchSmmrErr
+	}
+	if smmr == nil {
+		log.Info("Rejecting Knative service because the ServiceMeshMemberRoll does not exist", "smmr.namespace", constants.IstioNamespace, "smmr.name", constants.ServiceMeshMemberRollName)
+		return fmt.Errorf("rejecting creation of Knative service %s on namespace %s because the ServiceMeshMemberRoll does not exist", ksvc.Name, ksvc.Namespace)
+	}
+
+	log = log.WithValues("smmr.namespace", smmr.Namespace, "smmr.name", smmr.Name)
+
+	for _, memberNamespace := range smmr.Status.ConfiguredMembers {
+		if memberNamespace == ksvc.Namespace {
+			log.V(1).Info("The Knative service is accepted")
+			return nil
+		}
+	}
+
+	log.Info("Rejecting Knative service because its namespace is not a member of the service mesh")
+	return fmt.Errorf("rejecting creation of Knative service %s on namespace %s because the namespace is not a configured member of the mesh", ksvc.Name, ksvc.Namespace)
+}
+
+func (v *ksvcValidator) ValidateUpdate(_ context.Context, _, _ runtime.Object) error {
+	// Nothing to validate on updates
+	return nil
+}
+
+func (v *ksvcValidator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	// For deletion, we don't need to validate anything.
+	return nil
+}

--- a/controllers/webhook_ksvc_validator_test.go
+++ b/controllers/webhook_ksvc_validator_test.go
@@ -1,0 +1,157 @@
+package controllers
+
+import (
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	v1 "maistra.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
+)
+
+var _ = Describe("Knative validator webhook", func() {
+	var validator admission.CustomValidator
+
+	createKserveOwnedKsvc := func() *knservingv1.Service {
+		return &knservingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ksvc",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: kservev1beta1.SchemeGroupVersion.String(),
+						Kind:       "InferenceService",
+						Name:       "myISVC",
+					},
+				},
+			},
+			Spec: knservingv1.ServiceSpec{},
+		}
+	}
+
+	createSmmr := func(smmrStatus v1.ServiceMeshMemberRollStatus) *v1.ServiceMeshMemberRoll {
+		smmr := &v1.ServiceMeshMemberRoll{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.ServiceMeshMemberRollName,
+				Namespace: constants.IstioNamespace,
+			},
+		}
+
+		Expect(cli.Create(ctx, smmr)).To(Succeed())
+
+		smmr.Status = smmrStatus
+		Expect(cli.Status().Update(ctx, smmr)).To(Succeed())
+
+		return smmr
+	}
+
+	BeforeEach(func() {
+		validator = webhook.NewKsvcValidator(cli)
+
+		// Other tests may create a ServiceMeshMemberRoll.
+		// If there is one, delete it because it conflicts with tests in this file.
+		smmr := v1.ServiceMeshMemberRoll{}
+		getErr := cli.Get(ctx, types.NamespacedName{
+			Namespace: constants.IstioNamespace,
+			Name:      constants.ServiceMeshMemberRollName,
+		}, &smmr)
+		if getErr != nil {
+			if !errors.IsNotFound(getErr) {
+				Fail("Error waiting for SMMR to be deleted: " + getErr.Error())
+			}
+		} else {
+			cli.Delete(ctx, &smmr)
+		}
+	})
+
+	It("should accept creating a Knative service that does not have metadata", func() {
+		ksvc := knservingv1.Service{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+		Expect(validator.ValidateCreate(ctx, &ksvc)).To(Succeed())
+	})
+
+	It("should accept creating a Knative service that does not have owner references", func() {
+		ksvc := knservingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "ksvc",
+				Namespace:       "ns",
+				OwnerReferences: nil,
+			},
+		}
+
+		Expect(validator.ValidateCreate(ctx, &ksvc)).To(Succeed())
+	})
+
+	It("should accept creating a Knative service that is now owned by KServe", func() {
+		ksvc := knservingv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ksvc",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "Foo/v1",
+						Kind:       "MyKind",
+						Name:       "MyKindInstance",
+						Controller: nil,
+					},
+				},
+			},
+		}
+
+		Expect(validator.ValidateCreate(ctx, &ksvc)).To(Succeed())
+	})
+
+	It("should accept creating a Knative service that is forced to not have an Istio sidecar", func() {
+		ksvc := createKserveOwnedKsvc()
+		ksvc.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			"sidecar.istio.io/inject": "false",
+		}
+
+		Expect(validator.ValidateCreate(ctx, ksvc)).To(Succeed())
+	})
+
+	It("should reject creating a Knative service if there is no ServiceMeshMemberRoll yet", func() {
+		ksvc := createKserveOwnedKsvc()
+		Expect(validator.ValidateCreate(ctx, ksvc)).ToNot(Succeed())
+	})
+
+	It("should reject creating a Knative service if the ServiceMeshMemberRoll has null ConfiguredMembers", func() {
+		ksvc := createKserveOwnedKsvc()
+		smmr := createSmmr(v1.ServiceMeshMemberRollStatus{ConfiguredMembers: nil})
+		defer func() { cli.Delete(ctx, smmr) }()
+
+		Expect(validator.ValidateCreate(ctx, ksvc)).ToNot(Succeed())
+	})
+
+	It("should reject creating a Knative service if the namespace is not a configured member of the ServiceMeshMemberRoll", func() {
+		ksvc := createKserveOwnedKsvc()
+		smmr := createSmmr(v1.ServiceMeshMemberRollStatus{ConfiguredMembers: []string{"foo"}})
+		defer func() { cli.Delete(ctx, smmr) }()
+
+		Expect(validator.ValidateCreate(ctx, ksvc)).ToNot(Succeed())
+	})
+
+	It("should accept creating a Knative service if the namespace is a configured member of the ServiceMeshMemberRoll", func() {
+		ksvc := createKserveOwnedKsvc()
+		smmr := createSmmr(v1.ServiceMeshMemberRollStatus{ConfiguredMembers: []string{ksvc.Namespace}})
+		defer func() { cli.Delete(ctx, smmr) }()
+
+		Expect(validator.ValidateCreate(ctx, ksvc)).To(Succeed())
+	})
+
+	It("should validate on update of Knative service regardless of the received objects", func() {
+		Expect(validator.ValidateUpdate(ctx, nil, nil)).To(Succeed())
+	})
+
+	It("should validate on deletion of Knative service regardless of the received object", func() {
+		Expect(validator.ValidateDelete(ctx, nil)).To(Succeed())
+	})
+})


### PR DESCRIPTION
## Description

When a KServe InferenceService is created, odh-model-controller enrolls the ISVC namespace to the mesh, if needed. It was found that sometimes the namespace enrollment process may take a little time to be processed.

Since KServe and odh-model-controllers are (to certain extent) independent of each other, sometimes KServe controller and Knative serving controller are faster and the pod from the KSVC may be created faster than the mesh enrollment process. This would lead to the KSVC pod not having an Istio sidecar.

Since the Istio authorization rules are evaluated on the sidecar of target service, the missing sidecar on the model/ksvc pod would mean that the traffic would bypass the authorization rules and this impacts ODH KServe authorization (ref: https://istio.io/latest/docs/ops/best-practices/security/#server-first-tcp-protocols-are-not-supported).

In an effort to prevent that situation, this is adding a new validating webhook that would block creation of the Knative Service until the namespace is acknowledged to be a member of the service mesh.

Fixes https://issues.redhat.com/browse/RHOAIENG-2542

## How Has This Been Tested?
Simple sanity check: ensuring a model can be deployed.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
