### PR TITLE
[RHOAIENG-13638] - Do not allow isvc creation in protected isvc

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -4,3 +4,4 @@ caikit-standalone-image=quay.io/opendatahub/caikit-nlp:fast
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2024.3-release
 vllm-image=quay.io/opendatahub/vllm:fast
+

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -5,6 +5,25 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-isvc-odh-service
+  failurePolicy: Fail
+  name: validating.isvc.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - inferenceservices
+  sideEffects: None
+- admissionReviewVersions:
   - v1
   clientConfig:
     service:

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -17,3 +17,7 @@ webhooks:
     clientConfig:
       service:
         name: odh-model-controller-webhook-service
+  - name: validating.isvc.odh-model-controller.opendatahub.io
+    clientConfig:
+      service:
+        name: odh-model-controller-webhook-service

--- a/controllers/kserve_inferenceservice_controller_metrics_test.go
+++ b/controllers/kserve_inferenceservice_controller_metrics_test.go
@@ -63,7 +63,6 @@ var _ = Describe("The KServe Dashboard reconciler", func() {
 		if err := cli.Create(ctx, inferenceServiceConfig); err != nil && !errors.IsAlreadyExists(err) {
 			Fail(err.Error())
 		}
-
 	})
 
 	When("deploying a Kserve model", func() {

--- a/controllers/storageconfig_controller_test.go
+++ b/controllers/storageconfig_controller_test.go
@@ -183,7 +183,7 @@ var _ = Describe("StorageConfig controller", func() {
 			expectedUpdatedStorageConfigSecret := &corev1.Secret{}
 			err = convertToStructuredResource(storageconfigUpdatedCertEncodedPath, expectedUpdatedStorageConfigSecret)
 			Expect(err).NotTo(HaveOccurred())
-			
+
 			Expect(compareSecrets(updatedStorageconfigSecret, expectedUpdatedStorageConfigSecret)).Should((BeTrue()))
 		})
 	})

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -264,6 +264,25 @@ func VerifyIfMeshAuthorizationIsEnabled(ctx context.Context, cli client.Client) 
 	return false, nil
 }
 
