### PR TITLE
Auth race condition mitigation

### DIFF
--- a/controllers/utils/init.go
+++ b/controllers/utils/init.go
@@ -3,6 +3,7 @@ package utils
 import (
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -32,6 +33,7 @@ func RegisterSchemes(s *runtime.Scheme) {
 	utilruntime.Must(telemetryv1alpha1.AddToScheme(s))
 	utilruntime.Must(maistrav1.SchemeBuilder.AddToScheme(s))
 	utilruntime.Must(knservingv1.AddToScheme(s))
+	utilruntime.Must(authorinov1beta2.SchemeBuilder.AddToScheme(s))
 
 	// The following are related to Service Mesh, uncomment this and other
 	// similar blocks to use with Service Mesh

--- a/main.go
+++ b/main.go
@@ -22,15 +22,12 @@ import (
 	"os"
 	"strconv"
 
-	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
-
 	// to ensure that exec-entrypoint and run can make use of them.
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -196,17 +193,6 @@ func main() {
 		}
 	} else {
 		setupLog.Info("Skipping setup of Knative Service validating Webhook, because KServe Serverless setup seems to be disabled in the DataScienceCluster resource.")
-	}
-
-	authorinoEnabled, capabilityErr := utils.VerifyIfMeshAuthorizationIsEnabled(context.Background(), mgr.GetClient())
-	if capabilityErr != nil {
-		setupLog.Error(capabilityErr, "unable to determine if Authorino is enabled")
-		os.Exit(1)
-	}
-	if kserveWithMeshEnabled && authorinoEnabled {
-		utilruntime.Must(authorinov1beta2.SchemeBuilder.AddToScheme(scheme))
-	} else {
-		setupLog.Info("Authorino is not enabled, skipping handling")
 	}
 
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
A race condition was found that leads to odh-model-controller starting in a state not suitable for KServe, despite KServe is installed with authorization enabled.

This mitigates such condition by:
* Always adding AuthConfigs to the schema. Adding types to the schema doesn't seem to have any bad effects, even if such types does not exist in the cluster. This prevents a "no kind is registered" error when trying to reconcile an InferenceService if Authorino setup finished after odh-model-controller booted.
* Invoking `Owns` on inferenceservice_controller.go setup based on the existence of the AuthConfig CRD in the cluster, rather than based on the existence of a specific AuthorizationPolicy.

These changes, together with opendatahub-io/opendatahub-operator#1019 should mitigate/fix the race condition and odh-model-controller should properly start in a good state suitable for KServe.

Related to https://issues.redhat.com/browse/RHOAIENG-7312

## How Has This Been Tested?
Three different test were done:
* Install only ModelMesh (no service mesh, nor knative, nor authorino operators installed), and check that odh-model-controller would start properly.
* Install KServe but skip installation of Authorino operator. Check that odh-model-controller would start properly. Also, check that a model can be deployed and inference requests work.
* Install KServe with all prerequisites. Check that odh-model-controller would start properly. Also, check that a model can be deployed and inference requests work.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
