### PR TITLE
[RHOAIENG-15207] Removed the $(mesh_namespace) variable from manifests

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -136,17 +136,3 @@ replacements:
           name: validating-webhook-configuration
         fieldPaths:
           - webhooks.0.clientConfig.service.namespace
-  - source:
-      kind: ConfigMap
-      version: v1
-      name: odh-model-controller-parameters
-      fieldPath: metadata.namespace
-    targets:
-      - select:
-          kind: ClusterRoleBinding
-          name: odh-model-controller-rolebinding-$(mesh_namespace)
-        options:
-          delimiter: '-'
-          index: 4
-        fieldPaths:
-          - metadata.name

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: odh-model-controller-rolebinding-$(mesh_namespace)
+  name: odh-model-controller-rolebinding-opendatahub
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the unused variable `$(mesh_namespace)` from the manifests and added the `-opendatahub` suffix to be hardcoded instead. 

## Description
Removed the specification of how the ClusterRoleBinding resource should be defined in the `config/base/kustomization.yaml` file, and removed the variable from the `config/rbac/role_binding.yaml` file.

## How Has This Been Tested?
Ensured that the `-opendatahub` suffix persisted in the RHOAI 2.16 builds where many manifests were changed. The suffix persisting confirmed that the variable could be disposed of. Building the kustomize file with the removed variable resulted in the same manifests that were built with the variable there.