### PR TITLE
Refactor kserve metrics solution to work with prometheus annotations

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,18 @@ spec:
                   name: auth-refs
                   key: AUTHORINO_LABEL
                   optional: true
+            - name: CONTROL_PLANE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: service-mesh-refs
+                  key: CONTROL_PLANE_NAME
+                  optional: true
+            - name: MESH_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: service-mesh-refs
+                  key: MESH_NAMESPACE
+                  optional: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,9 +25,20 @@ rules:
   - endpoints
   - namespaces
   - pods
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -19,6 +19,7 @@ const (
 	InferenceServiceKind = "InferenceService"
 
 	IstioNamespace                   = "istio-system"
+	IstioControlPlaneName            = "data-science-smcp"
 	ServiceMeshMemberRollName        = "default"
 	IstioIngressService              = "istio-ingressgateway"
 	IstioIngressServiceHTTPPortName  = "http2"

--- a/controllers/reconcilers/kserve_istio_peerauthentication_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_peerauthentication_reconciler.go
@@ -50,7 +50,7 @@ func NewKServeIstioPeerAuthenticationReconciler(client client.Client) *KserveIst
 
 // TODO remove this reconcile loop in future versions
 func (r *KserveIstioPeerAuthenticationReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	log.V(1).Info("Reconciling PeerAuthentication for target namespace, checking if there are resource for deletion")
+	log.V(1).Info("Reconciling PeerAuthentication for target namespace, checking if there are resources for deletion")
 	// Create Desired resource
 	desiredResource, err := r.createDesiredResource(isvc)
 	if err != nil {

--- a/controllers/reconcilers/kserve_istio_peerauthentication_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_peerauthentication_reconciler.go
@@ -22,10 +22,7 @@ import (
 	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
-	"istio.io/api/security/v1beta1"
-	istiotypes "istio.io/api/type/v1beta1"
 	istiosecv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,9 +48,9 @@ func NewKServeIstioPeerAuthenticationReconciler(client client.Client) *KserveIst
 	}
 }
 
+// TODO remove this reconcile loop in future versions
 func (r *KserveIstioPeerAuthenticationReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	log.V(1).Info("Reconciling PeerAuthentication for target namespace")
-
+	log.V(1).Info("Reconciling PeerAuthentication for target namespace, checking if there are resource for deletion")
 	// Create Desired resource
 	desiredResource, err := r.createDesiredResource(isvc)
 	if err != nil {
@@ -79,25 +76,7 @@ func (r *KserveIstioPeerAuthenticationReconciler) Cleanup(ctx context.Context, l
 }
 
 func (r *KserveIstioPeerAuthenticationReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*istiosecv1beta1.PeerAuthentication, error) {
-	desiredPeerAuthentication := &istiosecv1beta1.PeerAuthentication{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      peerAuthenticationName,
-			Namespace: isvc.Namespace,
-		},
-		Spec: v1beta1.PeerAuthentication{
-			Selector: &istiotypes.WorkloadSelector{
-				MatchLabels: map[string]string{
-					"component": "predictor",
-				},
-			},
-			Mtls: &v1beta1.PeerAuthentication_MutualTLS{Mode: 3},
-			PortLevelMtls: map[uint32]*v1beta1.PeerAuthentication_MutualTLS{
-				8086: {Mode: 2},
-				3000: {Mode: 2},
-			},
-		},
-	}
-	return desiredPeerAuthentication, nil
+	return nil, nil
 }
 
 func (r *KserveIstioPeerAuthenticationReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*istiosecv1beta1.PeerAuthentication, error) {

--- a/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
@@ -90,8 +90,9 @@ func (r *KserveIstioPodMonitorReconciler) createDesiredResource(ctx context.Cont
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key:      "istio-prometheus-ignore",
-						Operator: metav1.LabelSelectorOpDoesNotExist,
+						Key:      "component",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"predictor", "explainer", "transformer"},
 					},
 				},
 			},

--- a/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_podmonitor_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
@@ -80,10 +79,7 @@ func (r *KserveIstioPodMonitorReconciler) Cleanup(ctx context.Context, log logr.
 }
 
 func (r *KserveIstioPodMonitorReconciler) createDesiredResource(ctx context.Context, isvc *kservev1beta1.InferenceService) (*v1.PodMonitor, error) {
-	dsciName, err := utils.GetDSCIName(ctx, r.client)
-	if err != nil {
-		log.V(1).Error(err, "Error getting DSCI name, default value will be used.")
-	}
+	istioControlPlaneName, meshNamespace := utils.GetIstioControlPlaneName(ctx, r.client)
 
 	desiredPodMonitor := &v1.PodMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,7 +139,7 @@ func (r *KserveIstioPodMonitorReconciler) createDesiredResource(ctx context.Cont
 						},
 						{
 							Action:      "replace",
-							Replacement: fmt.Sprintf("%s-istio-system", dsciName),
+							Replacement: fmt.Sprintf("%s-%s", istioControlPlaneName, meshNamespace),
 							TargetLabel: "mesh_id",
 						},
 					},

--- a/controllers/reconcilers/kserve_istio_servicemonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_istio_servicemonitor_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	"github.com/kuadrant/authorino/pkg/log"
 	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
@@ -80,10 +79,7 @@ func (r *KserveIstioServiceMonitorReconciler) Cleanup(ctx context.Context, log l
 }
 
 func (r *KserveIstioServiceMonitorReconciler) createDesiredResource(ctx context.Context, isvc *kservev1beta1.InferenceService) (*v1.ServiceMonitor, error) {
-	dsciName, err := utils.GetDSCIName(ctx, r.client)
-	if err != nil {
-		log.V(1).Error(err, "Error getting DSCI name, default value will be used.")
-	}
+	istioControlPlaneName, meshNamespace := utils.GetIstioControlPlaneName(ctx, r.client)
 
 	desiredServiceMonitor := &v1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -104,7 +100,7 @@ func (r *KserveIstioServiceMonitorReconciler) createDesiredResource(ctx context.
 					RelabelConfigs: []*v1.RelabelConfig{
 						{
 							TargetLabel: "mesh_id",
-							Replacement: fmt.Sprintf("%s-istio-system", dsciName),
+							Replacement: fmt.Sprintf("%s-%s", istioControlPlaneName, meshNamespace),
 							Action:      "replace",
 						},
 					},

--- a/controllers/reconcilers/kserve_metrics_service_reconciler.go
+++ b/controllers/reconcilers/kserve_metrics_service_reconciler.go
@@ -23,10 +23,7 @@ import (
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,8 +48,9 @@ func NewKServeMetricsServiceReconciler(client client.Client) *KserveMetricsServi
 	}
 }
 
+// TODO remove this reconcile loop in future versions
 func (r *KserveMetricsServiceReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	log.V(1).Info("Reconciling Metrics Service for InferenceService")
+	log.V(1).Info("Reconciling Metrics Service for InferenceService, checking if there are resource for deletion")
 
 	// Create Desired resource
 	desiredResource, err := r.createDesiredResource(log, isvc)
@@ -74,40 +72,7 @@ func (r *KserveMetricsServiceReconciler) Reconcile(ctx context.Context, log logr
 }
 
 func (r *KserveMetricsServiceReconciler) createDesiredResource(log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.Service, error) {
-	metricsService := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getMetricsServiceName(isvc),
-			Namespace: isvc.Namespace,
-			Labels: map[string]string{
-				"name": getMetricsServiceName(isvc),
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{
-					Name:       "caikit-metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       8086,
-					TargetPort: intstr.FromInt(8086),
-				},
-				{
-					Name:       "tgis-metrics",
-					Protocol:   v1.ProtocolTCP,
-					Port:       3000,
-					TargetPort: intstr.FromInt(3000),
-				},
-			},
-			Type: v1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				inferenceServiceLabelName: isvc.Name,
-			},
-		},
-	}
-	if err := ctrl.SetControllerReference(isvc, metricsService, r.client.Scheme()); err != nil {
-		log.Error(err, "Unable to add OwnerReference to the Metrics Service")
-		return nil, err
-	}
-	return metricsService, nil
+	return nil, nil
 }
 
 func (r *KserveMetricsServiceReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.Service, error) {

--- a/controllers/reconcilers/kserve_metrics_servicemonitor_reconciler.go
+++ b/controllers/reconcilers/kserve_metrics_servicemonitor_reconciler.go
@@ -23,9 +23,7 @@ import (
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -46,6 +44,7 @@ func NewKServeMetricsServiceMonitorReconciler(client client.Client) *KserveMetri
 	}
 }
 
