### PR TITLE
RHOAIENG-1044: Update hardcoded constants as environment variables 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" POD_NAMESPACE=default go test -v ./controllers/... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" POD_NAMESPACE=default MESH_NAMESPACE=istio-system CONTROL_PLANE_NAME=istio-system go test -v ./controllers/... -coverprofile cover.out
 
 .PHONY: e2e-test
 e2e-test: manifests generate fmt vet ## Run e2e-tests.

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -18,8 +18,6 @@ package constants
 const (
 	InferenceServiceKind = "InferenceService"
 
-	IstioNamespace                   = "istio-system"
-	IstioControlPlaneName            = "data-science-smcp"
 	ServiceMeshMemberRollName        = "default"
 	ServiceMeshMemberName            = "default"
 	IstioIngressService              = "istio-ingressgateway"

--- a/controllers/kserve_inferenceservice_controller_authconfig_test.go
+++ b/controllers/kserve_inferenceservice_controller_authconfig_test.go
@@ -332,7 +332,8 @@ func createAuthorizationPolicy(authPolicyFile string) error {
 
 	gvr := istiosec_v1b1.SchemeGroupVersion.WithResource("authorizationpolicies")
 	resource := dynamicClient.Resource(gvr)
-	_, createErr := resource.Namespace(constants.IstioNamespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+	_, meshNamespace := utils.GetIstioControlPlaneName(ctx, cli)
+	_, createErr := resource.Namespace(meshNamespace).Create(context.TODO(), obj, metav1.CreateOptions{})
 
 	return createErr
 }
@@ -371,5 +372,6 @@ func deleteAuthorizationPolicy(authPolicyFile string) error {
 	}
 
 	gvr := istiosec_v1b1.SchemeGroupVersion.WithResource("authorizationpolicies")
-	return dynamicClient.Resource(gvr).Namespace(constants.IstioNamespace).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
+	_, meshNamespace := utils.GetIstioControlPlaneName(ctx, cli)
+	return dynamicClient.Resource(gvr).Namespace(meshNamespace).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
 }

--- a/controllers/kserve_inferenceservice_controller_mesh_test.go
+++ b/controllers/kserve_inferenceservice_controller_mesh_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 )
 
 var _ = Describe("The KServe mesh reconciler", func() {
@@ -43,6 +44,7 @@ var _ = Describe("The KServe mesh reconciler", func() {
 	}
 
 	createUserOwnedMeshEnrolment := func(namespace string) *maistrav1.ServiceMeshMember {
+		controlPlaneName, meshNamespace := utils.GetIstioControlPlaneName(ctx, cli)
 		smm := &maistrav1.ServiceMeshMember{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        constants.ServiceMeshMemberName,
@@ -52,8 +54,8 @@ var _ = Describe("The KServe mesh reconciler", func() {
 			},
 			Spec: maistrav1.ServiceMeshMemberSpec{
 				ControlPlaneRef: maistrav1.ServiceMeshControlPlaneRef{
-					Name:      constants.IstioControlPlaneName,
-					Namespace: constants.IstioNamespace,
+					Name:      controlPlaneName,
+					Namespace: meshNamespace,
 				}},
 			Status: maistrav1.ServiceMeshMemberStatus{},
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -18,12 +18,13 @@ package controllers
 import (
 	"context"
 	"fmt"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -52,7 +53,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
 	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -140,10 +140,11 @@ var _ = BeforeSuite(func() {
 	Expect(cli).NotTo(BeNil())
 
 	// Create istio-system namespace
+	_, meshNamespace := utils.GetIstioControlPlaneName(ctx, cli)
 	istioNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.IstioNamespace,
-			Namespace: constants.IstioNamespace,
+			Name:      meshNamespace,
+			Namespace: meshNamespace,
 		},
 	}
 	Expect(cli.Create(ctx, istioNamespace)).Should(Succeed())
@@ -212,7 +213,8 @@ var _ = AfterSuite(func() {
 var _ = AfterEach(func() {
 	cleanUp := func(namespace string, cli client.Client) {
 		inNamespace := client.InNamespace(namespace)
-		istioNamespace := client.InNamespace(constants.IstioNamespace)
+		_, meshNamespace := utils.GetIstioControlPlaneName(ctx, cli)
+		istioNamespace := client.InNamespace(meshNamespace)
 		Expect(cli.DeleteAllOf(context.TODO(), &kservev1alpha1.ServingRuntime{}, inNamespace)).ToNot(HaveOccurred())
 		Expect(cli.DeleteAllOf(context.TODO(), &kservev1beta1.InferenceService{}, inNamespace)).ToNot(HaveOccurred())
 		Expect(cli.DeleteAllOf(context.TODO(), &routev1.Route{}, inNamespace)).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactored the controllers/utils function GetIstioControlPlaneName to no longer reference IstioNamespace and IstioControlPlaneName constants, and to return errors instead of automatically setting the env vars. Removed the constants from the constants/constants.go file, and replaced all references of the constants in the code with a call to the utils function mentioned before. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
