### PR TITLE
Add Caikit Standalone template

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -21,6 +21,13 @@ vars:
       kind: ConfigMap
       name: odh-model-controller-parameters
   - fieldref:
+      fieldPath: data.caikit-standalone-image
+    name: caikit-standalone-image
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: odh-model-controller-parameters
+  - fieldref:
       fieldPath: data.tgis-image
     name: tgis-image
     objref:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,5 +1,6 @@
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
 caikit-tgis-image=quay.io/opendatahub/caikit-tgis-serving:fast
+caikit-standalone-image=quay.io/opendatahub/caikit-nlp:fast
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:fast
 vllm-image=quay.io/opendatahub/vllm:fast-ibm

--- a/config/runtimes/caikit-standalone-template.yaml
+++ b/config/runtimes/caikit-standalone-template.yaml
@@ -1,0 +1,76 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: Caikit is an AI toolkit that enables users to manage models through a set of developer friendly APIs. It provides a consistent format for creating and using AI models against a wide variety of data domains and tasks.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/caikit-nlp
+    template.openshift.io/long-description: This template defines resources needed to deploy caikit-standalone-serving servingruntime with Red Hat Data Science KServe for LLM model
+    template.openshift.io/support-url: https://access.redhat.com
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+  name: caikit-standalone-serving-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: caikit-standalone-runtime
+      annotations:
+        openshift.io/display-name: Caikit Standalone ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        prometheus.io/port: '8086'
+        prometheus.io/path: /metrics
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: caikit
+      containers:
+        - name: kserve-container
+          image: $(caikit-standalone-image)
+          command:
+            - python
+            - '-m'
+            - caikit.runtime
+          env:
+            - name: RUNTIME_LOCAL_MODELS_DIR
+              value: /mnt/models
+            - name: HF_HOME
+              value: /tmp/hf_home
+            - name: RUNTIME_GRPC_ENABLED
+              value: 'false'
+            - name: RUNTIME_HTTP_ENABLED
+              value: 'true'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - readiness
+            initialDelaySeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - python
+                - -m
+                - caikit_health_probe
+                - liveness
+            initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /health
+            # Allow 12 mins to start
+            failureThreshold: 24
+            periodSeconds: 30

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - tgis-template.yaml
   - ovms-kserve-template.yaml
   - vllm-template.yaml
+  - caikit-standalone-template.yaml

