### PR TITLE
feat(authz): soft opt-in for authz capability

### DIFF
--- a/config/crd/external/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/external/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -1,0 +1,717 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: datascienceclusters.datasciencecluster.opendatahub.io
+spec:
+  group: datasciencecluster.opendatahub.io
+  names:
+    kind: DataScienceCluster
+    listKind: DataScienceClusterList
+    plural: datascienceclusters
+    shortNames:
+      - dsc
+    singular: datasciencecluster
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: DataScienceCluster is the Schema for the datascienceclusters
+            API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataScienceClusterSpec defines the desired state of the cluster.
+              properties:
+                components:
+                  description: Override and fine tune specific component configurations.
+                  properties:
+                    codeflare:
+                      description: CodeFlare component configuration. If CodeFlare Operator
+                        has been installed in the cluster, it should be uninstalled
+                        first before enabled component.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    dashboard:
+                      description: Dashboard component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    datasciencepipelines:
+                      description: DataServicePipeline component configuration. Require
+                        OpenShift Pipelines Operator to be installed before enable component
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    kserve:
+                      description: Kserve component configuration. Require OpenShift
+                        Serverless and OpenShift Service Mesh Operators to be installed
+                        before enable component Does not support enabled ModelMeshServing
+                        at the same time
+                      properties:
+                        defaultDeploymentMode:
+                          description: Configures the default deployment mode for Kserve.
+                            This can be set to 'Serverless' or 'RawDeployment'. The
+                            value specified in this field will be used to set the default
+                            deployment mode in the 'inferenceservice-config' configmap
+                            for Kserve If no default deployment mode is specified, Kserve
+                            will use Serverless mode
+                          enum:
+                            - Serverless
+                            - RawDeployment
+                          pattern: ^(Serverless|RawDeployment)$
+                          type: string
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                        serving:
+                          description: Serving configures the KNative-Serving stack
+                            used for model serving. A Service Mesh (Istio) is prerequisite,
+                            since it is used as networking layer.
+                          properties:
+                            ingressGateway:
+                              description: IngressGateway allows to customize some parameters
+                                for the Istio Ingress Gateway that is bound to KNative-Serving.
+                              properties:
+                                certificate:
+                                  description: Certificate specifies configuration of
+                                    the TLS certificate securing communications of the
+                                    for Ingress Gateway.
+                                  properties:
+                                    secretName:
+                                      description: SecretName specifies the name of
+                                        the Kubernetes Secret resource that contains
+                                        a TLS certificate secure HTTP communications
+                                        for the KNative network.
+                                      type: string
+                                    type:
+                                      default: SelfSigned
+                                      description: 'Type specifies if the TLS certificate
+                                      should be generated automatically, or if the
+                                      certificate is provided by the user. Allowed
+                                      values are: * SelfSigned: A certificate is going
+                                      to be generated using an own private key. *
+                                      Provided: Pre-existence of the TLS Secret (see
+                                      SecretName) with a valid certificate is assumed.'
+                                      enum:
+                                        - SelfSigned
+                                        - Provided
+                                      type: string
+                                  type: object
+                                domain:
+                                  description: Domain specifies the DNS name for intercepting
+                                    ingress requests coming from outside the cluster.
+                                    Most likely, you will want to use a wildcard name,
+                                    like *.example.com. If not set, the domain of the
+                                    OpenShift Ingress is used. If you choose to generate
+                                    a certificate, this is the domain used for the certificate
+                                    request.
+                                  type: string
+                              type: object
+                            managementState:
+                              default: Managed
+                              enum:
+                                - Managed
+                                - Unmanaged
+                                - Removed
+                              pattern: ^(Managed|Unmanaged|Force|Removed)$
+                              type: string
+                            name:
+                              default: knative-serving
+                              description: Name specifies the name of the KNativeServing
+                                resource that is going to be created to instruct the
+                                KNative Operator to deploy KNative serving components.
+                                This resource is created in the "knative-serving" namespace.
+                              type: string
+                          type: object
+                      type: object
+                    kueue:
+                      description: Kueue component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    modelmeshserving:
+                      description: ModelMeshServing component configuration. Does not
+                        support enabled Kserve at the same time
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    modelregistry:
+                      description: ModelRegistry component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    ray:
+                      description: Ray component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trainingoperator:
+                      description: Training Operator component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    trustyai:
+                      description: TrustyAI component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                    workbenches:
+                      description: Workbenches component configuration.
+                      properties:
+                        devFlags:
+                          description: Add developer fields
+                          properties:
+                            manifests:
+                              description: List of custom manifests for the given component
+                              items:
+                                properties:
+                                  contextDir:
+                                    default: ""
+                                    description: contextDir is the relative path to
+                                      the folder containing manifests in a repository
+                                    type: string
+                                  sourcePath:
+                                    default: ""
+                                    description: 'sourcePath is the subpath within contextDir
+                                    where kustomize builds start. Examples include
+                                    any sub-folder or path: `base`, `overlays/dev`,
+                                    `default`, `odh` etc.'
+                                    type: string
+                                  uri:
+                                    default: ""
+                                    description: uri is the URI point to a git repo
+                                      with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        managementState:
+                          description: "Set to one of the following values: \n - \"Managed\"
+                          : the operator is actively managing the component and trying
+                          to keep it active. It will only upgrade the component if
+                          it is safe to do so \n - \"Removed\" : the operator is actively
+                          managing the component and will not install it, or if it
+                          is installed, the operator will try to remove it"
+                          enum:
+                            - Managed
+                            - Removed
+                          pattern: ^(Managed|Unmanaged|Force|Removed)$
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: DataScienceClusterStatus defines the observed state of DataScienceCluster.
+              properties:
+                conditions:
+                  description: Conditions describes the state of the DataScienceCluster
+                    resource.
+                  items:
+                    description: Condition represents the state of the operator's reconciliation
+                      functionality.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType is the state of the operator's reconciliation
+                          functionality.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                errorMessage:
+                  type: string
+                installedComponents:
+                  additionalProperties:
+                    type: boolean
+                  description: List of components with status if installed or not
+                  type: object
+                phase:
+                  description: Phase describes the Phase of DataScienceCluster reconciliation
+                    state This is used by OLM UI to provide status information to the
+                    user
+                  type: string
+                relatedObjects:
+                  description: RelatedObjects is a list of objects created and maintained
+                    by this operator. Object references will be added to this list after
+                    they have been created AND found in the cluster.
+                  items:
+                    description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/crd/external/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/external/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -1,0 +1,300 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: dscinitializations.dscinitialization.opendatahub.io
+spec:
+  group: dscinitialization.opendatahub.io
+  names:
+    kind: DSCInitialization
+    listKind: DSCInitializationList
+    plural: dscinitializations
+    shortNames:
+      - dsci
+    singular: dscinitialization
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Current Phase
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Created At
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: DSCInitialization is the Schema for the dscinitializations API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DSCInitializationSpec defines the desired state of DSCInitialization.
+              properties:
+                applicationsNamespace:
+                  default: opendatahub
+                  description: Namespace for applications to be installed, non-configurable,
+                    default to "opendatahub"
+                  type: string
+                devFlags:
+                  description: Internal development useful field to test customizations.
+                    This is not recommended to be used in production environment.
+                  properties:
+                    logmode:
+                      default: production
+                      enum:
+                        - devel
+                        - development
+                        - prod
+                        - production
+                      type: string
+                    manifestsUri:
+                      description: Custom manifests uri for odh-manifests
+                      type: string
+                  type: object
+                monitoring:
+                  description: Enable monitoring on specified namespace
+                  properties:
+                    managementState:
+                      description: 'Set to one of the following values: - "Managed"
+                      : the operator is actively managing the component and trying
+                      to keep it active. It will only upgrade the component if it
+                      is safe to do so. - "Removed" : the operator is actively managing
+                      the component and will not install it, or if it is installed,
+                      the operator will try to remove it.'
+                      enum:
+                        - Managed
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                    namespace:
+                      default: opendatahub
+                      description: Namespace for monitoring if it is enabled
+                      type: string
+                  type: object
+                serviceMesh:
+                  description: Configures Service Mesh as networking layer for Data
+                    Science Clusters components. The Service Mesh is a mandatory prerequisite
+                    for single model serving (KServe) and you should review this configuration
+                    if you are planning to use KServe. For other components, it enhances
+                    user experience; e.g. it provides unified authentication giving
+                    a Single Sign On experience.
+                  properties:
+                    auth:
+                      description: Auth holds configuration of authentication and authorization
+                        services used by Service Mesh in Opendatahub.
+                      properties:
+                        audiences:
+                          default:
+                            - https://kubernetes.default.svc
+                          description: Audiences is a list of the identifiers that the
+                            resource server presented with the token identifies as.
+                            Audience-aware token authenticators will verify that the
+                            token was intended for at least one of the audiences in
+                            this list. If no audiences are provided, the audience will
+                            default to the audience of the Kubernetes apiserver (kubernetes.default.svc).
+                          items:
+                            type: string
+                          type: array
+                        namespace:
+                          description: Namespace where it is deployed. If not provided,
+                            the default is to use '-auth-provider' suffix on the ApplicationsNamespace
+                            of the DSCI.
+                          type: string
+                      type: object
+                    controlPlane:
+                      description: ControlPlane holds configuration of Service Mesh
+                        used by Opendatahub.
+                      properties:
+                        metricsCollection:
+                          default: Istio
+                          description: MetricsCollection specifies if metrics from components
+                            on the Mesh namespace should be collected. Setting the value
+                            to "Istio" will collect metrics from the control plane and
+                            any proxies on the Mesh namespace (like gateway pods). Setting
+                            to "None" will disable metrics collection.
+                          enum:
+                            - Istio
+                            - None
+                          type: string
+                        name:
+                          default: data-science-smcp
+                          description: Name is a name Service Mesh Control Plane. Defaults
+                            to "data-science-smcp".
+                          type: string
+                        namespace:
+                          default: istio-system
+                          description: Namespace is a namespace where Service Mesh is
+                            deployed. Defaults to "istio-system".
+                          type: string
+                      type: object
+                    managementState:
+                      default: Removed
+                      enum:
+                        - Managed
+                        - Unmanaged
+                        - Removed
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  type: object
+                trustedCABundle:
+                  description: When set to `Managed`, adds odh-trusted-ca-bundle Configmap
+                    to all namespaces that includes cluster-wide Trusted CA Bundle in
+                    .data["ca-bundle.crt"]. Additionally, this fields allows admins
+                    to add custom CA bundles to the configmap using the .CustomCABundle
+                    field.
+                  properties:
+                    customCABundle:
+                      default: ""
+                      description: A custom CA bundle that will be available for  all  components
+                        in the Data Science Cluster(DSC). This bundle will be stored
+                        in odh-trusted-ca-bundle ConfigMap .data.odh-ca-bundle.crt .
+                      type: string
+                    managementState:
+                      default: Removed
+                      description: managementState indicates whether and how the operator
+                        should manage customized CA bundle
+                      enum:
+                        - Managed
+                        - Removed
+                        - Unmanaged
+                      pattern: ^(Managed|Unmanaged|Force|Removed)$
+                      type: string
+                  required:
+                    - customCABundle
+                    - managementState
+                  type: object
+              required:
+                - applicationsNamespace
+              type: object
+            status:
+              description: DSCInitializationStatus defines the observed state of DSCInitialization.
+              properties:
+                conditions:
+                  description: Conditions describes the state of the DSCInitializationStatus
+                    resource
+                  items:
+                    description: Condition represents the state of the operator's reconciliation
+                      functionality.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType is the state of the operator's reconciliation
+                          functionality.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                errorMessage:
+                  type: string
+                phase:
+                  description: Phase describes the Phase of DSCInitializationStatus
+                    This is used by OLM UI to provide status information to the user
+                  type: string
+                relatedObjects:
+                  description: RelatedObjects is a list of objects created and maintained
+                    by this operator. Object references will be added to this list after
+                    they have been created AND found in the cluster
+                  items:
+                    description: "ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs. 1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
+                    usage help.  It is impossible to add specific help for individual
+                    usage.  In most embedded usages, there are particular restrictions
+                    like, \"must refer only to types A and B\" or \"UID not honored\"
+                    or \"name must be restricted\". Those cannot be well described
+                    when embedded. 3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen. 4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple and the version of the actual struct
+                    is irrelevant. 5. We cannot easily change it.  Because this type
+                    is embedded in many locations, updates to this type will affect
+                    numerous schemas.  Don't make new APIs embed an underspecified
+                    API type they do not control. \n Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    ."
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,7 +56,7 @@ rules:
 - apiGroups:
   - dscinitialization.opendatahub.io
   resources:
