### PR TITLE
Add runtime templates

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -14,6 +14,34 @@ generatorOptions:
 
 vars:
   - fieldref:
+      fieldPath: data.caikit-tgis-image
+    name: caikit-tgis-image
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.tgis-image
+    name: tgis-image
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.ovms-image
+    name: ovms-image
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
+      fieldPath: data.vllm-image
+    name: vllm-image
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
       fieldPath: metadata.namespace
     name: mesh-namespace
     objref:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,1 +1,5 @@
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
+caikit-tgis-image=quay.io/opendatahub/caikit-tgis-serving:fast
+tgis-image=quay.io/opendatahub/text-generation-inference:fast
+ovms-image=quay.io/opendatahub/openvino_model_server:fast
+vllm-image=quay.io/opendatahub/vllm:fast-ibm

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,3 +2,4 @@ bases:
   - ../rbac
   - ../manager
   - ../webhook
+  - ../runtimes

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -5,3 +5,6 @@ varReference:
   - path: spec/template/spec/containers[]/image
     kind: Deployment
     apiVersion: apps/v1
+  - path: objects[]/spec/containers[]/image
+    kind: Template
+    apiVersion: template.openshift.io/v1

--- a/config/runtimes/caikit-tgis-template.yaml
+++ b/config/runtimes/caikit-tgis-template.yaml
@@ -1,0 +1,81 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: Caikit is an AI toolkit that enables users to manage models through a set of developer friendly APIs. It provides a consistent format for creating and using AI models against a wide variety of data domains and tasks.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/caikit-tgis-serving
+    template.openshift.io/long-description: This template defines resources needed to deploy caikit-tgis-serving servingruntime with Red Hat Data Science KServe for LLM model
+    template.openshift.io/support-url: https://access.redhat.com
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+  name: caikit-tgis-serving-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: caikit-tgis-runtime
+      annotations:
+        openshift.io/display-name: Caikit TGIS ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        prometheus.io/port: '3000'
+        prometheus.io/path: /metrics
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: caikit
+      containers:
+        - name: kserve-container
+          image: $(tgis-image)
+          command:
+            - text-generation-launcher
+          args:
+            - --model-name=/mnt/models/artifacts/
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+        - name: transformer-container
+          image: $(caikit-tgis-image)
+          env:
+            - name: RUNTIME_LOCAL_MODELS_DIR
+              value: /mnt/models
+            - name: HF_HOME
+              value: /tmp/hf_home
+            - name: RUNTIME_GRPC_ENABLED
+              value: 'false'
+            - name: RUNTIME_HTTP_ENABLED
+              value: 'true'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - readiness
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - liveness
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /health
+            # Allow 12 mins to start
+            failureThreshold: 24
+            periodSeconds: 30

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+  - ovms-mm-template.yaml
+  - caikit-tgis-template.yaml
+  - tgis-template.yaml
+  - ovms-kserve-template.yaml
+  - vllm-template.yaml

--- a/config/runtimes/ovms-kserve-template.yaml
+++ b/config/runtimes/ovms-kserve-template.yaml
@@ -1,0 +1,64 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: kserve-ovms
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    tags: 'kserve-ovms,servingruntime'
+    description: 'OpenVino Model Serving Definition'
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      annotations:
+        openshift.io/display-name: OpenVINO Model Server
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      name: kserve-ovms
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      multiModel: false
+      annotations:
+        prometheus.io/port: '8888'
+        prometheus.io/path: /metrics
+      supportedModelFormats:
+        - name: openvino_ir
+          version: opset13
+          autoSelect: true
+        - name: onnx
+          version: '1'
+        - name: tensorflow
+          version: '1'
+          autoSelect: true
+        - name: tensorflow
+          version: '2'
+          autoSelect: true
+        - name: paddle
+          version: '2'
+          autoSelect: true
+        - name: pytorch
+          version: '2'
+          autoSelect: true
+      protocolVersions:
+        - v2
+        - grpc-v2
+      containers:
+        - name: kserve-container
+          image: $(ovms-image)
+          args:
+            - '--model_name={{.Name}}'
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--model_path=/mnt/models'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=0.0.0.0'
+            - '--rest_bind_address=0.0.0.0'
+            - '--target_device=AUTO'
+            - '--metrics_enable'
+          ports:
+            - containerPort: 8888
+              protocol: TCP

