### PR TITLE
[RHOAIENG-12726] - odh-model-controller crashes with empty isvc.model field

### DIFF
--- a/controllers/testdata/deploy/kserve-nil-model-inference-service.yaml
+++ b/controllers/testdata/deploy/kserve-nil-model-inference-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: custom-model
+  namespace: default
+spec:
+  predictor:
+    containers:
+      - name: kserve-container
+        image: user/custom-model:v1


### PR DESCRIPTION
Cherry-picks https://github.com/opendatahub-io/odh-model-controller/pull/264