### PR TITLE
[RHOAIENG-15179] remove wrong fields in manifests

### DIFF
--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,13 +1,9 @@
 varReference:
   - path: metadata/name
     kind: ClusterRoleBinding
-    apiGroup: rbac.authorization.k8s.io/v1
   - path: spec/template/spec/containers[]/image
     kind: Deployment
-    apiVersion: apps/v1
   - path: objects[]/spec/containers[]/image
     kind: Template
-    apiVersion: template.openshift.io/v1
   - path: webhooks/clientConfig[]/service/namespace
     kind: ValidatingWebhookConfiguration
-    apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Kustomize can not generate manifests
https://issues.redhat.com/browse/RHOAIENG-15179

error:
```
kustomize build ./config/overlays/odh/ --stack-trace
Error: error unmarshaling JSON: while decoding JSON: json: unknown field "apiGroup"

kustomize build config/base/
Error: accumulating resources: accumulation err='accumulating resources from '../overlays/odh': '/tmp/test/odh-model-controller/config/overlays/odh' must resolve to a file': recursed accumulation of path '/tmp/test/odh-model-controller/config/overlays/odh': error unmarshaling JSON: while decoding JSON: json: unknown field "apiGroup"

```

how to test:
```
kustomize build ./config/overlay/odh
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