--- a/config/runtimes/ovms-mm-template.yaml
+++ b/config/runtimes/ovms-mm-template.yaml
@@ -1,0 +1,65 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: ovms
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    tags: 'ovms,servingruntime'
+    description: 'OpenVino Model Serving Definition'
+    opendatahub.io/modelServingSupport: '["multi"]'
+    opendatahub.io/apiProtocol: 'REST'
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: ovms
+      annotations:
+        openshift.io/display-name: 'OpenVINO Model Server'
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      builtInAdapter:
+        env:
+          - name: OVMS_FORCE_TARGET_DEVICE
+            value: AUTO
+        memBufferBytes: 134217728
+        modelLoadingTimeoutMillis: 90000
+        runtimeManagementPort: 8888
+        serverType: ovms
+      containers:
+        - args:
+            - '--port=8001'
+            - '--rest_port=8888'
+            - '--config_path=/models/model_config_list.json'
+            - '--file_system_poll_wait_seconds=0'
+            - '--grpc_bind_address=0.0.0.0'
+            - '--rest_bind_address=0.0.0.0'
+          image: $(ovms-image)
+          name: ovms
+          resources:
+            limits:
+              cpu: '0'
+              memory: 0Gi
+            requests:
+              cpu: '0'
+              memory: 0Gi
+      grpcDataEndpoint: 'port:8001'
+      grpcEndpoint: 'port:8085'
+      multiModel: true
+      protocolVersions:
+        - grpc-v1
+      replicas: 1
+      supportedModelFormats:
+        - autoSelect: true
+          name: openvino_ir
+          version: opset1
+        - autoSelect: true
+          name: onnx
+          version: '1'
+        - autoSelect: true
+          name: tensorflow
+          version: '2'
+parameters: []

--- a/config/runtimes/tgis-template.yaml
+++ b/config/runtimes/tgis-template.yaml
@@ -1,0 +1,68 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: Text Generation Inference Server (TGIS) is a high performance inference engine that deploys and serves Large Language Models.
+    openshift.io/display-name: TGIS Standalone ServingRuntime for KServe
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/text-generation-inference
+    template.openshift.io/long-description: This template defines resources needed to deploy TGIS standalone servingruntime with KServe in Red Hat OpenShift AI
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'gRPC'
+  name: tgis-grpc-serving-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: tgis-grpc-runtime
+      annotations:
+        openshift.io/display-name: TGIS Standalone ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        prometheus.io/port: '3000'
+        prometheus.io/path: '/metrics'
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: pytorch
+      containers:
+        - name: kserve-container
+          image: $(tgis-image)
+          command: ['text-generation-launcher']
+          args:
+            - '--model-name=/mnt/models/'
+            - '--port=3000'
+            - '--grpc-port=8033'
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - localhost:3000/health
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - localhost:3000/health
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /health
+            # Allow 12 mins to start
+            failureThreshold: 24
+            periodSeconds: 30
+          ports:
+            - containerPort: 8033
+              name: h2c
+              protocol: TCP

--- a/config/runtimes/vllm-template.yaml
+++ b/config/runtimes/vllm-template.yaml
@@ -1,0 +1,64 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs 
+    openshift.io/display-name: vLLM ServingRuntime for KServe
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime with KServe in Red Hat OpenShift AI
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+  name: vllm-runtime-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: vllm-runtime
+      annotations:
+        openshift.io/display-name: vLLM ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        prometheus.io/port: '8080'
+        prometheus.io/path: '/metrics'
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: vLLM
+      containers:
+        - name: kserve-container
+          image: $(vllm-image)
+          args:
+            - '--port=8080'
+            - '--model=/mnt/models'
+            - '--served-model-name={{.Name}}'
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+          readinessProbe:
+            httpGet: 
+              port: 8080
+              path: /health
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet: 
+              port: 8080
+              path: /health
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /health
+            # Allow 12 mins to start
+            failureThreshold: 24
+            periodSeconds: 30
+          ports:
+            - containerPort: 8080
+              protocol: TCP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Will close: https://issues.redhat.com/browse/RHOAIENG-860
and: https://issues.redhat.com/browse/RHOAIENG-3786

## Description
<!--- Describe your changes in detail -->
We are migrating the runtime templates from odh-dashboard repo to model serving repo of odh-model-controller both for ODH and RHOAI. We are also moving the image tags from kustomization.yaml to params.env per DevOps request.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been only tested within model serving. The test together with operator and odh-dashboard is in progress (not yet complete).

