### PR TITLE
[RHOAIENG-6877] - odh-model-controller breaks Knative if KServe-Serve…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	# Any customization needed, apply to the webhook_patch.yaml file
+	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 external-manifests: 
 	go get github.com/kserve/modelmesh-serving

--- a/config/webhook/field_patch.yaml
+++ b/config/webhook/field_patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: validating.odh-model-controller.opendatahub.io

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,5 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - manifests.yaml
-  - service.yaml
+- manifests.yaml
+- service.yaml
+
+
+patches:
+  - path: webhook_patch.yaml
+    target:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+      version: v1
+  - path: field_patch.yaml
+    target:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+      version: v1
+

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,15 +2,14 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating.odh-model-controller.opendatahub.io
-  annotations:
-    service.beta.openshift.io/inject-cabundle: true
+  name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: odh-model-controller-webhook-service
+      name: webhook-service
+      namespace: system
       path: /validate-serving-knative-dev-v1-service
   failurePolicy: Fail
   name: validating.ksvc.odh-model-controller.opendatahub.io

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating.odh-model-controller.opendatahub.io
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true
+webhooks:
+  - name: validating.ksvc.odh-model-controller.opendatahub.io
+    clientConfig:
+      service:
+        name: odh-model-controller-webhook-service
+    objectSelector:
+      matchExpressions:
+        - key: serving.kserve.io/inferenceservice
+          operator: Exists
+


### PR DESCRIPTION
…rless is not enabled

chore: Make the validating.odh-model-controller.opendatahub.io intercept only ksvc that
	   contains the `serving.kserve.io/inferenceservice` label. This label is added by KServe
	   to any ksvc handled by it, this way we avoid other OpenShift Serverless user not be
	   affected by this webhook in case it is not started by odh-model-controller.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

**Steps to test:**

- Deploy the RHOAI Operator with KServe and ServiceMesh disable, make sure the `odh-model-controller`  does not starts the webhook.
- Try to deploy the ksvc again, you will notice that it will fail indicating the validating webhook is not available.


**Applying the patch:**

- Update the DSC with this content:
```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      managementState: Removed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Removed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Removed
    modelmeshserving:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: 'base'
            uri: 'https://github.com/spolti/odh-model-controller/tarball/RHOAIENG-6877-test'
      managementState: Managed
    datasciencepipelines:
      managementState: Removed
```

- After the reconcile loops have ended, make sure that `odh-model-operator` didn't start the webhook, and can be checked in the logs.
- try to deploy the ksvc again. It should succeed as the `objectSelector` is only filtering, to confirm that, add the kserve label `serving.kserve.io/inferenceservice` with any value and try to deploy the ksvc again, it will fail. 


Note that, if the odh-model-controller image does not starts and it is not overridden, the test can be done anyways as the webhook will not be functional.
The validation webhook is correctly updated, you can check by querying it:
```bash
oc get ValidatingWebhookConfiguration validating.odh-model-controller.opendatahub.io -n redhat-ods-applications -o yaml
```

And check for these line:
```yaml
  objectSelector:
    matchExpressions:
    - key: serving.kserve.io/inferenceservice
      operator: Exists

```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