-  - datascienceclusterinitializations
+  - dscinitializations
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - dscinitialization.opendatahub.io
+  resources:
+  - datascienceclusterinitializations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   resources:
   - ingresses

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -29,6 +29,8 @@ const (
 	LabelEnableAuthODH = "security.opendatahub.io/enable-auth"
 	LabelEnableAuth    = "enable-auth"
 	LabelEnableRoute   = "enable-route"
+
+	CapabilityServiceMeshAuthorization = "CapabilityServiceMeshAuthorization"
 )
 
 // model registry

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -162,10 +162,12 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 	}
 
 	if kserveWithMeshEnabled && authorinoEnabled {
-		r.log.Info("KServe is enabled and Authorino is registered, enabling Authorization capability")
+		r.log.Info("KServe with Service Mesh is enabled and Authorino is registered, enabling Authorization")
 		builder.Owns(&authorinov1beta2.AuthConfig{})
+	} else if kserveWithMeshEnabled {
+		r.log.Info("Using KServe with Service Mesh, but Authorino is not installed - skipping authorization.")
 	} else {
-		r.log.Info("didn't find kserve with service mesh, and Authorino is not a requirement")
+		r.log.Info("Didn't find KServe with Service Mesh.")
 	}
 
 	return builder.Complete(r)

