### PR TITLE
add sanity check on regex match results while determining runtime image

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -60,6 +60,7 @@ const (
 	TgisImageName                    = "text-generation-inference"
 	VllmImageName                    = "vllm"
 	CaikitImageName                  = "caikit-nlp"
+	ServingRuntimeFallBackImageName  = "unsupported"
 )
 
 // openshift

--- a/controllers/testdata/deploy/kserve-unsupported-metrics-serving-runtime.yaml
+++ b/controllers/testdata/deploy/kserve-unsupported-metrics-serving-runtime.yaml
@@ -12,7 +12,7 @@ spec:
         - '--model_name={{.Name}}'
         - '--model_dir=/mnt/models'
         - '--http_port=8080'
-      image: 'kserve/unsupportedimage:v0.12.1'
+      image: 'kserve/dummy-sklearn-server' #This image does not exist. 
       name: kserve-container
       resources:
         limits:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes : https://issues.redhat.com/browse/RHOAIENG-10286 
- Added a sanity check to the regex match array so that the controller does not panic. 
  - If the regex match is not what is expected odh-model-controller will end up creating a configmap for unsupported metrics 
- Modified unit tests to cover this case 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit test coverage
- Try to deploy the SR mentioned in the JIRA and verify odh-model-controller doesn't crash 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