1. In a cluster that has RHOAI or ODH deployed, use the following DSC:
```
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/heyselbi/odh-model-controller/tarball/move-templates'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      devFlags:
        manifests:
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/heyselbi/odh-dashboard/tarball/move-templates'
      managementState: Managed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
```
2. Ensure that the pods have all reconciled and are running:
```
[selbi@fedora ~]$ oc get pods -n redhat-ods-applications
NAME                                         READY   STATUS    RESTARTS   AGE
kserve-controller-manager-79c79f64bb-w5f9k   1/1     Running   0          2d21h
odh-model-controller-7476ddbdfc-m7xmq        1/1     Running   0          7m6s
odh-model-controller-7476ddbdfc-sbkk5        1/1     Running   0          7m16s
odh-model-controller-7476ddbdfc-vft9c        1/1     Running   0          7m27s
rhods-dashboard-646ccf474d-6xskx             2/2     Running   0          6m47s
rhods-dashboard-646ccf474d-9rltt             2/2     Running   0          7m48s
rhods-dashboard-646ccf474d-gm6j2             2/2     Running   0          6m47s
rhods-dashboard-646ccf474d-pfhfq             2/2     Running   0          7m47s
rhods-dashboard-646ccf474d-zrc5x             2/2     Running   0          7m48s
```
3. Make sure that odh-model-controller and rhods-dashboard have the images below (`pr-*`):
```
oc get pods -n redhat-ods-applications -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' |sort |uniq -c
      2 quay.io/modh/kserve-controller@sha256:3ae3440ce4bbd981efefed70a4f21b587f45faf43f6cc4b95a77d1423fa5c7b3
     10 quay.io/opendatahub/odh-dashboard:pr-2706
      6 quay.io/opendatahub/odh-model-controller:pr-189
     10 registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

```
4. On top right, select OpenShift AI 
![image](https://github.com/opendatahub-io/odh-model-controller/assets/43946617/03670d84-f925-4b8d-b8d3-f40f95651caf)
5. In Dashboard, check all runtimes show up
![image](https://github.com/opendatahub-io/odh-model-controller/assets/43946617/b3948c19-ab1d-4331-9352-59b772f47202)
6. Check the runtime templates and check that it has the prometheus annotations
```
oc get template/tgis-grpc-serving-template -o yaml -n redhat-ods-applications | grep prometheus
      prometheus.io/path: /metrics
      prometheus.io/port: "3000"
```

Tests I performed:
- The above test --> that runtime templates appear
- vLLM (no dashboard): tested SR and ISVC following instructions [here](https://docs.google.com/document/d/19_1YhQu73v3NEEDiSaJeJxQQ4k8RvJJIWUsV-O9YZNk/edit) with CPUs (it errored saying no GPUs found) --> that vLLM template arguments work for model loading. ISVC used:
```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata: 
  name: vllm-gpt2-openai
  namespace: vllm-gpt2
spec: 
  predictor: 
    model: 
      runtime: kserve-vllm
      modelFormat: 
        name: vLLM
      storageUri: pvc://vlmm-gpt2-claim/gpt2/
```
- vLLM (no dashboard): tested SR and ISVC following instructions [here](https://docs.google.com/document/d/19_1YhQu73v3NEEDiSaJeJxQQ4k8RvJJIWUsV-O9YZNk/edit) with GPUs --> curl command was successful
- vLLM: tested via Dashboard/UI successfully. Created a minio and uploaded gpt2 model. Created data connection via UI and followed instructions for acceleratorProfile enablement for GPUs to appear when selecting resources. Resulting curl command:
```
[selbi@fedora ~]$ curl -v https://gpt2-dashboard-test.apps.rosa.selbii.[hidden].com:443/v1/chat/completions -k -H "Content-Type: application/json"   -d '{
    "model": "gpt2",
    "messages": [
      {
        "role": "system",
        "content": "You are a poetic assistant, skilled in explaining complex programming concepts with creative flair."
      },
      {
        "role": "user",
        "content": "Compose a poem that explains the concept of recursion in programming."
      }
    ]
  }' | jq .
  % Total    % Received **[....]**
{
  "id": "cmpl-6e7206f4c93b4603b44b8aaa0b233b10",
  "object": "chat.completion",
  "created": 1716930382,
  "model": "gpt2",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "A friend of mine came over **[cut the response since it was too long]**"
      },
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 32,
    "total_tokens": 1024,
    "completion_tokens": 992
  }
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
