### PR TITLE
Remove GOARCH from the go build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ COPY controllers/ controllers/
 
 # Build
 USER root
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GOARCH will be set by default to the target architecture, explicit mention of GOARCH is not necessary. This change will give flexibility to build this image on non-amd64 platform.

## How Has This Been Tested?

Podman build:
```
% podman build -t odh-model-controller:latest .
[1/2] STEP 1/9: FROM registry.access.redhat.com/ubi8/go-toolset:1.19 AS builder
[1/2] STEP 2/9: WORKDIR /workspace
--> Using cache ce0bcab09cbe43d5a7bdf3b4cb0ce7b737df0a6178df0bf0a1a9d2d35ada7d0c
--> ce0bcab09cbe
[1/2] STEP 3/9: COPY go.mod go.mod
--> Using cache dea32f8f9833a775b0fd960a5a811bee06995c70d30bf791823455cdf3a383f3
--> dea32f8f9833
[1/2] STEP 4/9: COPY go.sum go.sum
--> Using cache f74f3648eb469b942423589a0f0ceca6c461e8b141640a01402e1f28c414e063
--> f74f3648eb46
[1/2] STEP 5/9: RUN go mod download
--> 815d8a5e2301
[1/2] STEP 6/9: COPY main.go main.go
--> 6c274133fd03
[1/2] STEP 7/9: COPY controllers/ controllers/
--> 63815ccba8e4
[1/2] STEP 8/9: USER root
--> ba6fee90abbd
[1/2] STEP 9/9: RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
--> c2fb65c7c03a
[2/2] STEP 1/5: FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
Trying to pull registry.access.redhat.com/ubi8/ubi-minimal:8.6...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:e0f3026cb2e96232e1538d8c940db24c34e8399a20459e8993ed13a10fcb5582
Copying config sha256:c0862a85b0719ddca2295f4718ba5e601dc35b828fbd3b86ef744fe32861ab62
Writing manifest to image destination
Storing signatures
[2/2] STEP 2/5: WORKDIR /
--> dad887e48e02
[2/2] STEP 3/5: COPY --from=builder /workspace/manager .
--> d3c4a2226e0e
[2/2] STEP 4/5: USER 65532:65532
--> 7094e6ca2761
[2/2] STEP 5/5: ENTRYPOINT ["/manager"]
[2/2] COMMIT odh-model-controller:latest
--> 51daed5e2c17
Successfully tagged localhost/odh-model-controller:latest
51daed5e2c17324b25c961356b8dbbc68416f472a29163a1883b0973a0bf50bc
```


Podman run:
```
% podman run -ti localhost/odh-model-controller:latest --help
Usage of /manager:
  -alsologtostderr
    	log to standard error as well as files
  -health-probe-bind-address string
    	The address the probe endpoint binds to. (default ":8081")
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -log_link string
    	If non-empty, add symbolic links in this directory to the log files
  -logbuflevel int
    	Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
  -logtostderr
    	log to standard error instead of files
  -metrics-bind-address string
    	The address the metric endpoint binds to. (default ":8080")
  -model-registry-inference-reconcile
    	Enable model registry inference service reconciliation.
  -monitoring-namespace string
    	The Namespace where the monitoring stack's Prometheus resides.
  -stderrthreshold value
    	logs at or above this threshold go to stderr (default 2)
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
  -zap-devel
    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
  -zap-encoder value
    	Zap log encoding (one of 'json' or 'console')
  -zap-log-level value
    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
  -zap-stacktrace-level value
    	Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
  -zap-time-encoding value
    	Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
