### PR TITLE
add watch object 'configMap' for metrics dashboard configmap

### DIFF
--- a/controllers/inferenceservice_controller.go
+++ b/controllers/inferenceservice_controller.go
@@ -119,6 +119,7 @@ func (r *OpenshiftInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&routev1.Route{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Owns(&authv1.ClusterRoleBinding{}).
 		Owns(&networkingv1.NetworkPolicy{}).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://github.com/opendatahub-io/odh-model-controller/pull/240 missed watch object `configMap`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**(NOTE) Loopy was tested on fedora only.**

## Test
### Env setup
* Using source
  ~~~
  mkdir /tmp/test
  cd /tmp/test
  git clone git@github.com:Jooho/loopy.git
  cd loopy
  make init  
  ~~~

*  Using docker image
  ~~~
  docker run --name loopy -it  quay.io/jooholee/loopy:latest /bin/bash
  ~~~

## Create a cluster information script
  ~~~
  cd loopy
  
  cat cluster_info.sh
  CLUSTER_CONSOLE_URL=https://console-openshift-console.XXXX
  CLUSTER_API_URL=https://api.XXX:443
  CLUSTER_ADMIN_ID=admin
  CLUSTER_ADMIN_PW=password
  CLUSTER_TOKEN=sha256~XXX
  CLUSTER_TYPE=ROSA
  ~~~


### Install Kserve with a new manifests
~~~
./loopy playbooks run  odh-stable-install-kserve-serverless-on-existing-cluster -p CUSTOM_KSERVE_MANIFESTS=https://github.com/jooho/kserve/tarball/master  -p CUSTOM_ODH_MODEL_CONTROLLER_MANIFESTS=https://github.com/jooho/odh-model-controller/tarball/pr-test-manifests -vvv -i ./cluster_info.sh
~~~

### Deploy sample sklearn model
~~~
./loopy units run test-kserve-sklearn-v2-iris-role -vvv -i ./cluster_info.sh 
~~~

### Checks
1. Verify if configmap for metrics dashboard is created
~~~
oc get configmap -n kserve-demo
~~~




## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
