### PR TITLE
fix: nim pull secret name in servingrutime template

### DIFF
--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
-	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
 	"io"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -355,7 +354,7 @@ func GetNimServingRuntimeTemplate() *v1alpha1.ServingRuntime {
 				},
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{
-						Name: constants.NimPullSecretName,
+						Name: "ngc-secret",
 					},
 				},
 				Volumes: []corev1.Volume{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The pull secret name in the ServingRuntime im NVIDIA NIM template should be set to a static `ngc-secret`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
