### PR TITLE
Update ENVTEST_K8S_VERSION for s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/${USER}/odh-model-controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26
+ENVTEST_K8S_VERSION = 1.29
 
 ENGINE ?= docker
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Updated the ENVTEST_K8S_VERSION for s390x support
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- In Makefile, change ENVTEST_K8S_VERSION to 1.29
- Run make -e IMG=quay.io/${USER}/odh-model-controller:latest container-build container-push
- The container-build will internally run the make test command to pass all the unit tests and build image after passing tests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/01a65955-375b-4f81-8d17-36bffedf1c9c">