--- a/controllers/constants/caikit-metrics.json
+++ b/controllers/constants/caikit-metrics.json
@@ -1,0 +1,55 @@
+{
+    "metrics": {
+        "supported": "true",
+        "config": [
+            {
+                "title": "Number of requests",
+                "type": "REQUEST_COUNT",
+                "queries": [
+                    {
+                        "title": "Number of successful incoming requests",
+                        "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                    },
+                    {
+                        "title": "Number of failed incoming requests",
+                        "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code!='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                    }
+                ]
+            },
+            {
+                "title": "Average response time (ms)",
+                "type": "MEAN_LATENCY",
+                "queries": [
+                    {
+                        "title": "Average inference latency",
+                        "query": "sum by (model_id) (rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                    },
+                    {
+                        "title": "Average e2e latency",
+                        "query": "sum by (model_id) (rate(caikit_core_load_model_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m]) + rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(caikit_core_load_model_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]) + rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                    }
+                ]
+            },
+            {
+                "title": "CPU utilization %",
+                "type": "CPU_USAGE",
+                "queries": [
+                    {
+                        "title": "CPU usage",
+                        "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
+                    }
+                ]
+            },
+            {
+                "title": "Memory utilization %",
+                "type": "MEMORY_USAGE",
+                "queries": [
+                    {
+                        "title": "Memory usage",
+                        "query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/RHOAIENG-6856 --> Support caikit-nlp embeddings service
Closes https://issues.redhat.com/browse/RHOAIENG-8157 --> Enable metrics for caikit standalone

## Description
Add Caikit Standalone runtime template to ODH and RHOAI

## How Has This Been Tested?
### Tested updated odh-model-controller image
1. Edited the RHOAI DSC:
```
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/christinaexyou/odh-model-controller/tarball/add-caikit-standalone'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            secretName: knative-serving-cert
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Managed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
```
2. Ensured that pods within `redhat-ods-applications` were reconciled and running:
```
 oc get pods -n redhat-ods-applications        
NAME                                         READY   STATUS    RESTARTS   AGE
kserve-controller-manager-64fc4858f9-4tjxh   1/1     Running   0          14m
odh-model-controller-675f76987b-fcrj6        1/1     Running   0          14m
odh-model-controller-675f76987b-lg75n        1/1     Running   0          14m
odh-model-controller-675f76987b-r24vd        1/1     Running   0          14m
rhods-dashboard-6f64f58c89-5pgxh             2/2     Running   0          14m
rhods-dashboard-6f64f58c89-9vkjw             2/2     Running   0          14m
rhods-dashboard-6f64f58c89-d78t5             2/2     Running   0          14m
rhods-dashboard-6f64f58c89-dg5gm             2/2     Running   0          14m
rhods-dashboard-6f64f58c89-tbkh9             2/2     Running   0          14m
```
3. Verified that the `odh-model-controller` image tag was `pr-218`
```
oc get pods -n redhat-ods-applications -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' |sort |uniq -c
   2 quay.io/opendatahub/kserve-controller:latest
   6 quay.io/opendatahub/odh-model-controller:pr-218
  10 registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
  10 registry.redhat.io/rhoai/odh-dashboard-rhel8@sha256:3a5f21a8aeefee80de9212415592273bf1e6d8542b9b1eda4ebe0c2903dbfb1f
```
4. Confirmed that `Caikit Standalone ServingRuntime` was visible in the UI
<img width="1459" alt="Screenshot 2024-06-04 at 4 26 07 PM" src="https://github.com/opendatahub-io/odh-model-controller/assets/77992688/72945928-5be5-4209-8b6d-8cbc47bd0429">

### Validated inference responses with local model outputs
* Tested via RHOAI with CPUs using the instructions [here](https://github.com/christinaexyou/caikit-embeddings/blob/main/tests/test_embeddings.py), with each of the following models: 
   * all-minilm-l12-v2
   * bge-large-en-v1.5
   * multilingual-e5-large
*  For each model, the following steps were taken:
1. Bootstrapped the model using the Caikit Embeddings module
2. Containerized the model
6. Deployed MinIO image with a reference to the containerized model
7. Deployed the model using the following SR and ISVC
```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  name: caikit-standalone-runtime
spec:
  multiModel: false
  supportedModelFormats:
    # Note: this currently *only* supports caikit format models
    - autoSelect: true
      name: caikit
  containers:
    - name: kserve-container
      image: quay.io/opendatahub/caikit-nlp:fast
      command: ["python", "-m", "caikit.runtime"]
      env:
        - name: RUNTIME_LOCAL_MODELS_DIR
          value: /mnt/models
        - name: TRANSFORMERS_CACHE
          value: /tmp/transformers_cache
        - name: RUNTIME_GRPC_ENABLED
          value: "false"
        - name: RUNTIME_HTTP_ENABLED
          value: "true"
      ports:
        - containerPort: 8080
          protocol: TCP
      # resources: # configure as required
      #   requests:
      #     cpu: 8
      #     memory: 16Gi
      readinessProbe:
        exec:
          command:
            - python
            - -m
            - caikit_health_probe
            - readiness
        initialDelaySeconds: 5 # might require larger values for large models
      livenessProbe:
        exec:
          command:
            - python
            - -m
            - caikit_health_probe
            - liveness
        initialDelaySeconds: 5
```
```
apiVersion: serving.kserve.io/v1alpha1
kind: ServingRuntime
metadata:
  name: caikit-standalone-runtime
spec:
  multiModel: false
  supportedModelFormats:
    # Note: this currently *only* supports caikit format models
    - autoSelect: true
      name: caikit
  containers:
    - name: kserve-container
      image: quay.io/opendatahub/caikit-nlp:fast
      command: ["python", "-m", "caikit.runtime"]
      env:
        - name: RUNTIME_LOCAL_MODELS_DIR
          value: /mnt/models
        - name: TRANSFORMERS_CACHE
          value: /tmp/transformers_cache
        - name: RUNTIME_GRPC_ENABLED
          value: "false"
        - name: RUNTIME_HTTP_ENABLED
          value: "true"
      ports:
        - containerPort: 8080
          protocol: TCP
      # resources: # configure as required
      #   requests:
      #     cpu: 8
      #     memory: 16Gi
      readinessProbe:
        exec:
          command:
            - python
            - -m
            - caikit_health_probe
            - readiness
        initialDelaySeconds: 5 # might require larger values for large models
      livenessProbe:
        exec:
          command:
            - python
            - -m
            - caikit_health_probe
            - liveness
        initialDelaySeconds: 5
```
8. Validated the 6 different embedding inference responses with a local model, using the test script [here](https://github.com/christinaexyou/caikit-embeddings/blob/main/tests/test_embeddings.py). Here is an example inference request to the `/api/v1/task/rerank/` endpoint for the model `all-minilm-l12-v2`:
```
>> inference_response = requests.post(
            isvc_url + "/api/v1/task/rerank",
            json={
             "model_id": model_id,
             "inputs": {
                 "documents": documents,
                 "query": text
             },
            # "parameters": {
            #     "top_n":
            #     }
            },
            verify=False
        ).json()
>> print(inference_response['result'])
{'query': 'test first sentence',
 'scores': [{'document': {'text': 'first sentence', 'title': 'first title'},
   'index': 0,
   'score': 0.6441316604614258,
   'text': 'first sentence'},
  {'document': {'text': 'another sentence', 'more': 'more attributes here'},
   'index': 1,
   'score': 0.4829946458339691,
   'text': 'another sentence'},
  {'document': {'text': 'a doc with a nested metadata',
    'meta': {'foo': 'bar', 'i': 999, 'f': 12.34}},
   'index': 2,
   'score': 0.0344165600836277,
   'text': 'a doc with a nested metadata'}]}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
