### PR TITLE
Kserve Dashboard Reconciler

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,10 @@ RUN go mod download
 COPY main.go main.go
 #COPY api/ api/
 COPY controllers/ controllers/
+COPY controllers/constants/ovms-metrics.json metrics_dashboards/ovms-metrics.json
+COPY controllers/constants/tgis-metrics.json metrics_dashboards/tgis-metrics.json
+COPY controllers/constants/vllm-metrics.json metrics_dashboards/vllm-metrics.json
+COPY controllers/constants/caikit-metrics.json metrics_dashboards/caikit-metrics.json
 
 # Build
 USER root
@@ -23,6 +27,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager main.go
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/metrics_dashboards/ovms-metrics.json .
+COPY --from=builder /workspace/metrics_dashboards/tgis-metrics.json .
+COPY --from=builder /workspace/metrics_dashboards/vllm-metrics.json .
+COPY --from=builder /workspace/metrics_dashboards/caikit-metrics.json .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/controllers/comparators/configmap_comparator.go
+++ b/controllers/comparators/configmap_comparator.go
@@ -1,0 +1,29 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparators
+
+import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetConfigMapComparator() ResourceComparator {
+	return func(deployed client.Object, requested client.Object) bool {
+		deployedConfigMap := deployed.(*corev1.ConfigMap)
+		requestedConfigMap := requested.(*corev1.ConfigMap)
+		return reflect.DeepEqual(deployedConfigMap.Data, requestedConfigMap.Data) &&
+			reflect.DeepEqual(deployedConfigMap.Labels, requestedConfigMap.Labels)
+	}
+}