+// GetApplicationNamespace returns the namespace where the application components are installed.
+// defaults to: RHOAI - redhat-ods-applications, ODH: opendatahub
+func GetApplicationNamespace(ctx context.Context, cli client.Client) (string, error) {
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	objectList, err := getDSCIObject(ctx, cli)
+	if err != nil {
+		log.V(0).Error(err, "Failed to fetch the DSCI object")
+		return "", err
+	}
+
+	for _, item := range objectList.Items {
+		ns, _, _ := unstructured.NestedString(item.Object, "spec", "applicationsNamespace")
+		if len(ns) > 0 {
+			podNamespace = ns
+		}
+	}
+	return podNamespace, nil
+}
+
 func IsNil(i any) bool {
 	return reflect.ValueOf(i).IsNil()
 }

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-logr/logr"
-	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/go-logr/logr"
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kuadrant/authorino/pkg/log"
@@ -37,6 +38,8 @@ var (
 	ModelMesh     IsvcDeploymentMode = "ModelMesh"
 
 	gvResourcesCache map[string]*metav1.APIResourceList
+
+	_appNamespace *string
 )
 
 const (
@@ -267,6 +270,10 @@ func VerifyIfMeshAuthorizationIsEnabled(ctx context.Context, cli client.Client) 
 // GetApplicationNamespace returns the namespace where the application components are installed.
 // defaults to: RHOAI - redhat-ods-applications, ODH: opendatahub
 func GetApplicationNamespace(ctx context.Context, cli client.Client) (string, error) {
+	if _appNamespace != nil {
+		return *_appNamespace, nil
+	}
+
 	podNamespace := os.Getenv("POD_NAMESPACE")
 	objectList, err := getDSCIObject(ctx, cli)
 	if err != nil {
@@ -280,6 +287,7 @@ func GetApplicationNamespace(ctx context.Context, cli client.Client) (string, er
 			podNamespace = ns
 		}
 	}
+	_appNamespace = &podNamespace
 	return podNamespace, nil
 }
 

--- a/controllers/webhook/isvc_validator.go
+++ b/controllers/webhook/isvc_validator.go
@@ -75,8 +75,8 @@ func (is *IsvcValidator) Handle(ctx context.Context, req admission.Request) admi
 	for _, ns := range protectedNamespaces {
 		if isvc.Namespace == ns {
 			log.V(1).Info("Namespace is protected, the InferenceService will not be created")
-			return admission.Denied(fmt.Sprintf("Namespace %s is protected, the InferenceService %s "+
-				"will not be created", isvc.Namespace, isvc.Name))
+			return admission.Denied(fmt.Sprintf("The InferenceService %s "+
+				"cannot be created in protected namespace %s.", isvc.Name, isvc.Namespace))
 		}
 	}
 	log.Info("Namespace is not protected")

--- a/controllers/webhook/isvc_validator.go
+++ b/controllers/webhook/isvc_validator.go
@@ -1,0 +1,84 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// +kubebuilder:webhook:admissionReviewVersions=v1beta1,path=/validate-isvc-odh-service,mutating=false,failurePolicy=fail,groups="serving.kserve.io",resources=inferenceservices,verbs=create,versions=v1beta1,name=validating.isvc.odh-model-controller.opendatahub.io,sideEffects=None
+
+type IsvcValidator struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// NewIsvcValidator For tests purposes
+func NewIsvcValidator(client client.Client, decoder *admission.Decoder) *IsvcValidator {
+	return &IsvcValidator{
+		Client:  client,
+		Decoder: decoder,
+	}
+}
+
+// Handle implements admission.Validator so a webhook will be registered for the type serving.kserve.io.inferenceServices
+// This webhook will filter out the protected namespaces preventing the user to create the InferenceService in those namespaces
+// which are: The Istio control plane namespace, Application namespace and Serving namespace
+// func (is *isvcValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+func (is *IsvcValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	protectedNamespaces := make([]string, 3)
+	// hardcoding for now since there is no plan to install knative on other namespaces
+	protectedNamespaces[0] = "knative-serving"
+
+	log := logf.FromContext(ctx).WithName("InferenceServiceValidatingWebhook")
+
+	isvc := &kservev1beta1.InferenceService{}
+	errs := is.Decoder.Decode(req, isvc)
+	if errs != nil {
+		return admission.Errored(http.StatusBadRequest, errs)
+	}
+
+	log = log.WithValues("namespace", isvc.Namespace, "isvc", isvc.Name)
+	log.Info("Validating InferenceService")
+
+	_, meshNamespace := utils.GetIstioControlPlaneName(ctx, is.Client)
+	protectedNamespaces[1] = meshNamespace
+
+	appNamespace, err := utils.GetApplicationNamespace(ctx, is.Client)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	protectedNamespaces[2] = appNamespace
+
+	log.Info("Filtering protected namespaces", "namespaces", protectedNamespaces)
+	for _, ns := range protectedNamespaces {
+		if isvc.Namespace == ns {
+			log.V(1).Info("Namespace is protected, the InferenceService will not be created")
+			return admission.Denied(fmt.Sprintf("Namespace %s is protected, the InferenceService %s "+
+				"will not be created", isvc.Namespace, isvc.Name))
+		}
+	}
+	log.Info("Namespace is not protected")
+	return admission.Allowed("Namespace is not protected")
+}

