### PR TITLE
[RHOAIENG-7034] Updated manifests to have 1 replica of odh-model-controller pods 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       control-plane: odh-model-controller
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       annotations:

--- a/config/overlays/dev/odh_model_controller_manager_patch.yaml
+++ b/config/overlays/dev/odh_model_controller_manager_patch.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: odh-model-controller
 spec:
-  replicas: 3
+  replicas: 1
   template:
     spec:
       containers:

--- a/config/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/config/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: odh-model-controller
 spec:
-  replicas: 3
   template:
     spec:
       containers:


### PR DESCRIPTION
Updated manifests to have 1 replica of odh-model-controller pods instead of 3. 

- The `config/manager/manager.yaml` is the main definition of odh-model-controller deployment -- change is needed here for replica value to be 1
- The `/overlay/dev` is to define some manifests that we don't want to deploy in ODH/RHOAI but are needed for local development or unit tests -- change is needed for the replica value to be 1
- The `overlays/odh/manager_patch` doesn't need to specify the replicas in this patch file anymore since the main file has it set to 1 -- replica completely removed here. 

Tested by running `kustomize build` after making changes and ensured that the replicas were set to 1 instead of 3. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
