### PR TITLE
[RHOAIENG-11527] - [backend] Incorrect values for number of requests …

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -56,6 +56,7 @@ const (
 	KserveMetricsConfigMapNameSuffix = "-metrics-dashboard"
 	DefaultStorageConfig             = "storage-config"
 	IntervalValue                    = "1m"
+	RequestRateInterval              = "5m"
 	OvmsImageName                    = "openvino_model_server"
 	TgisImageName                    = "text-generation-inference"
 	VllmImageName                    = "vllm"

--- a/controllers/constants/runtime-metrics.go
+++ b/controllers/constants/runtime-metrics.go
@@ -20,16 +20,16 @@ const (
 	CaikitMetricsData = `{
         "config": [
 			{
-				"title": "Number of requests",
+				"title": "Requests per 5 minutes",
 				"type": "REQUEST_COUNT",
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code='OK',model_id='${MODEL_NAME}'}[${REQUEST_RATE_INTERVAL}])))"
 					},
 					{
 						"title": "Number of failed incoming requests",
-						"query": "round(sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code!='OK',model_id='${MODEL_NAME}'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(predict_rpc_count_total{namespace='${NAMESPACE}',code!='OK',model_id='${MODEL_NAME}'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},
@@ -74,16 +74,16 @@ const (
 	OvmsMetricsData = `{
         "config": [
 			{
-				"title": "Number of requests",
+				"title": "Requests per 5 minutes",
 				"type": "REQUEST_COUNT",
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(ovms_requests_success{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(ovms_requests_success{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${REQUEST_RATE_INTERVAL}])))"
 					},
 					{
 						"title": "Number of failed incoming requests",
-						"query": "round(sum(increase(ovms_requests_fail{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(ovms_requests_fail{namespace='${NAMESPACE}',name='${MODEL_NAME}'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},
@@ -128,16 +128,16 @@ const (
 	TgisMetricsData = `{
         "config": [
 			{
-				"title": "Number of requests",
+				"title": "Requests per 5 minutes",
 				"type": "REQUEST_COUNT",
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(tgi_request_success{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(tgi_request_success{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
 					},
 					{
 						"title": "Number of failed incoming requests",
-						"query": "round(sum(increase(tgi_request_failure{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(tgi_request_failure{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},
@@ -182,12 +182,12 @@ const (
 	VllmMetricsData = `{
         "config": [
 			{
-				"title": "Number of requests",
+				"title": "Requests per 5 minutes",
 				"type": "REQUEST_COUNT",
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${RATE_INTERVAL}])))"
+						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},

--- a/controllers/reconcilers/kserve_metrics_dashboard_reconciler.go
+++ b/controllers/reconcilers/kserve_metrics_dashboard_reconciler.go
@@ -17,20 +17,18 @@ package reconcilers
 
 import (
 	"context"
-	"github.com/hashicorp/errwrap"
-	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
-	"regexp"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"strconv"
-	"strings"
-
 	"github.com/go-logr/logr"
+	"github.com/hashicorp/errwrap"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/opendatahub-io/odh-model-controller/controllers/comparators"
 	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
 	"github.com/opendatahub-io/odh-model-controller/controllers/processors"
 	"github.com/opendatahub-io/odh-model-controller/controllers/resources"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
+	"regexp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,17 +144,12 @@ func (r *KserveMetricsDashboardReconciler) createDesiredResource(ctx context.Con
 		return nil, err
 	}
 	if supported {
-		finaldata := substituteVariablesInQueries(data, isvc.Namespace, isvc.Name, constants.IntervalValue)
+		finaldata := utils.SubstituteVariablesInQueries(data, isvc.Namespace, isvc.Name)
 		configMap.Data["metrics"] = finaldata
 	}
 
 	return configMap, nil
 
-}
-
-func substituteVariablesInQueries(data string, namespace string, name string, IntervalValue string) string {
-	replacer := strings.NewReplacer("${NAMESPACE}", namespace, "${MODEL_NAME}", name, "${RATE_INTERVAL}", IntervalValue)
-	return replacer.Replace(data)
 }
 
 func (r *KserveMetricsDashboardReconciler) createConfigMap(isvc *kservev1beta1.InferenceService, supported bool, log logr.Logger) (*corev1.ConfigMap, error) {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kuadrant/authorino/pkg/log"
@@ -398,4 +399,13 @@ func FindSupportingRuntimeForISvc(ctx context.Context, cli client.Client, log lo
 		log.Info("No suitable Runtime available for InferenceService")
 		return desiredServingRuntime, errors.New(constants.NoSuitableRuntimeError)
 	}
+}
+
+func SubstituteVariablesInQueries(data string, namespace string, name string) string {
+	replacer := strings.NewReplacer(
+		"${NAMESPACE}", namespace,
+		"${MODEL_NAME}", name,
+		"${RATE_INTERVAL}", constants.IntervalValue,
+		"${REQUEST_RATE_INTERVAL}", constants.RequestRateInterval)
+	return replacer.Replace(data)
 }


### PR DESCRIPTION
…in Kserve Performance metrics
A summarized decision:
```
Update the chart title to match the approved by UXD. Use "Requests rate per 5 min" the same way as the model mesh to avoid confusion and maintain consistency as it denotes rate instead concrete values.

```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
