### PR TITLE
fix vllm template

### DIFF
--- a/config/runtimes/caikit-tgis-template.yaml
+++ b/config/runtimes/caikit-tgis-template.yaml
@@ -56,26 +56,3 @@ objects:
           ports:
             - containerPort: 8080
               protocol: TCP
-          readinessProbe:
-            exec:
-              command:
-                - python
-                - -m
-                - caikit_health_probe
-                - readiness
-            initialDelaySeconds: 5
-          livenessProbe:
-            exec:
-              command:
-                - python
-                - -m
-                - caikit_health_probe
-                - liveness
-            initialDelaySeconds: 5
-          startupProbe:
-            httpGet:
-              port: 8080
-              path: /health
-            # Allow 12 mins to start
-            failureThreshold: 24
-            periodSeconds: 30

--- a/config/runtimes/tgis-template.yaml
+++ b/config/runtimes/tgis-template.yaml
@@ -43,25 +43,6 @@ objects:
           env:
             - name: HF_HOME
               value: /tmp/hf_home
-          readinessProbe:
-            exec:
-              command:
-                - curl
-                - localhost:3000/health
-            initialDelaySeconds: 5
-          livenessProbe:
-            exec:
-              command:
-                - curl
-                - localhost:3000/health
-            initialDelaySeconds: 5
-          startupProbe:
-            httpGet:
-              port: 8080
-              path: /health
-            # Allow 12 mins to start
-            failureThreshold: 24
-            periodSeconds: 30
           ports:
             - containerPort: 8033
               name: h2c

--- a/config/runtimes/vllm-template.yaml
+++ b/config/runtimes/vllm-template.yaml
@@ -35,10 +35,15 @@ objects:
       containers:
         - name: kserve-container
           image: $(vllm-image)
+          command:
+            - python
+            - -m
+            - vllm.entrypoints.openai.api_server
           args:
-            - '--port=8080'
-            - '--model=/mnt/models'
-            - '--served-model-name={{.Name}}'
+            - "--port=8080"
+            - "--model=/mnt/models"
+            - "--served-model-name={{.Name}}"
+            - "--distributed-executor-backend=mp"
           env:
             - name: HF_HOME
               value: /tmp/hf_home

--- a/config/runtimes/vllm-template.yaml
+++ b/config/runtimes/vllm-template.yaml
@@ -47,23 +47,6 @@ objects:
           env:
             - name: HF_HOME
               value: /tmp/hf_home
-          readinessProbe:
-            httpGet: 
-              port: 8080
-              path: /health
-            initialDelaySeconds: 5
-          livenessProbe:
-            httpGet: 
-              port: 8080
-              path: /health
-            initialDelaySeconds: 5
-          startupProbe:
-            httpGet:
-              port: 8080
-              path: /health
-            # Allow 12 mins to start
-            failureThreshold: 24
-            periodSeconds: 30
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
- Get rid of probes in all runtimes: the idea is to have the user provide probes in the `InferenceService` definitions instead (https://issues.redhat.com/browse/RHOAIENG-8736)
- vllm: make `command` explicit (https://issues.redhat.com/browse/RHOAIENG-8774)