### PR TITLE
feat: added performance metric grpahs config for nvidia nim

### DIFF
--- a/controllers/constants/runtime-metrics.go
+++ b/controllers/constants/runtime-metrics.go
@@ -223,4 +223,54 @@ const (
 			}
 		]
     }`
+
+	// NVIDIA NIM
+	NIMMetricsData = `{
+        "config": [
+			{
+				"title": "Requests per 5 minutes",
+				"type": "REQUEST_COUNT",
+				"queries": [
+					{
+						"title": "Number of successful incoming requests",
+						"query": "round(sum(increase(request_success_total{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
+					},
+					{
+						"title": "Number of failed incoming requests",
+						"query": "round(sum(increase(request_failure_total{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
+					}
+				]
+			},
+{
+				"title": "Average response time (ms)",
+				"type": "MEAN_LATENCY",
+				"queries": [
+					{
+						"title": "Average e2e latency",
+						"query": "sum by (model_name) (rate(e2e_request_latency_seconds_sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]) * 1000) / sum by (model_name) (rate(e2e_request_latency_seconds_count{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]) * 1000)"
+					}
+				]
+			},
+			{
+				"title": "CPU utilization %",
+				"type": "CPU_USAGE",
+				"queries": [
+					{
+						"title": "CPU usage",
+						"query":  "sum(pod:container_cpu_usage:sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='cpu', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			},
+			{
+				"title": "Memory utilization %",
+				"type": "MEMORY_USAGE",
+				"queries": [
+					{
+						"title": "Memory usage",
+						"query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='memory', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			}
+		]
+    }`
 )

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -91,7 +91,7 @@ const (
 	nimGetNgcCatalog         = "https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER"
 	nimGetNgcToken           = "https://authn.nvidia.com/token?service=ngc&"
 	nimGetNgcModelDataFmt    = "https://api.ngc.nvidia.com/v2/org/%s/team/%s/repos/%s?resolve-labels=true"
-	IsNimRuntimeAnnotation   = "openshift.io/nvidia-nim-runtime"
+	IsNimRuntimeAnnotation   = "runtimes.opendatahub.io/nvidia-nim"
 )
 
 var NimHttpClient HttpClient

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -91,6 +91,7 @@ const (
 	nimGetNgcCatalog         = "https://api.ngc.nvidia.com/v2/search/catalog/resources/CONTAINER"
 	nimGetNgcToken           = "https://authn.nvidia.com/token?service=ngc&"
 	nimGetNgcModelDataFmt    = "https://api.ngc.nvidia.com/v2/org/%s/team/%s/repos/%s?resolve-labels=true"
+	IsNimRuntimeAnnotation   = "openshift.io/nvidia-nim-runtime"
 )
 
 var NimHttpClient HttpClient
@@ -296,6 +297,7 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 			Annotations: map[string]string{
 				"opendatahub.io/recommended-accelerators": "[\"nvidia.com/gpu\"]",
 				"openshift.io/display-name":               "NVIDIA NIM",
+				IsNimRuntimeAnnotation:                    "true",
 			},
 			Labels: map[string]string{
 				"opendatahub.io/dashboard": "true",
@@ -304,6 +306,10 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 		},
 		Spec: v1alpha1.ServingRuntimeSpec{
 			ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+				Annotations: map[string]string{
+					"prometheus.io/path": "/metrics",
+					"prometheus.io/port": "8000",
+				},
 				Containers: []corev1.Container{
 					{Env: []corev1.EnvVar{
 						{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added metrics graphs configuration for NVIDIA NIM runtimes, including logic for identifying said runtimes:
| Graph | Query |
| ------ | ------ |
| Requests per 5 minutes | Number of successful incoming requests |
|  | Number of failed incoming requests |
| Average response time (ms) | Average inference latency **(not included)** |
|  | Average e2e latency |
| CPU utilization %	| CPU usage |
| Memory utilization % | Memory usage |

Currently, NIM runtimes do not report inference latency (see [here](https://docs.nvidia.com/nim/large-language-models/latest/observability.html)). Hence, the _Average inference latency_ query is **NOT** included in this PR.

**This PR includes**:
- Modifying the Template for NIM's ServingRuntimes:
  - Adding runtime metadata annotation for identification.
  - Adding runtime spec annotations for ISTIO Prometheus metrics merge.
- Adding metrics JSON object encapsulating NVIDIA NIM queries.
- Modified metrics JSON selection process to return the new NVIDIA NIM object for runtimes annotated accordingly.

Jira: [NVPE-30](https://issues.redhat.com/browse/NVPE-30).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This work was tested against an OpenShift cluster (dev04):
- I deployed NIM runtime.
- I executed a couple of requests against the runtime.
- I connected to the ISTIO sidecar and verified the metrics merge.
- I opened the related graphs page and verified them (see attached snapshot).

![image](https://github.com/user-attachments/assets/dd89c871-d589-40ba-a1fd-7b097d6d2ae8)

> [!NOTE]  
> Since graphs are currently turned off for NIM runtimes, after enabling locally on my computer, the snapshot was taken from a frontend running on my local against the remote cluster. Jira for enabling: [NVPE-18](https://issues.redhat.com/browse/NVPE-18)

> [!NOTE]
> Building and testing the queries required enabling monitoring for user-defined projects (see [here](https://docs.openshift.com/container-platform/4.17/observability/monitoring/enabling-monitoring-for-user-defined-projects.html)), to make the runtime metrics available from OpenShift Metrics dashboard.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