--- a/controllers/webhook/ksvc_validator.go
+++ b/controllers/webhook/ksvc_validator.go
@@ -1,3 +1,18 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (

--- a/controllers/webhook/nim_account_webhook.go
+++ b/controllers/webhook/nim_account_webhook.go
@@ -1,3 +1,18 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package webhook
 
 import (

--- a/controllers/webhook_isvc_validator_test.go
+++ b/controllers/webhook_isvc_validator_test.go
@@ -1,0 +1,108 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
+	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("Inference Service validator webhook", func() {
+	var validator *webhook.IsvcValidator
+	var meshNamespace, appsNamespace string
+
+	createInferenceService := func(namespace, name string) *kservev1beta1.InferenceService {
+		inferenceService := &kservev1beta1.InferenceService{}
+		err := convertToStructuredResource(KserveInferenceServicePath1, inferenceService)
+		Expect(err).NotTo(HaveOccurred())
+		inferenceService.SetNamespace(namespace)
+		if len(name) != 0 {
+			inferenceService.Name = name
+		}
+		Expect(cli.Create(ctx, inferenceService)).Should(Succeed())
+		return inferenceService
+	}
+
+	BeforeEach(func() {
+		_, meshNamespace = utils.GetIstioControlPlaneName(ctx, cli)
+		appsNamespace, _ = utils.GetApplicationNamespace(ctx, cli)
+		validator = webhook.NewIsvcValidator(cli, admission.NewDecoder(cli.Scheme()))
+	})
+
+	It("Should allow the Inference Service in the test-model namespace", func() {
+		testNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-model",
+				Namespace: "test-model",
+			},
+		}
+		Expect(cli.Create(ctx, testNs)).Should(Succeed())
+
+		isvc := createInferenceService(testNs.Name, "test-isvc")
+		isvcBytes, err := json.Marshal(isvc)
+		Expect(err).NotTo(HaveOccurred())
+		response := validator.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: testNs.Name, Name: "test-isvc",
+				Object: runtime.RawExtension{Raw: isvcBytes}}})
+		Expect(response.Allowed).To(BeTrue())
+	})
+
+	It("Should not allow the Inference Service in the ServiceMesh namespace", func() {
+		isvc := createInferenceService(meshNamespace, "test-isvc")
+		isvcBytes, err := json.Marshal(isvc)
+		Expect(err).NotTo(HaveOccurred())
+		response := validator.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: meshNamespace, Name: "test-isvc",
+				Object: runtime.RawExtension{Raw: isvcBytes}}})
+		Expect(response.Allowed).To(BeFalse())
+	})
+
+	It("Should not allow the Inference Service in the ApplicationsNamespace namespace", func() {
+		isvc := createInferenceService(appsNamespace, "test-isvc")
+		isvcBytes, err := json.Marshal(isvc)
+		Expect(err).NotTo(HaveOccurred())
+		response := validator.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: appsNamespace, Name: "test-isvc",
+				Object: runtime.RawExtension{Raw: isvcBytes}}})
+		Expect(response.Allowed).To(BeFalse())
+	})
+
+	It("Should not allow the Inference Service in the knative-serving namespace", func() {
+		testNs := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "knative-serving",
+				Namespace: "knative-serving",
+			},
+		}
+		Expect(cli.Create(ctx, testNs)).Should(Succeed())
+		isvc := createInferenceService(testNs.Name, "test-isvc")
+		isvcBytes, err := json.Marshal(isvc)
+		Expect(err).NotTo(HaveOccurred())
+		response := validator.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: testNs.Name, Name: "test-isvc",
+				Object: runtime.RawExtension{Raw: isvcBytes}}})
+		Expect(response.Allowed).To(BeFalse())
+	})
+})

--- a/controllers/webhook_ksvc_validator_test.go
+++ b/controllers/webhook_ksvc_validator_test.go
@@ -1,3 +1,18 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (

--- a/main.go
+++ b/main.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"flag"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"strconv"
 
-	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -31,14 +29,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	// to ensure that exec-entrypoint and run can make use of them.
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/opendatahub-io/odh-model-controller/controllers"
 	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
+	"github.com/opendatahub-io/odh-model-controller/controllers/webhook"
 	"istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
chore:	Fixes [RHOAIENG-13638] - Kserve model is not Ready after a kserve model is created and deleted from `istio-system` namespace


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Unit tests and test on cluster.

To test it use the following DSC:

```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/spolti/odh-model-controller/tarball/RHOAIENG-13638-t'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            secretName: knative-serving-cert
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    modelregistry:
      registriesNamespace: odh-model-registries
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Removed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    trainingoperator: {}
```

Try to create a new ISVC using one of the protected namespaces:

- knative-serving
- Application Namespace
- Mesh Namespace

ISVC:
```yaml
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: example-onnx-mnist
  # annotations:
  #   serving.kserve.io/deploymentMode: ModelMesh
spec:
  predictor:
    model:
      modelFormat:
        name: onnx
      runtime: ovms-1.x
      storage:
        key: localMinIO
        path: onnx/mnist.onnx
        parameters: # Parameters to override the default values inside the common secret.
          bucket: modelmesh-example-models
```


You should receive a issue like this preventing the isvc to be created:

```bash
$ oc create -f mnist-isvc.yaml -n opendatahub
Error from server (Forbidden): error when creating "mnist-isvc.yaml": admission webhook "validating.isvc.odh-model-controller.opendatahub.io" denied the request: namespace opendatahub is protected, The InferenceService example-onnx-mnist will not be created
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
