### PR TITLE
Updated kustomize labels to kustomize v5 syntax

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -12,53 +12,111 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 
-vars:
-  - fieldref:
-      fieldPath: data.caikit-tgis-image
-    name: caikit-tgis-image
-    objref:
-      apiVersion: v1
+replacements:
+  - source:
       kind: ConfigMap
+      version: v1
       name: odh-model-controller-parameters
-  - fieldref:
-      fieldPath: data.caikit-standalone-image
-    name: caikit-standalone-image
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: odh-model-controller-parameters
-  - fieldref:
       fieldPath: data.tgis-image
-    name: tgis-image
-    objref:
-      apiVersion: v1
+    targets:
+      - select:
+          kind: Template
+          name: caikit-tgis-serving-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
       kind: ConfigMap
+      version: v1
       name: odh-model-controller-parameters
-  - fieldref:
+      fieldPath: data.caikit-tgis-image
+    targets:
+      - select:
+          kind: Template
+          name: caikit-tgis-serving-template
+        fieldPaths:
+          - objects.0.spec.containers.1.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.caikit-standalone-image
+    targets:
+      - select:
+          kind: Template
+          name: caikit-standalone-serving-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.tgis-image
+    targets:
+      - select:
+          kind: Template
+          name: tgis-grpc-serving-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.ovms-image
-    name: ovms-image
-    objref:
-      apiVersion: v1
+    targets:
+      - select:
+          kind: Template
+          name: kserve-ovms
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+      - select:
+          kind: Template
+          name: ovms
+        fieldPaths:
+          - objects.0.spec.containers.0.image    
+  - source:
       kind: ConfigMap
+      version: v1
       name: odh-model-controller-parameters
-  - fieldref:
       fieldPath: data.vllm-image
-    name: vllm-image
-    objref:
-      apiVersion: v1
+    targets:
+      - select:
+          kind: Template
+          name: vllm-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
       kind: ConfigMap
+      version: v1
       name: odh-model-controller-parameters
-  - fieldref:
-      fieldPath: metadata.namespace
-    name: mesh-namespace
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: odh-model-controller-parameters
-  - fieldref:
       fieldPath: data.odh-model-controller
-    name: odh-model-controller
-    objref:
-      apiVersion: v1
+    targets:
+      - select: 
+          kind: Deployment
+          name: odh-model-controller
+        fieldPaths:
+          - spec.template.spec.containers.0.image
+  - source:
       kind: ConfigMap
+      version: v1
       name: odh-model-controller-parameters
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+          name: validating-webhook-configuration
+        fieldPaths:
+          - webhooks.0.clientConfig.service.namespace
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          kind: ClusterRoleBinding
+          name: odh-model-controller-rolebinding-$(mesh_namespace)
+        options:
+          delimiter: '-'
+          index: 4
+        fieldPaths:
+          - metadata.name

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,8 +1,6 @@
-bases:
+resources:
   - ../rbac
   - ../manager
   - ../webhook
   - ../runtimes
-
-resources:
   - networkpolicy.yaml

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -2,8 +2,8 @@ resources:
 - ../../crd/external
 - ../../default
 
-patchesStrategicMerge:
-- odh_model_controller_manager_patch.yaml
+patches:
+- path: odh_model_controller_manager_patch.yaml
 
 namespace: default
 configMapGenerator:
@@ -13,18 +13,16 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: mesh-namespace
-  objref:
-    apiVersion: v1
+
+replacements:
+- source:
     kind: ConfigMap
+    version: v1
     name: odh-model-controller-parameters
-- fieldref:
     fieldPath: data.monitoring-namespace
-  name: monitoring-namespace
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: odh-model-controller-parameters
+  targets:
+  - select:
+      kind: Deployment
+      name: odh-model-controller
+    fieldPaths:
+      - spec.template.spec.containers.0.env.0.value

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - ../../default
 
-patchesStrategicMerge:
-  - odh_model_controller_manager_patch.yaml
-
+patches:
+- path: odh_model_controller_manager_patch.yaml
+  
 configurations:
   - params.yaml

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: odh-model-controller-rolebinding-$(mesh-namespace)
+  name: odh-model-controller-rolebinding-$(mesh_namespace)
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app: odh-dashboard
-  app.kubernetes.io/part-of: odh-dashboard
+labels:
+  - pairs:
+      app: odh-dashboard
+      app.kubernetes.io/part-of: odh-dashboard
+    includeSelectors: true
 resources:
   - ovms-mm-template.yaml
   - caikit-tgis-template.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request addresses the task of upgrading all Kustomize labels and syntax within the repository to the newer v5 standards. The primary goal is to remove all deprecation errors encountered when running the kustomize build command.

### Key updates include:

- Transitioning from deprecated Kustomize syntax to v5 syntax.
- Major changes in the config/base/kustomization.yaml file to replace the deprecated vars section with the new replacements section.
- Updated the variable placeholder in config/rbac/rolebinding.yaml to use a delimiter option for appending the namespace after the 4th hyphen in the name, which required changing:
```
metadata:
  name: odh-model-controller-rolebinding-$(mesh-namespace)
```
to:
```
metadata:
  name: odh-model-controller-rolebinding-$(mesh_namespace)
```
No other functionality or logic was altered—this is strictly a syntax upgrade to align with Kustomize v5 requirements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To ensure the correctness of these changes, the following steps were taken:

1. Ran the kustomize build command on the original manifests to produce the current state of the resources.
2. Updated to Kustomize v5 labels.
3. Ran the kustomize build command again on the updated manifests.
4. Compared the output of the kustomize build command from both the original and updated manifests.
5. Verified that there was no difference between the outputs.

Gist of all kustomize build pre-changes and post-changes:
https://gist.github.com/KillianGolds/b88f6a433b9031df4cd936bdc8d2f1ea

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