--- a/controllers/kserve_inferenceservice_controller_authconfig_test.go
+++ b/controllers/kserve_inferenceservice_controller_authconfig_test.go
@@ -33,41 +33,43 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var _ = When("InferenceService is created", func() {
+var _ = Describe("InferenceService Authorization", func() {
 
 	var (
 		namespace *corev1.Namespace
 		isvc      *kservev1beta1.InferenceService
 	)
-	BeforeEach(func() {
-		ctx := context.Background()
-		namespace = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: Namespaces.Get(),
-			},
-		}
-		Expect(cli.Create(ctx, namespace)).Should(Succeed())
-		inferenceServiceConfig := &corev1.ConfigMap{}
 
-		Expect(convertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
-		if err := cli.Create(ctx, inferenceServiceConfig); err != nil && !errors.IsAlreadyExists(err) {
-			Fail(err.Error())
-		}
-
-		// We need to stub the cluster state and indicate that Authorino is configured as authorization layer
-		if dsciErr := createDSCIWithAuthorinoEnabled(); dsciErr != nil && !errors.IsAlreadyExists(dsciErr) {
-			Fail(dsciErr.Error())
-		}
-	})
-
-	Context("when not ready", func() {
+	When("not configured for the cluster", func() {
 		BeforeEach(func() {
-			isvc = createISVCMissingStatus(namespace.Name)
+			ctx := context.Background()
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: Namespaces.Get(),
+				},
+			}
+			Expect(cli.Create(ctx, namespace)).Should(Succeed())
+			inferenceServiceConfig := &corev1.ConfigMap{}
+
+			Expect(convertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
+			if err := cli.Create(ctx, inferenceServiceConfig); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			// We need to stub the cluster state and indicate if Authorino is configured as authorization layer
+			if dsciErr := createDSCI(DSCIWithoutAuthorization); dsciErr != nil && !errors.IsAlreadyExists(dsciErr) {
+				Fail(dsciErr.Error())
+			}
+
+			isvc = createISVCWithoutAuth(namespace.Name)
 		})
 
-		It("should not create auth config on missing status.URL", func() {
+		AfterEach(func() {
+			Expect(deleteDSCI(DSCIWithoutAuthorization)).To(Succeed())
+		})
 
-			Consistently(func(g Gomega) error {
+		It("should not create auth config", func() {
+			Consistently(func() error {
 				ac := &authorinov1beta2.AuthConfig{}
 				return getAuthConfig(namespace.Name, isvc.Name, ac)
 			}).
@@ -77,92 +79,138 @@ var _ = When("InferenceService is created", func() {
 		})
 	})
 
-	Context("when ready", func() {
+	When("configured for the cluster", func() {
 
-		Context("auth not enabled", func() {
+		BeforeEach(func() {
+			ctx := context.Background()
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: Namespaces.Get(),
+				},
+			}
+			Expect(cli.Create(ctx, namespace)).Should(Succeed())
+			inferenceServiceConfig := &corev1.ConfigMap{}
+
+			Expect(convertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
+			if err := cli.Create(ctx, inferenceServiceConfig); err != nil && !errors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			// We need to stub the cluster state and indicate that Authorino is configured as authorization layer
+			if dsciErr := createDSCI(DSCIWithAuthorization); dsciErr != nil && !errors.IsAlreadyExists(dsciErr) {
+				Fail(dsciErr.Error())
+			}
+		})
+
+		AfterEach(func() {
+			Expect(deleteDSCI(DSCIWithAuthorization)).To(Succeed())
+		})
+
+		Context("when InferenceService is not ready", func() {
 			BeforeEach(func() {
-				isvc = createISVCWithoutAuth(namespace.Name)
+				isvc = createISVCMissingStatus(namespace.Name)
 			})
 
-			It("should create anonymous auth config", func() {
-				Expect(updateISVCStatus(isvc)).To(Succeed())
+			It("should not create auth config on missing status.URL", func() {
 
-				Eventually(func(g Gomega) {
+				Consistently(func() error {
 					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-					g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
+					return getAuthConfig(namespace.Name, isvc.Name, ac)
 				}).
 					WithTimeout(timeout).
 					WithPolling(interval).
-					Should(Succeed())
-			})
-
-			It("should update to non anonymous on enable", func() {
-				Expect(updateISVCStatus(isvc)).To(Succeed())
-
-				Eventually(func(g Gomega) {
-					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-					g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
-				}).
-					WithTimeout(timeout).
-					WithPolling(interval).
-					Should(Succeed())
-
-				Expect(enableAuth(isvc)).To(Succeed())
-				Eventually(func(g Gomega) {
-					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-				}).
-					WithTimeout(timeout).
-					WithPolling(interval).
-					Should(Succeed())
+					Should(Not(Succeed()))
 			})
 		})
 
-		Context("auth enabled", func() {
-			BeforeEach(func() {
-				isvc = createISVCWithAuth(namespace.Name)
+		Context("when InferenceService is ready", func() {
+
+			Context("auth not enabled", func() {
+				BeforeEach(func() {
+					isvc = createISVCWithoutAuth(namespace.Name)
+				})
+
+				It("should create anonymous auth config", func() {
+					Expect(updateISVCStatus(isvc)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+						g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+				})
+
+				It("should update to non anonymous on enable", func() {
+					Expect(updateISVCStatus(isvc)).To(Succeed())
+
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+						g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+
+					Expect(enableAuth(isvc)).To(Succeed())
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+				})
 			})
 
-			It("should create user defined auth config", func() {
-				Expect(updateISVCStatus(isvc)).To(Succeed())
+			Context("auth enabled", func() {
+				BeforeEach(func() {
+					isvc = createISVCWithAuth(namespace.Name)
+				})
 
-				Eventually(func(g Gomega) {
-					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-					g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
-				}).
-					WithTimeout(timeout).
-					WithPolling(interval).
-					Should(Succeed())
-			})
+				It("should create user defined auth config", func() {
+					Expect(updateISVCStatus(isvc)).To(Succeed())
 
-			It("should update to anonymous on disable", func() {
-				Expect(updateISVCStatus(isvc)).To(Succeed())
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+						g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+				})
 
-				Eventually(func(g Gomega) {
-					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-					g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
-				}).
-					WithTimeout(timeout).
-					WithPolling(interval).
-					Should(Succeed())
+				It("should update to anonymous on disable", func() {
+					Expect(updateISVCStatus(isvc)).To(Succeed())
 
-				Expect(disableAuth(isvc)).To(Succeed())
-				Eventually(func(g Gomega) {
-					ac := &authorinov1beta2.AuthConfig{}
-					g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
-					g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
-				}).
-					WithTimeout(timeout).
-					WithPolling(interval).
-					Should(Succeed())
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+						g.Expect(ac.Spec.Authorization["kubernetes-user"]).NotTo(BeNil())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+
+					Expect(disableAuth(isvc)).To(Succeed())
+					Eventually(func(g Gomega) {
+						ac := &authorinov1beta2.AuthConfig{}
+						g.Expect(getAuthConfig(namespace.Name, isvc.Name, ac)).To(Succeed())
+						g.Expect(ac.Spec.Authorization["anonymous-access"]).NotTo(BeNil())
+					}).
+						WithTimeout(timeout).
+						WithPolling(interval).
+						Should(Succeed())
+				})
 			})
 		})
 	})
+
 })
 
 func getAuthConfig(namespace, name string, ac *authorinov1beta2.AuthConfig) error {
@@ -226,11 +274,9 @@ func enableAuth(isvc *kservev1beta1.InferenceService) error {
 	return cli.Update(context.Background(), isvc)
 }
 
-// createDSCIWithAuthorinoEnabled creates a DSCInitialization which has a condition indicating
-// that Authorino is configured for the given cluster.
-func createDSCIWithAuthorinoEnabled() error {
+func createDSCI(dsci string) error {
 	obj := &unstructured.Unstructured{}
-	if err := convertToUnstructuredResource(DSCIWithAuthorization, obj); err != nil {
+	if err := convertToUnstructuredResource(dsci, obj); err != nil {
 		return err
 	}
 
@@ -263,4 +309,25 @@ func createDSCIWithAuthorinoEnabled() error {
 	_, statusErr := resource.UpdateStatus(context.TODO(), createdObj, metav1.UpdateOptions{})
 
 	return statusErr
+}
+
+func deleteDSCI(dsci string) error {
+	obj := &unstructured.Unstructured{}
+	if err := convertToUnstructuredResource(dsci, obj); err != nil {
+		return err
+	}
+
+	gvk := utils.GVK.DataScienceClusterInitialization
+	obj.SetGroupVersionKind(gvk)
+	dynamicClient, err := dynamic.NewForConfig(envTest.Config)
+	if err != nil {
+		return err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    gvk.Group,
+		Version:  gvk.Version,
+		Resource: "dscinitializations",
+	}
+	return dynamicClient.Resource(gvr).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
 }

--- a/controllers/kserve_inferenceservice_controller_authconfig_test.go
+++ b/controllers/kserve_inferenceservice_controller_authconfig_test.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	. "github.com/onsi/ginkgo"
@@ -261,7 +260,7 @@ func createDSCIWithAuthorinoEnabled() error {
 		}
 	}
 
-	update, statusErr := resource.UpdateStatus(context.TODO(), createdObj, metav1.UpdateOptions{})
-	fmt.Printf("%s", update.GetName())
+	_, statusErr := resource.UpdateStatus(context.TODO(), createdObj, metav1.UpdateOptions{})
+
 	return statusErr
 }

--- a/controllers/reconcilers/kserve_authconfig_reconciler.go
+++ b/controllers/reconcilers/kserve_authconfig_reconciler.go
@@ -18,6 +18,7 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -56,6 +57,15 @@ func NewKserveAuthConfigReconciler(client client.Client) *KserveAuthConfigReconc
 
 func (r *KserveAuthConfigReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
 	log.V(1).Info("Reconciling Authorino AuthConfig for InferenceService")
+	authorinoEnabled, capabilityErr := utils.VerifyIfCapabilityIsEnabled(context.Background(), r.client, constants.CapabilityServiceMeshAuthorization, utils.AuthorinoEnabledWhenOperatorNotMissing)
+	if capabilityErr != nil {
+		log.V(1).Error(capabilityErr, "Error while verifying if Authorino is enabled")
+		return nil
+	}
+	if !authorinoEnabled {
+		log.V(1).Info("Skipping AuthConfig reconciliation, authorization capability is not enabled")
+		return nil
+	}
 
 	if isvc.Status.URL == nil {
 		log.V(1).Info("Inference Service not ready yet, waiting for URL")

--- a/controllers/reconcilers/kserve_authconfig_reconciler.go
+++ b/controllers/reconcilers/kserve_authconfig_reconciler.go
@@ -63,7 +63,7 @@ func (r *KserveAuthConfigReconciler) Reconcile(ctx context.Context, log logr.Log
 		return nil
 	}
 	if !authorinoEnabled {
-		log.V(1).Info("Skipping AuthConfig reconciliation, authorization capability is not enabled")
+		log.V(1).Info("Skipping AuthConfig reconciliation, authorization is not enabled")
 		return nil
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,8 @@ package controllers
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -38,7 +40,6 @@ import (
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -75,6 +76,7 @@ const (
 	InferenceServiceConfigPath1     = "./testdata/configmaps/inferenceservice-config.yaml"
 	ExpectedRoutePath               = "./testdata/results/example-onnx-mnist-route.yaml"
 	ExpectedRouteNoRuntimePath      = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
+	DSCIWithAuthorization           = "./testdata/dsci-with-authorino-enabled.yaml"
 	odhtrustedcabundleConfigMapPath = "./testdata/configmaps/odh-trusted-ca-bundle-configmap.yaml"
 	timeout                         = time.Second * 20
 	interval                        = time.Millisecond * 10
@@ -116,12 +118,14 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	// Register API objects
-	utils.RegisterSchemes(scheme.Scheme)
+	testScheme := runtime.NewScheme()
+	utils.RegisterSchemes(testScheme)
+	utilruntime.Must(authorinov1beta2.AddToScheme(testScheme))
 
 	// +kubebuilder:scaffold:scheme
 
 	// Initialize Kubernetes client
-	cli, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	cli, err = client.New(cfg, client.Options{Scheme: testScheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cli).NotTo(BeNil())
 
@@ -136,7 +140,7 @@ var _ = BeforeSuite(func() {
 
 	// Setup controller manager
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
+		Scheme:             testScheme,
 		LeaderElection:     false,
 		MetricsBindAddress: "0",
 	})
@@ -211,18 +215,22 @@ var _ = AfterEach(func() {
 	Namespaces.Clear()
 })
 
-func convertToStructuredResource(path string, out runtime.Object) (err error) {
+func convertToStructuredResource(path string, out runtime.Object) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	// Unmarshal the YAML data into the struct
-	err = utils.ConvertToStructuredResource(data, out)
+	return utils.ConvertToStructuredResource(data, out)
+}
+
+func convertToUnstructuredResource(path string, out *unstructured.Unstructured) error {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	return utils.ConvertToUnstructuredResource(data, out)
 }
 
 type NamespaceHolder struct {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -77,6 +77,7 @@ const (
 	ExpectedRoutePath               = "./testdata/results/example-onnx-mnist-route.yaml"
 	ExpectedRouteNoRuntimePath      = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
 	DSCIWithAuthorization           = "./testdata/dsci-with-authorino-enabled.yaml"
+	DSCIWithoutAuthorization        = "./testdata/dsci-with-authorino-missing.yaml"
 	odhtrustedcabundleConfigMapPath = "./testdata/configmaps/odh-trusted-ca-bundle-configmap.yaml"
 	timeout                         = time.Second * 20
 	interval                        = time.Millisecond * 10

--- a/controllers/testdata/dsci-with-authorino-enabled.yaml
+++ b/controllers/testdata/dsci-with-authorino-enabled.yaml
@@ -1,0 +1,30 @@
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: default
+  serviceMesh:
+    auth:
+      audiences:
+        - https://rh-oidc.s3.us-east-1.amazonaws.com/27bd6cg0vs7nn08mue83fbof94dj4m9a
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed
+status:
+  conditions:
+    - lastHeartbeatTime: "2024-04-04T16:34:55Z"
+      lastTransitionTime: "2024-04-04T16:32:22Z"
+      message: Service Mesh configured
+      reason: Configured
+      status: "True"
+      type: CapabilityServiceMesh
+    - lastHeartbeatTime: "2024-04-04T16:35:06Z"
+      lastTransitionTime: "2024-04-04T16:35:06Z"
+      message: Service Mesh Authorization configured
+      reason: Configured
+      status: "True"
+      type: CapabilityServiceMeshAuthorization
+  phase: Ready

--- a/controllers/testdata/dsci-with-authorino-missing.yaml
+++ b/controllers/testdata/dsci-with-authorino-missing.yaml
@@ -1,0 +1,30 @@
+apiVersion: dscinitialization.opendatahub.io/v1
+kind: DSCInitialization
+metadata:
+  name: default-dsci
+spec:
+  applicationsNamespace: default
+  serviceMesh:
+    auth:
+      audiences:
+        - https://rh-oidc.s3.us-east-1.amazonaws.com/27bd6cg0vs7nn08mue83fbof94dj4m9a
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed
+status:
+  conditions:
+    - lastHeartbeatTime: "2024-04-04T16:34:55Z"
+      lastTransitionTime: "2024-04-04T16:32:22Z"
+      message: Service Mesh configured
+      reason: Configured
+      status: "True"
+      type: CapabilityServiceMesh
+    - lastHeartbeatTime: "2024-04-04T16:35:06Z"
+      lastTransitionTime: "2024-04-04T16:35:06Z"
+      message: Service Mesh Authorization not available
+      reason: MissingOperator
+      status: "False"
+      type: CapabilityServiceMeshAuthorization
+  phase: Ready

--- a/controllers/utils/converter.go
+++ b/controllers/utils/converter.go
@@ -1,18 +1,20 @@
 package utils
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/yaml"
 )
 
 func ConvertToStructuredResource(yamlContent []byte, out runtime.Object) error {
-
 	s := runtime.NewScheme()
 	RegisterSchemes(s)
 	decode := serializer.NewCodecFactory(s).UniversalDeserializer().Decode
 	_, _, err := decode(yamlContent, nil, out)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
+}
+
+func ConvertToUnstructuredResource(yamlContent []byte, out *unstructured.Unstructured) error {
+	return yaml.Unmarshal(yamlContent, &out.Object)
 }

--- a/controllers/utils/gvk.go
+++ b/controllers/utils/gvk.go
@@ -1,0 +1,21 @@
+package utils
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// GVK is a struct that holds the GroupVersionKind for resources we don't have direct dependency on (by means of golang API)
+// but we still want to interact with them e.g. through unstructured objects.
+var GVK = struct {
+	DataScienceClusterInitialization,
+	DataScienceCluster schema.GroupVersionKind
+}{
+	DataScienceCluster: schema.GroupVersionKind{
+		Group:   "datasciencecluster.opendatahub.io",
+		Version: "v1",
+		Kind:    "DataScienceCluster",
+	},
+	DataScienceClusterInitialization: schema.GroupVersionKind{
+		Group:   "dscinitialization.opendatahub.io",
+		Version: "v1",
+		Kind:    "DSCInitialization",
+	},
+}

--- a/controllers/utils/init.go
+++ b/controllers/utils/init.go
@@ -3,7 +3,6 @@ package utils
 import (
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -38,6 +37,5 @@ func RegisterSchemes(s *runtime.Scheme) {
 	// similar blocks to use with Service Mesh
 	//utilruntime.Must(virtualservicev1.AddToScheme(scheme))
 
-	utilruntime.Must(authorinov1beta2.SchemeBuilder.AddToScheme(s))
 	//+kubebuilder:scaffold:scheme
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -24,9 +24,7 @@ var (
 const (
 	inferenceServiceDeploymentModeAnnotation = "serving.kserve.io/deploymentMode"
 	KserveConfigMapName                      = "inferenceservice-config"
-	dataScienceClusterKind                   = "DataScienceCluster"
-	dataScienceClusterApiVersion             = "datasciencecluster.opendatahub.io/v1"
-	KserveAuthorinoComponent                 = "kserve-authorino"
+	KServeWithServiceMeshComponent           = "kserve-service-mesh"
 )
 
 func GetDeploymentModeForIsvc(ctx context.Context, cli client.Client, isvc *kservev1beta1.InferenceService) (IsvcDeploymentMode, error) {
@@ -77,8 +75,8 @@ func GetDeploymentModeForIsvc(ctx context.Context, cli client.Client, isvc *kser
 func VerifyIfComponentIsEnabled(ctx context.Context, cli client.Client, componentName string) (bool, error) {
 	// Query the custom object
 	objectList := &unstructured.UnstructuredList{}
-	objectList.SetAPIVersion(dataScienceClusterApiVersion)
-	objectList.SetKind(dataScienceClusterKind)
+	objectList.SetAPIVersion(GVK.DataScienceCluster.GroupVersion().String())
+	objectList.SetKind(GVK.DataScienceCluster.Kind)
 
 	if err := cli.List(ctx, objectList); err != nil {
 		return false, fmt.Errorf("not able to read %s: %w", objectList, err)
@@ -87,7 +85,7 @@ func VerifyIfComponentIsEnabled(ctx context.Context, cli client.Client, componen
 	// there must be only one dsc
 	if len(objectList.Items) == 1 {
 		fields := []string{"spec", "components", componentName, "managementState"}
-		if componentName == KserveAuthorinoComponent {
+		if componentName == KServeWithServiceMeshComponent {
 			// For KServe, Authorino is required when serving is enabled
 			// By Disabling ServiceMesh for RawDeployment, it should reflect on disabling
 			// the Authorino integration as well.
@@ -116,8 +114,55 @@ func VerifyIfComponentIsEnabled(ctx context.Context, cli client.Client, componen
 		}
 		return val == "Managed", nil
 	} else {
-		return false, fmt.Errorf("there is no %s available in the cluster", dataScienceClusterKind)
+		return false, fmt.Errorf("there is no %s available in the cluster", GVK.DataScienceCluster.Kind)
 	}
+}
+
+// AuthorinoEnabledWhenOperatorNotMissing is a helper function to check if Authorino is enabled when the Operator is not missing.
+// This is defined by Condition.Reason=MissingOperator. In any other case, it is assumed that Authorino is enabled but DSC might not be
+// in the Ready state and will reconcile.
+func AuthorinoEnabledWhenOperatorNotMissing(_, reason string) bool {
+	return reason != "MissingOperator"
+}
+
+// VerifyIfCapabilityIsEnabled checks if given DSCI capability is enabled. It only fails if client call to fetch DSCI fails.
+// In other cases it assumes capability is not enabled.
+func VerifyIfCapabilityIsEnabled(ctx context.Context, cli client.Client, capabilityName string, enabledWhen func(status, reason string) bool) (bool, error) {
+	objectList := &unstructured.UnstructuredList{}
+	objectList.SetAPIVersion(GVK.DataScienceClusterInitialization.GroupVersion().String())
+	objectList.SetKind(GVK.DataScienceClusterInitialization.Kind)
+
+	if err := cli.List(ctx, objectList); err != nil {
+		return false, fmt.Errorf("not able to read %s: %w", objectList, err)
+	}
+
+	for _, item := range objectList.Items {
+		statusField, found, err := unstructured.NestedFieldNoCopy(item.Object, "status", "conditions")
+		if err != nil || !found {
+			return false, nil
+		}
+
+		conditions, ok := statusField.([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, condition := range conditions {
+			condMap, ok := condition.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if condType, ok := condMap["type"].(string); ok && condType == capabilityName {
+				status, _ := condMap["status"].(string)
+				reason, _ := condMap["reason"].(string)
+				return enabledWhen(status, reason), nil
+			}
+		}
+	}
+
+	return false, nil
+
 }
 
 func IsNil(i any) bool {

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func init() { //nolint:gochecknoinits //reason this way we ensure schemes are al
 // +kubebuilder:rbac:groups="",resources=secrets;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=datascienceclusterinitializations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch
 
 func getEnvAsBool(name string, defaultValue bool) bool {
 	valStr := os.Getenv(name)

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() {
 
 	authorinoEnabled, capabilityErr := utils.VerifyIfCapabilityIsEnabled(context.Background(), mgr.GetClient(), constants.CapabilityServiceMeshAuthorization, utils.AuthorinoEnabledWhenOperatorNotMissing)
 	if capabilityErr != nil {
-		setupLog.Error(capabilityErr, "unable to determine if Authorino in service mesh is enabled")
+		setupLog.Error(capabilityErr, "unable to determine if Authorino is enabled")
 		os.Exit(1)
 	}
 	if kserveWithMeshEnabled && authorinoEnabled {


### PR DESCRIPTION
This change handles "soft opt-in" for authorization capability handled by Authorino.

The solution is based on Conditions exposed in DSCInitialization resource, as provided in https://github.com/opendatahub-io/opendatahub-operator/pull/949.

When the condition of type `CapabilityServiceMeshAuthorization` has a reason `MissingOperator` it will assume authorino/authorization module is not present and therefore does not handle AuthConfigs - leaving models not secured as it was for the previous versions. This approach allows to softly opt-in for Authorization without blocking the upgrade. Any other reason means that ODH Operator is in not happy state and will eventually reconcile so that Authorino will start working.

The logic consists of the following steps:

 * during the controller bootstrap it will check separately if ServiceMesh is enabled and Authorino is present (latter by inspecting the status.condition)
 * when defining watches (using builder instance for OpenshiftReconciler) it will conditionally set a watch for `AuthConfig` 
 * it guards AuthConfig reconciler from executing based on the "authorization capability". This prevents constant failures due to `AuthConfig` not being defined for the cluster.

> [!NOTE]
> As it is the case with original logic brought in #181, it will require restart of the controller pod to set a watch on AuthConfig resource when Authorino is installed in the cluster.

Custom image: `quay.io/bmajsak/odh-model-controller:authz-soft-opt-in`