+// TODO remove this reconcile loop in future versions
 func (r *KserveMetricsServiceMonitorReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
 	log.V(1).Info("Reconciling Metrics ServiceMonitor for InferenceService")
 
@@ -68,35 +67,9 @@ func (r *KserveMetricsServiceMonitorReconciler) Reconcile(ctx context.Context, l
 	return nil
 }
 
+// TODO remove this reconcile loop in future versions
 func (r *KserveMetricsServiceMonitorReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) (*v1.ServiceMonitor, error) {
-	desiredServiceMonitor := &v1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getMetricsServiceMonitorName(isvc),
-			Namespace: isvc.Namespace,
-		},
-		Spec: v1.ServiceMonitorSpec{
-			Endpoints: []v1.Endpoint{
-				{
-					Port:   "caikit-metrics",
-					Scheme: "http",
-				},
-				{
-					Port:   "tgis-metrics",
-					Scheme: "http",
-				},
-			},
-			NamespaceSelector: v1.NamespaceSelector{},
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"name": getMetricsServiceMonitorName(isvc),
-				},
-			},
-		},
-	}
-	if err := ctrl.SetControllerReference(isvc, desiredServiceMonitor, r.client.Scheme()); err != nil {
-		return nil, err
-	}
-	return desiredServiceMonitor, nil
+	return nil, nil
 }
 
 func (r *KserveMetricsServiceMonitorReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.ServiceMonitor, error) {

--- a/main.go
+++ b/main.go
@@ -75,7 +75,8 @@ func init() { //nolint:gochecknoinits //reason this way we ensure schemes are al
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=namespaces;pods;services;endpoints,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces;pods;endpoints,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=secrets;configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=get;list;watch


### PR DESCRIPTION

chore:  Make sure that the vLLM metrics are getting correctly exposed when the
        prometheus annotations are set.
	Fixes [RHOAIENG-6264] - Ensure Metrics work in vLLM

Signed-off-by: Spolti <fspolti@redhat.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change removes the hardcode monitoring Service, ServiceMonitor and PeerAuthentication resources in favor of a centralized configuration using the PodMonitor and Istio's ServiceMonitor resources to fit our needs and make them available in the aggregated metrics endpoint: http://<pod-ip>:15020/stats/prometheus

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test it follow the following steps (Can be tested with OVMS ServingRuntime as well):

- Have a cluster with GPU nodes available (only if testing with vLLM)
- Deploy the following ServingRuntime (If testing with vLLM): Available in the jira
- Deploy the following ISVC (If testing with vLLM): Available in the jira
- Use the Following DSC:
```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/spolti/odh-model-controller/tarball/RHOAIENG-6264-test'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Removed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
```

When everything is deployed, check the metrics in the Prometheus console, it should show the `vllm` prefixed metrics:
<img width="748" alt="Screenshot 2024-04-29 at 16 21 59" src="https://github.com/opendatahub-io/odh-model-controller/assets/1863987/636dfb88-14c5-467f-b0bb-58980ddd7df0">



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
