### PR TITLE
Fix performance issues in odh model controller

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,9 +20,12 @@ import (
 	"context"
 	"flag"
 	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"strconv"
 
@@ -124,6 +127,15 @@ func main() {
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{&v1beta1.AuthorizationPolicy{}},
+			},
+		},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&v1.Secret{}: {
+					Label: labels.SelectorFromSet(labels.Set{
+						"opendatahub.io/managed": "true",
+					}),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Description
The ODH model controller is currently using far too much memory and is getting OOMKilled.

### Replication
I am able to replicate this issue with 2000 namespaces where each namespace has 20 secrets of 1mb each.


### Analysis
As analyzed, odh-model-controller consumes a lot of memory because it loads all the Secret of all namespaces into in-memory controller pod.
It happened because we have defined Secret in a list of watch objects inside OpenshiftInferenceServiceReconciler.


### Details analysis
When we define any Object kind in the Watch list(as shown below), the operator would maintain the cache for all instances of watched object type. In short, the operator loads all the object of the watch type from all namespaces into the cache.

```
builder := ctrl.NewControllerManagedBy(mgr).
    For(&kservev1beta1.InferenceService{}).
    Owns(&kservev1alpha1.ServingRuntime{}).
    Owns(&corev1.Namespace{}).
    Owns(&routev1.Route{}).
    Owns(&corev1.ServiceAccount{}).
    Owns(&corev1.Service{}).
    Owns(&corev1.Secret{}).
    Owns(&authv1.ClusterRoleBinding{}).
    Owns(&networkingv1.NetworkPolicy{}).
    Owns(&monitoringv1.ServiceMonitor{}).
    Owns(&monitoringv1.PodMonitor{}).
    Watches(&kservev1alpha1.ServingRuntime{}, 
```


For Example : In above code block Secret is defined in the watch object list so by default Operator would load all Secret from all namespaces into the controller pod.


### Solution
**Solution 1 :** We should carefully define the watcher. If there is any object we should not watch then we should remove it from the watcher list. For example in OpenshiftInferenceServiceReconciler we had defined Secret in the watch list but we didn't create or maintain any Secret in that reconciler so we should remove it.


**Solution 2 :** Cache for watch list is maintained at operator level. Let's suppose if we have 4 controllers and only one of them requires to watch Secret. Even In that case all secrets from all namespace would be loaded into operator memory. If this type of scenario happened then Solution 1 would not be much helpful.
In this case the best possible solution is to restrict the resources which the Operator could monitor. We could configure the controller by defining the cache options while creating a manager instance.

```
mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
.
.
.
Cache: cache.Options{},
} 
```



Cache restriction could mainly be define at two levels :
**Namespace Level** : Cache all resources from specific namespace.
**Object Level** : Cache Object of kind using selector.

**Namespace Level cache**
In this approach, we could provide a list of namespaces which we want to monitor and the controller would only load the objects from these namespaces only. 

Sample implementation :
```
mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
.
.
.
Cache: cache.Options{
  DefaultNamespaces: map[string]cache.Config{
        "opendatahub": {
          LabelSelector: labels.SelectorFromSet(labels.Set{
                      "opendatahub.io/managed": "true",
          }),
        },
      },
},
}
```

**Challenge:**
We can't provide label_selector to select the namespaces. We can't dynamically select a namespace to cache. If we want to restrict by namespaces then all cache namespace should be provided at time of starting operator.
Providing the name of all inference namespaces at time of starting operator is very unlikely because RHOAI provides functionality to create new projects any time which is equivalent to a namespace.

**Object Level cache**
We could define the selector on object type in below format :
```
mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
    .
    .
    .
    Cache: cache.Options{
      ByObject: map[client.Object]cache.ByObject{
        &v1.Secret{}: {
          Label: labels.SelectorFromSet(labels.Set{
              "opendatahub.io/managed": "true",
              "opendatahub.io/dashboard": "true",
          }),
        },
        },
      },
    },
  })
```

We could define the selector in terms of a different combination of Label and Field selector.
With the above cache configuration, the operator has created a separate cache to keep just only secrets which have labels opendatahub.io/managed=true && opendatahub.io/dashboard=true and separate cache to keep all objects of all namespace apart from secret.

**Cache and Client working together**
I do some quick tests on client and cache behavior together. Client also work on what we define in cache.
It means if in the cache option we put a selector to select a secret whose name is storage-config then the client would only be able to query a secret whose name is storage-config. If the client tries to fetch other secrets whose name is [test-1](https://issues.redhat.com//browse/test-1) then it would return an not found error.


In our context it means if we decide to put a selector on Secret then we need to make sure the selector covers all the secrets that we are going to use in odh-model-controller.

**Selector challenge** 
Multiple values in the label/field selector work with AND operation. 
For example in below code
```
Cache: cache.Options{
      ByObject: map[client.Object]cache.ByObject{
        &v1.Secret{}: {
          Label: labels.SelectorFromSet(labels.Set{
              "opendatahub.io/managed": "true",
              "opendatahub.io/dashboard": "true",
          }),
        },
        },
      },
```

Operator would only cache those secrets which have both labels(opendatahub.io/managed=true , opendatahub.io/dashboard=true).
This type of selectors works fine with Secret because all Secret in odh-model-controller have common labels but It causes issues with ConfigMap selection.
As per my analysis, we are querying below 3 ConfigMaps and none of them have a common label/field.

- inferenceservice-config
- odh-kserve-custom-ca-bundle
- odh-trusted-ca-bundle

## How Has This Been Tested?
To test it follow the following steps :
- Have a cluster with 300 namespace where each namespace has 20 secrets of 1mb each.
- Deploy the ServingRuntime
- Deploy the ISVC
- Use the Following DSC:
```
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/vaibhavjainwiz/odh-model-controller/tarball/RHOAIENG-1006_test'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Removed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
```
### Test Result
Memory consuption of odh-model-controller should be around ~150mb.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
