### PR TITLE
Pin vLLM images for Gaudi and ROCM

### DIFF
--- a/config/base/params-vllm-gaudi.env
+++ b/config/base/params-vllm-gaudi.env
@@ -1,1 +1,1 @@
-vllm-gaudi-image=quay.io/opendatahub/vllm:stable-gaudi
+vllm-gaudi-image=quay.io/opendatahub/vllm:stable-gaudi-4f9d7e5

--- a/config/base/params-vllm-rocm.env
+++ b/config/base/params-vllm-rocm.env
@@ -1,1 +1,1 @@
-vllm-rocm-image=quay.io/opendatahub/vllm:stable-rocm
+vllm-rocm-image=quay.io/opendatahub/vllm:stable-rocm-9ac4882


### PR DESCRIPTION
Because we need images pinned to generate stable ODH releases