### PR TITLE
update global ca bundle logic and storage-config logic

### DIFF
--- a/controllers/kserve_customcacert_controller.go
+++ b/controllers/kserve_customcacert_controller.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/opendatahub-io/odh-model-controller/controllers/constants"
@@ -56,7 +57,7 @@ func (r *KServeCustomCACertReconciler) reconcileConfigMap(configmap *corev1.Conf
 		}
 		configmap = odhCustomCertConfigMap
 	}
-	odhCustomCertData = configmap.Data[constants.ODHCustomCACertFileName]
+	odhCustomCertData = strings.TrimSpace(configmap.Data[constants.ODHCustomCACertFileName])
 
 	// Create Desired resource
 	configData := map[string]string{kserveCustomCACertFileName: odhCustomCertData}

--- a/controllers/storageconfig_controller.go
+++ b/controllers/storageconfig_controller.go
@@ -104,19 +104,18 @@ func (r *StorageSecretReconciler) reconcileSecret(secret *corev1.Secret,
 	odhCustomCertData := ""
 	odhGlobalCertConfigMap := &corev1.ConfigMap{}
 	err = r.Get(ctx, types.NamespacedName{
-		Name:      constants.ODHGlobalCertConfigMapName,
+		Name:      constants.KServeCACertConfigMapName,
 		Namespace: secret.Namespace,
 	}, odhGlobalCertConfigMap)
 
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			log.Info("unable to fetch the ODH Global Cert ConfigMap", "error", err)
-
 		} else {
 			return err
 		}
 	} else {
-		odhCustomCertData = odhGlobalCertConfigMap.Data[constants.ODHCustomCACertFileName]
+		odhCustomCertData = odhGlobalCertConfigMap.Data[constants.KServeCACertFileName]
 	}
 
 	// Generate desire Storage Config Secret

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -71,24 +71,25 @@ var (
 )
 
 const (
-	WorkingNamespace                = "default"
-	MonitoringNS                    = "monitoring-ns"
-	RoleBindingPath                 = "./testdata/results/model-server-ns-role.yaml"
-	ServingRuntimePath1             = "./testdata/deploy/test-openvino-serving-runtime-1.yaml"
-	KserveServingRuntimePath1       = "./testdata/deploy/kserve-openvino-serving-runtime-1.yaml"
-	ServingRuntimePath2             = "./testdata/deploy/test-openvino-serving-runtime-2.yaml"
-	InferenceService1               = "./testdata/deploy/openvino-inference-service-1.yaml"
-	InferenceServiceNoRuntime       = "./testdata/deploy/openvino-inference-service-no-runtime.yaml"
-	KserveInferenceServicePath1     = "./testdata/deploy/kserve-openvino-inference-service-1.yaml"
-	InferenceServiceConfigPath1     = "./testdata/configmaps/inferenceservice-config.yaml"
-	ExpectedRoutePath               = "./testdata/results/example-onnx-mnist-route.yaml"
-	ExpectedRouteNoRuntimePath      = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
-	DSCIWithAuthorization           = "./testdata/dsci-with-authorino-enabled.yaml"
-	DSCIWithoutAuthorization        = "./testdata/dsci-with-authorino-missing.yaml"
-	KServeAuthorizationPolicy       = "./testdata/kserve-authorization-policy.yaml"
-	odhtrustedcabundleConfigMapPath = "./testdata/configmaps/odh-trusted-ca-bundle-configmap.yaml"
-	timeout                         = time.Second * 20
-	interval                        = time.Millisecond * 10
+	WorkingNamespace                     = "default"
+	MonitoringNS                         = "monitoring-ns"
+	RoleBindingPath                      = "./testdata/results/model-server-ns-role.yaml"
+	ServingRuntimePath1                  = "./testdata/deploy/test-openvino-serving-runtime-1.yaml"
+	KserveServingRuntimePath1            = "./testdata/deploy/kserve-openvino-serving-runtime-1.yaml"
+	ServingRuntimePath2                  = "./testdata/deploy/test-openvino-serving-runtime-2.yaml"
+	InferenceService1                    = "./testdata/deploy/openvino-inference-service-1.yaml"
+	InferenceServiceNoRuntime            = "./testdata/deploy/openvino-inference-service-no-runtime.yaml"
+	KserveInferenceServicePath1          = "./testdata/deploy/kserve-openvino-inference-service-1.yaml"
+	InferenceServiceConfigPath1          = "./testdata/configmaps/inferenceservice-config.yaml"
+	ExpectedRoutePath                    = "./testdata/results/example-onnx-mnist-route.yaml"
+	ExpectedRouteNoRuntimePath           = "./testdata/results/example-onnx-mnist-no-runtime-route.yaml"
+	DSCIWithAuthorization                = "./testdata/dsci-with-authorino-enabled.yaml"
+	DSCIWithoutAuthorization             = "./testdata/dsci-with-authorino-missing.yaml"
+	KServeAuthorizationPolicy            = "./testdata/kserve-authorization-policy.yaml"
+	odhtrustedcabundleConfigMapPath      = "./testdata/configmaps/odh-trusted-ca-bundle-configmap.yaml"
+	odhKserveCustomCABundleConfigMapPath = "./testdata/configmaps/odh-kserve-custom-ca-cert-configmap.yaml"
+	timeout                              = time.Second * 20
+	interval                             = time.Millisecond * 10
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/go-logr/logr v1.3.0
+	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kserve/kserve v0.12.1
 	github.com/kuadrant/authorino v0.15.0
@@ -11,6 +12,7 @@ require (
 	github.com/onsi/gomega v1.30.0
 	github.com/opendatahub-io/model-registry v0.1.1
 	github.com/openshift/api v3.9.0+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.1
 	github.com/tidwall/gjson v1.17.0
 	go.uber.org/zap v1.26.0
@@ -62,7 +64,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -74,7 +75,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ODH Operator changed the default string for customCA: https://github.com/opendatahub-io/opendatahub-operator/pull/1339
With this change, odh-model-controller need to change  some logic

1. customcacert logic 
small change - it simply trim new lines in cert data.
With this change, if there is only newlines in the cert data, it will not create a kserve custom cert cm.

2. storage-config logic
It was checking if global cert cm (odh-trusted-ca-bundle) exist but now it is checking if kserve custom cert cm(odh-kserve-custom-ca-bundle) exist. If so, it will add the certificate information into `storage-config`

ref https://issues.redhat.com/browse/RHOAIENG-16070
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Setup
1. Deploy the latest kserve using odh operator
2. Update odh-model-controller image with quay.io/opendatahub/odh-model-controller:pr-308

Test
1. check if the kserve custom cert cm(odh-kserve-custom-ca-bundle) exist. by default, it should not be created.
2. update dsci 
~~~
    trustedCABundle:
      customCABundle: |
        ---TEST---
        TST
        ---TEST---
~~~
then check if  the kserve custom cert cm(odh-kserve-custom-ca-bundle) exist. it should be created.
Plus, storage-config secret should include the information like the following:
```
{"access_key_id":"XXX","bucket":"XXX","cabundle_configmap":"odh-kserve-custom-ca-bundle","certificate":"---TEST---\nTST\n---TEST---","default_bucket":"XXX","endpoint_url":"https://s3.amazonaws.com/","region":"us-east-1","secret_access_key":"XXX","type":"s3"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