--- a/controllers/constants/caikit-metrics.json
+++ b/controllers/constants/caikit-metrics.json
@@ -1,55 +1,52 @@
 {
-    "metrics": {
-        "supported": "true",
-        "config": [
-            {
-                "title": "Number of requests",
-                "type": "REQUEST_COUNT",
-                "queries": [
-                    {
-                        "title": "Number of successful incoming requests",
-                        "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    },
-                    {
-                        "title": "Number of failed incoming requests",
-                        "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code!='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "Average response time (ms)",
-                "type": "MEAN_LATENCY",
-                "queries": [
-                    {
-                        "title": "Average inference latency",
-                        "query": "sum by (model_id) (rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    },
-                    {
-                        "title": "Average e2e latency",
-                        "query": "sum by (model_id) (rate(caikit_core_load_model_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m]) + rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(caikit_core_load_model_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]) + rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "CPU utilization %",
-                "type": "CPU_USAGE",
-                "queries": [
-                    {
-                        "title": "CPU usage",
-                        "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
-                    }
-                ]
-            },
-            {
-                "title": "Memory utilization %",
-                "type": "MEMORY_USAGE",
-                "queries": [
-                    {
-                        "title": "Memory usage",
-                        "query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
-                    }
-                ]
-            }
-        ]
-    }
+    "config": [
+        {
+            "title": "Number of requests",
+            "type": "REQUEST_COUNT",
+            "queries": [
+                {
+                    "title": "Number of successful incoming requests",
+                    "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                },
+                {
+                    "title": "Number of failed incoming requests",
+                    "query": "sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code!='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "Average response time (ms)",
+            "type": "MEAN_LATENCY",
+            "queries": [
+                {
+                    "title": "Average inference latency",
+                    "query": "sum by (model_id) (rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                },
+                {
+                    "title": "Average e2e latency",
+                    "query": "sum by (model_id) (rate(caikit_core_load_model_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m]) + rate(predict_caikit_library_duration_seconds_sum{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[1m])) / sum by (model_id) (rate(caikit_core_load_model_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]) + rate(predict_caikit_library_duration_seconds_count{namespace='${NAMESPACE}',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "CPU utilization %",
+            "type": "CPU_USAGE",
+            "queries": [
+                {
+                    "title": "CPU usage",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
+                }
+            ]
+        },
+        {
+            "title": "Memory utilization %",
+            "type": "MEMORY_USAGE",
+            "queries": [
+                {
+                    "title": "Memory usage",
+                    "query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
+                }
+            ]
+        }
+    ]
 }

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -53,4 +53,9 @@ const (
 
 const (
 	DefaultStorageConfig = "storage-config"
+	IntervalValue        = "1m"
+	OvmsImageName        = "openvino_model_server"
+	TgisImageName        = "text-generation-inference"
+	VllmImageName        = "vllm"
+	CaikitImageName      = "caikit-nlp"
 )

--- a/controllers/constants/ovms-metrics.json
+++ b/controllers/constants/ovms-metrics.json
@@ -1,55 +1,52 @@
 {
-    "metrics": {
-        "supported": "true",
-        "config": [
-            {
-                "title": "Number of requests",
-                "type": "REQUEST_COUNT",
-                "queries": [
-                    {
-                        "title": "Number of successful incoming requests",
-                        "query": "sum(increase(ovms_requests_success{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    },
-                    {
-                        "title": "Number of failed incoming requests",
-                        "query": "sum(increase(ovms_requests_fail{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "Average response time (ms)",
-                "type": "MEAN_LATENCY",
-                "queries": [
-                    {
-                        "title": "Average inference latency",
-                        "query": "sum by (name) (rate(ovms_inference_time_us_sum{namespace='${NAMESPACE}', name='${MODEL_NAME}'}[1m])) / sum by (name) (rate(ovms_inference_time_us_count{namespace='${NAMESPACE}', name='${MODEL_NAME}'}[{RATE_INTERVAL}]))"
-                    },
-                    {
-                        "title": "Average e2e latency",
-                        "query": "sum by (name) (rate(ovms_request_time_us_sum{name='${MODEL_NAME}'}[1m])) / sum by (name) (rate(ovms_request_time_us_count{name='${MODEL_NAME}'}[{RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "CPU utilization %",
-                "type": "CPU_USAGE",
-                "queries": [
-                    {
-                        "title": "CPU usage",
-                        "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
-                    }
-                ]
-            },
-            {
-                "title": "Memory utilization %",
-                "type": "MEMORY_USAGE",
-                "queries": [
-                    {
-                        "title": "Memory usage",
-                        "query": "sum(container_memory_working_set_bytes{namespace='$(MODEL_NAMESPACE)', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
-                    }
-                ]
-            }
-        ]
-    }
+    "config": [
+        {
+            "title": "Number of requests",
+            "type": "REQUEST_COUNT",
+            "queries": [
+                {
+                    "title": "Number of successful incoming requests",
+                    "query": "sum(increase(ovms_requests_success{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                },
+                {
+                    "title": "Number of failed incoming requests",
+                    "query": "sum(increase(ovms_requests_fail{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "Average response time (ms)",
+            "type": "MEAN_LATENCY",
+            "queries": [
+                {
+                    "title": "Average inference latency",
+                    "query": "sum by (name) (rate(ovms_inference_time_us_sum{namespace='${NAMESPACE}', name='${MODEL_NAME}'}[1m])) / sum by (name) (rate(ovms_inference_time_us_count{namespace='${NAMESPACE}', name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                },
+                {
+                    "title": "Average e2e latency",
+                    "query": "sum by (name) (rate(ovms_request_time_us_sum{name='${MODEL_NAME}'}[1m])) / sum by (name) (rate(ovms_request_time_us_count{name='${MODEL_NAME}'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "CPU utilization %",
+            "type": "CPU_USAGE",
+            "queries": [
+                {
+                    "title": "CPU usage",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
+                }
+            ]
+        },
+        {
+            "title": "Memory utilization %",
+            "type": "MEMORY_USAGE",
+            "queries": [
+                {
+                    "title": "Memory usage",
+                    "query": "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
+                }
+            ]
+        }
+    ]
 }

--- a/controllers/constants/tgis-metrics.json
+++ b/controllers/constants/tgis-metrics.json
@@ -1,55 +1,52 @@
 {
-    "metrics": {
-        "supported": "true",
-        "config": [
-            {
-                "title": "Number of requests",
-                "type": "REQUEST_COUNT",
-                "queries": [
-                    {
-                        "title": "Number of successful incoming requests",
-                        "query": "sum(increase(tgi_request_success{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
-                    },
-                    {
-                        "title": "Number of failed incoming requests",
-                        "query": "sum(increase(tgi_request_failure{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "Average response time (ms)",
-                "type": "MEAN_LATENCY",
-                "queries": [
-                    {
-                        "title": "Average inference latency",
-                        "query": "sum by (pod) (rate(tgi_request_inference_duration_sum{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])) / sum by (pod) (rate(tgi_request_inference_duration_count{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))  "
-                    },
-                    {
-                        "title": "Average e2e latency",
-                        "query": "sum by (pod) (rate(tgi_request_duration_sum{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])) / sum by (pod) (rate(tgi_request_duration_count{namespace=${NAMESPACE}, pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "CPU utilization %",
-                "type": "CPU_USAGE",
-                "queries": [
-                    {
-                        "title": "CPU usage",
-                        "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
-                    }
-                ]
-            },
-            {
-                "title": "Memory utilization %",
-                "type": "MEMORY_USAGE",
-                "queries": [
-                    {
-                        "title": "Memory usage",
-                        "query": "sum(container_memory_working_set_bytes{namespace='$(MODEL_NAMESPACE)', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
-                    }
-                ]
-            }
-        ]
-    }
+    "config": [
+        {
+            "title": "Number of requests",
+            "type": "REQUEST_COUNT",
+            "queries": [
+                {
+                    "title": "Number of successful incoming requests",
+                    "query": "sum(increase(tgi_request_success{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
+                },
+                {
+                    "title": "Number of failed incoming requests",
+                    "query": "sum(increase(tgi_request_failure{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "Average response time (ms)",
+            "type": "MEAN_LATENCY",
+            "queries": [
+                {
+                    "title": "Average inference latency",
+                    "query": "sum by (pod) (rate(tgi_request_inference_duration_sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])) / sum by (pod) (rate(tgi_request_inference_duration_count{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))  "
+                },
+                {
+                    "title": "Average e2e latency",
+                    "query": "sum by (pod) (rate(tgi_request_duration_sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])) / sum by (pod) (rate(tgi_request_duration_count{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "CPU utilization %",
+            "type": "CPU_USAGE",
+            "queries": [
+                {
+                    "title": "CPU usage",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
+                }
+            ]
+        },
+        {
+            "title": "Memory utilization %",
+            "type": "MEMORY_USAGE",
+            "queries": [
+                {
+                    "title": "Memory usage",
+                    "query": "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
+                }
+            ]
+        }
+    ]
 }

--- a/controllers/constants/vllm-metrics.json
+++ b/controllers/constants/vllm-metrics.json
@@ -1,47 +1,44 @@
 {
-    "metrics": {
-        "supported": "true",
-        "config": [
-            {
-                "title": "Number of requests",
-                "type": "REQUEST_COUNT",
-                "queries": [
-                    {
-                        "title": "Number of successful incoming requests",
-                        "query": "sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${RATE_INTERVAL}]))"
-                    }
-                ]
-            },
-            {
-                "title": "Average response time (ms)",
-                "type": "MEAN_LATENCY",
-                "queries": [
-                    {
-                        "title": "Average e2e latency",
-                        "query": "histogram_quantile(0.5, sum(rate(vllm:e2e_request_latency_seconds_bucket{namespace=${NAMESPACE}, model_name='${MODEL_NAME}'}[${RATE_INTERVAL}])) by (le, model_name))"
-                    }
-                ]
-            },
-            {
-                "title": "CPU utilization %",
-                "type": "CPU_USAGE",
-                "queries": [
-                    {
-                        "title": "CPU usage",
-                        "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'}* on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
-                    }
-                ]
-            },
-            {
-                "title": "Memory utilization %",
-                "type": "MEMORY_USAGE",
-                "queries": [
-                    {
-                        "title": "Memory usage",
-                        "query":  "sum(container_memory_working_set_bytes{namespace='$(MODEL_NAMESPACE)', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
-                    }
-                ]
-            }
-        ]
-    }
+    "config": [
+        {
+            "title": "Number of requests",
+            "type": "REQUEST_COUNT",
+            "queries": [
+                {
+                    "title": "Number of successful incoming requests",
+                    "query": "sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${RATE_INTERVAL}]))"
+                }
+            ]
+        },
+        {
+            "title": "Average response time (ms)",
+            "type": "MEAN_LATENCY",
+            "queries": [
+                {
+                    "title": "Average e2e latency",
+                    "query": "histogram_quantile(0.5, sum(rate(vllm:e2e_request_latency_seconds_bucket{namespace='${NAMESPACE}', model_name='${MODEL_NAME}'}[${RATE_INTERVAL}])) by (le, model_name))"
+                }
+            ]
+        },
+        {
+            "title": "CPU utilization %",
+            "type": "CPU_USAGE",
+            "queries": [
+                {
+                    "title": "CPU usage",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace='${NAMESPACE}'} * on(namespace,pod) group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{namespace='${NAMESPACE}', workload=~'${MODEL_NAME}-predictor-.*', workload_type=~'deployment'}) by (pod)"
+                }
+            ]
+        },
+        {
+            "title": "Memory utilization %",
+            "type": "MEMORY_USAGE",
+            "queries": [
+                {
+                    "title": "Memory usage",
+                    "query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (pod)"
+                }
+            ]
+        }
+    ]
 }

--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -115,6 +116,7 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&authv1.ClusterRoleBinding{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&monitoringv1.ServiceMonitor{}).

--- a/controllers/reconcilers/kserve_metrics_dashboard_reconciler.go
+++ b/controllers/reconcilers/kserve_metrics_dashboard_reconciler.go
@@ -1,0 +1,243 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
+	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
+	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
+	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Query struct {
+	Title string `json:"title"`
+	Query string `json:"query"`
+}
+
+type Config struct {
+	Title   string  `json:"title"`
+	Type    string  `json:"type"`
+	Queries []Query `json:"queries"`
+}
+
+type MetricsDashboardConfigMapData struct {
+	Data []Config `json:"data"`
+}
+
+var _ SubResourceReconciler = (*KserveMetricsDashboardReconciler)(nil)
+var ovmsData []byte
+var tgisData []byte
+var vllmData []byte
+var caikitData []byte
+
+type KserveMetricsDashboardReconciler struct {
+	NoResourceRemoval
+	client           client.Client
+	configMapHandler resources.ConfigMapHandler
+	deltaProcessor   processors.DeltaProcessor
+}
+
+func NewKserveMetricsDashboardReconciler(client client.Client) *KserveMetricsDashboardReconciler {
+	return &KserveMetricsDashboardReconciler{
+		client:           client,
+		configMapHandler: resources.NewConfigMapHandler(client),
+		deltaProcessor:   processors.NewDeltaProcessor(),
+	}
+}
+
+func (r *KserveMetricsDashboardReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+
+	// Create Desired resource
+	desiredResource, err := r.createDesiredResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
+
+	// Get Existing resource
+	existingResource, err := r.getExistingResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
+
+	// Process Delta
+	if err = r.processDelta(ctx, log, desiredResource, existingResource); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *KserveMetricsDashboardReconciler) createDesiredResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*corev1.ConfigMap, error) {
+
+	// resolve SR
+	isvcRuntime := isvc.Spec.Predictor.Model.Runtime
+	runtime := &kservev1alpha1.ServingRuntime{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: *isvcRuntime, Namespace: isvc.Namespace}, runtime); err != nil {
+		log.Error(err, "Could not determine servingruntime for isvc")
+	}
+
+	if (runtime.Spec.Containers == nil) || (len(runtime.Spec.Containers) < 1) {
+		log.V(1).Info("Could not determine runtime image")
+		return nil, nil
+	}
+
+	servingRuntimeImage := runtime.Spec.Containers[0].Image
+	re := regexp.MustCompile(`/([^/@]+)[@:]`)
+	findImageName := re.FindStringSubmatch(servingRuntimeImage)
+	servingRuntime := findImageName[1]
+
+	var data []byte
+	switch servingRuntime {
+	case constants.OvmsImageName:
+		if ovmsData == nil {
+			ovmsData, err := os.ReadFile("ovms-metrics.json")
+			if err != nil {
+				log.Error(err, "Unable to load metrics dashboard template file:")
+				return nil, err
+			}
+			data = ovmsData
+		}
+	case constants.TgisImageName:
+		if tgisData == nil {
+			tgisData, err := os.ReadFile("tgis-metrics.json")
+			if err != nil {
+				log.Error(err, "Unable to load metrics dashboard template file:")
+				return nil, err
+			}
+			data = tgisData
+		}
+
+	case constants.VllmImageName:
+		if vllmData == nil {
+			vllmData, err := os.ReadFile("vllm-metrics.json")
+			if err != nil {
+				log.Error(err, "Unable to load metrics dashboard template file:")
+				return nil, err
+			}
+			data = vllmData
+		}
+
+	case constants.CaikitImageName:
+		if caikitData == nil {
+			caikitData, err := os.ReadFile("caikit-metrics.json")
+			if err != nil {
+				log.Error(err, "Unable to load metrics dashboard template file:")
+				return nil, err
+			}
+			data = caikitData
+		}
+
+	default:
+		log.V(1).Info("Metrics for runtime not supported.", "Runtime:", runtime.Name)
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      isvc.Name + "-metrics-dashboard",
+				Namespace: isvc.Namespace,
+			},
+			Data: map[string]string{
+				"supported": "false",
+			},
+		}
+		// Add labels to the configMap
+		configMap.Labels = map[string]string{
+			"app.opendatahub.io/kserve": "true",
+		}
+		if err := ctrl.SetControllerReference(isvc, configMap, r.client.Scheme()); err != nil {
+			log.Error(err, "Unable to add OwnerReference to the Metrics Dashboard Configmap")
+			return nil, err
+		}
+		return configMap, nil
+	}
+
+	finaldata := substituteVariablesInQueries(data, isvc.Namespace, isvc.Name, constants.IntervalValue)
+	// Create ConfigMap object
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      isvc.Name + "-metrics-dashboard",
+			Namespace: isvc.Namespace,
+		},
+		Data: map[string]string{
+			"supported": "true",
+			"metrics":   string(finaldata),
+		},
+	}
+	// Add labels to the configMap
+	configMap.Labels = map[string]string{
+		"app.opendatahub.io/kserve": "true",
+	}
+	if err := ctrl.SetControllerReference(isvc, configMap, r.client.Scheme()); err != nil {
+		log.Error(err, "Unable to add OwnerReference to the Metrics Dashboard Configmap")
+		return nil, err
+	}
+
+	return configMap, nil
+}
+
+func substituteVariablesInQueries(data []byte, namespace string, name string, IntervalValue string) []byte {
+	replacer := strings.NewReplacer("${NAMESPACE}", namespace, "${MODEL_NAME}", name, "${RATE_INTERVAL}", IntervalValue)
+	return []byte(replacer.Replace(string(data)))
+}
+
+func (r *KserveMetricsDashboardReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*corev1.ConfigMap, error) {
+	return r.configMapHandler.FetchConfigMap(ctx, log, types.NamespacedName{Name: isvc.Name + "-metrics-dashboard", Namespace: isvc.Namespace})
+}
+
+func (r *KserveMetricsDashboardReconciler) processDelta(ctx context.Context, log logr.Logger, desiredResource *corev1.ConfigMap, existingResource *corev1.ConfigMap) (err error) {
+
+	comparator := comparators.GetConfigMapComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desiredResource, existingResource)
+	if !delta.HasChanges() {
+		log.V(1).Info("No delta found in metrics configmap")
+		return nil
+	}
+
+	if delta.IsAdded() {
+		log.V(1).Info("Delta found", "create", desiredResource.GetName())
+		if err = r.client.Create(ctx, desiredResource); err != nil {
+			return
+		}
+	}
+	if delta.IsUpdated() {
+		log.V(1).Info("Delta found", "update", existingResource.GetName())
+		rp := existingResource.DeepCopy()
+		rp.Labels = desiredResource.Labels
+		rp.Data = desiredResource.Data
+
+		if err = r.client.Update(ctx, rp); err != nil {
+			return
+		}
+	}
+	if delta.IsRemoved() {
+		log.V(1).Info("Delta found", "delete", existingResource.GetName())
+		if err = r.client.Delete(ctx, existingResource); err != nil {
+			return
+		}
+	}
+	return nil
+}

--- a/controllers/reconcilers/kserve_serverless_inferenceservice_reconciler.go
+++ b/controllers/reconcilers/kserve_serverless_inferenceservice_reconciler.go
@@ -17,6 +17,7 @@ package reconcilers
 
 import (
 	"context"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/go-logr/logr"
@@ -45,6 +46,7 @@ func NewKServeServerlessInferenceServiceReconciler(client client.Client) *Kserve
 		NewKServeIstioPeerAuthenticationReconciler(client),
 		NewKServeNetworkPolicyReconciler(client),
 		NewKserveAuthConfigReconciler(client),
+		NewKserveMetricsDashboardReconciler(client),
 	}
 
 	return &KserveServerlessInferenceServiceReconciler{

--- a/controllers/resources/configmap.go
+++ b/controllers/resources/configmap.go
@@ -1,0 +1,50 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ConfigMapHandler interface {
+	FetchConfigMap(ctx context.Context, log logr.Logger, key types.NamespacedName) (*corev1.ConfigMap, error)
+}
+
+type configMapHandler struct {
+	client client.Client
+}
+
+func NewConfigMapHandler(client client.Client) ConfigMapHandler {
+	return &configMapHandler{
+		client: client,
+	}
+}
+
+func (r *configMapHandler) FetchConfigMap(ctx context.Context, log logr.Logger, key types.NamespacedName) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	err := r.client.Get(ctx, key, configMap)
+	if err != nil && errors.IsNotFound(err) {
+		log.V(1).Info("ConfigMap not found.")
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	log.V(1).Info("Successfully fetched ConfigMap", "ConfigMap:", key.Name)
+	return configMap, nil
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,14 +17,15 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/controllers/testdata/deploy/kserve-openvino-serving-runtime-1.yaml
+++ b/controllers/testdata/deploy/kserve-openvino-serving-runtime-1.yaml
@@ -1,42 +1,52 @@
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
+  annotations:
+    openshift.io/display-name: OpenVINO Model Server
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: ovms-1.x
   namespace: default
+  labels:
+    opendatahub.io/dashboard: 'true'
 spec:
+  multiModel: false
+  annotations:
+    prometheus.io/port: '8888'
+    prometheus.io/path: /metrics
   supportedModelFormats:
     - name: openvino_ir
-      version: opset1
+      version: opset13
       autoSelect: true
     - name: onnx
-      version: "1"
+      version: '1'
+    - name: tensorflow
+      version: '1'
+      autoSelect: true
+    - name: tensorflow
+      version: '2'
+      autoSelect: true
+    - name: paddle
+      version: '2'
+      autoSelect: true
+    - name: pytorch
+      version: '2'
       autoSelect: true
   protocolVersions:
-    - grpc-v1
-  grpcEndpoint: "port:8085"
-  grpcDataEndpoint: "port:8001"
+    - v2
+    - grpc-v2
   containers:
-    - name: ovms
-      image: quay.io/modh/odh-openvino-servingruntime-container:v1.19.0-18
+    - name: kserve-container
+      image: quay.io/opendatahub/openvino_model_server:fast
       args:
-        - --port=8001
-        - --rest_port=8888
-        # must match the default value in the ovms adapter server
-        - --config_path=/models/model_config_list.json
-        # the adapter will call `/v1/config/reload` to trigger reloads
-        - --file_system_poll_wait_seconds=0
-        # bind to localhost only to constrain requests to containers in the pod
-        - --grpc_bind_address=127.0.0.1
-        - --rest_bind_address=127.0.0.1
-      resources:
-        requests:
-          cpu: 500m
-          memory: 1Gi
-        limits:
-          cpu: 5
-          memory: 1Gi
-  builtInAdapter:
-    serverType: ovms
-    runtimeManagementPort: 8888
-    memBufferBytes: 134217728
-    modelLoadingTimeoutMillis: 90000
+        - '--model_name=example-onnx-mnist'
+        - '--port=8001'
+        - '--rest_port=8888'
+        - '--model_path=/mnt/models'
+        - '--file_system_poll_wait_seconds=0'
+        - '--grpc_bind_address=0.0.0.0'
+        - '--rest_bind_address=0.0.0.0'
+        - '--target_device=AUTO'
+        - '--metrics_enable'
+      ports:
+        - containerPort: 8888
+          protocol: TCP

--- a/main.go
+++ b/main.go
@@ -19,15 +19,16 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
+	"strconv"
+
 	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"strconv"
 
 	// to ensure that exec-entrypoint and run can make use of them.
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -133,6 +134,11 @@ func main() {
 				&v1.Secret{}: {
 					Label: labels.SelectorFromSet(labels.Set{
 						"opendatahub.io/managed": "true",
+					}),
+				},
+				&v1.ConfigMap{}: {
+					Label: labels.SelectorFromSet(labels.Set{
+						"app.opendatahub.io/kserve": "true",
 					}),
 				},
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add logic for configmap creation for Kserve metrics in ODH Model Controller
Closes: [RHOAIENG-3956](https://issues.redhat.com/browse/RHOAIENG-3956)

## How Has This Been Tested?
- install odh
- install the following DSC 
- ```spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/opendatahub-io/kserve/tarball/master'
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/ashley-o0o/odh-model-controller/tarball/kserveReconciler'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    modelregistry:
      managementState: Removed
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Managed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    trainingoperator:
      managementState: Removed
- create a data science project
- deploy a sample model for each supported ServingRuntime 
- ensure <modelname>-metrics-dashboard configmap exists, and contents are correct 
- ensure configmap is deleted when model is deleted. 
- ensure that the configmap cannot be changed by the user (the reconciler should revert changes) 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
