### PR TITLE
chore: added pagination support for nim catalog response

### DIFF
--- a/controllers/nim_account_controller_test.go
+++ b/controllers/nim_account_controller_test.go
@@ -74,6 +74,9 @@ var _ = Describe("NIM Account Controller Test Cases", func() {
 		Expect(cli.Get(ctx, pullSecretSubject, pullSecret)).To(Succeed())
 		Expect(pullSecret.OwnerReferences[0]).To(Equal(expectedOwner))
 
+		By("Verify models info")
+		Expect(dataCmap.Data).To(HaveLen(2))
+
 		By("Cleanups")
 		apiKeySecret := &corev1.Secret{}
 		apiKeySubject := namespacedNameFromReference(&account.Spec.APIKeySecret)

--- a/controllers/testdata/nim/ngc_catalog_response_page_0.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_0.json
@@ -1,0 +1,238 @@
+{
+  "resultTotal": 2,
+  "resultPageTotal": 2,
+  "params": {
+    "orderBy": [
+      {
+        "field": "score",
+        "value": "DESC"
+      }
+    ],
+    "queryFields": [
+      "name",
+      "displayName",
+      "all",
+      "publisher",
+      "builtBy",
+      "description"
+    ],
+    "scoredSize": 1,
+    "pageSize": 1,
+    "fields": [
+      "weight_popular",
+      "ace_name",
+      "date_created",
+      "resource_type",
+      "description",
+      "display_name",
+      "created_by",
+      "weight_featured",
+      "team_name",
+      "labels",
+      "shared_with_orgs",
+      "date_modified",
+      "shared_with_teams",
+      "is_public",
+      "name",
+      "resource_id",
+      "attributes",
+      "org_name",
+      "guest_access",
+      "msg_timestamp",
+      "status"
+    ],
+    "page": 0,
+    "filters": [
+      {
+        "field": "orgName",
+        "value": "nim"
+      },
+      {
+        "field": "resourceType",
+        "value": "container"
+      },
+      {
+        "field": "accessType",
+        "value": "LISTED"
+      },
+      {
+        "field": "isPublic",
+        "value": "true"
+      }
+    ],
+    "query": "*:*",
+    "groupBy": "resourceType"
+  },
+  "results": [
+    {
+      "totalCount": 1,
+      "groupValue": "_scored",
+      "resources": [
+        {
+          "orgName": "nim",
+          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
+          "labels": [
+            {
+              "values": [
+                "NSPECT-Y9G4-II8Q",
+                "NVIDIA AI Enterprise Supported",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nv-ai-enterprise",
+                "nim-dev"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/microsoft"
+          ],
+          "teamName": "microsoft",
+          "msgTimestamp": 1729620896993,
+          "dateModified": "2024-10-22T18:14:56.808Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
+          "dateCreated": "2024-10-18T04:04:45.314Z",
+          "weightPopular": 249.5,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "Phi-3-Mini-4K-Instruct",
+          "name": "phi-3-mini-4k-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.2.3"
+            },
+            {
+              "key": "size",
+              "value": "6835134649"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-10-18T04:07:55.199Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "totalCount": 2,
+      "groupValue": "CONTAINER",
+      "resources": [
+        {
+          "orgName": "nim",
+          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
+          "labels": [
+            {
+              "values": [
+                "NSPECT-Y9G4-II8Q",
+                "NVIDIA AI Enterprise Supported",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nv-ai-enterprise",
+                "nim-dev"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/microsoft"
+          ],
+          "teamName": "microsoft",
+          "msgTimestamp": 1729620896993,
+          "dateModified": "2024-10-22T18:14:56.808Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
+          "dateCreated": "2024-10-18T04:04:45.314Z",
+          "weightPopular": 249.5,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "Phi-3-Mini-4K-Instruct",
+          "name": "phi-3-mini-4k-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.2.3"
+            },
+            {
+              "key": "size",
+              "value": "6835134649"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-10-18T04:07:55.199Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/controllers/testdata/nim/ngc_catalog_response_page_1.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_1.json
@@ -1,6 +1,6 @@
 {
   "resultTotal": 2,
-  "resultPageTotal": 1,
+  "resultPageTotal": 2,
   "params": {
     "orderBy": [
       {
@@ -41,7 +41,7 @@
       "msg_timestamp",
       "status"
     ],
-    "page": 0,
+    "page": 1,
     "filters": [
       {
         "field": "orgName",
@@ -153,85 +153,6 @@
       "totalCount": 2,
       "groupValue": "CONTAINER",
       "resources": [
-        {
-          "orgName": "nim",
-          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
-          "labels": [
-            {
-              "values": [
-                "NSPECT-Y9G4-II8Q",
-                "NVIDIA AI Enterprise Supported",
-                "NVIDIA NIM"
-              ],
-              "key": "general"
-            },
-            {
-              "values": [
-                "signed images"
-              ],
-              "key": "system"
-            },
-            {
-              "values": [
-                "true"
-              ],
-              "key": "hasSignedTag"
-            },
-            {
-              "values": [
-                "NVIDIA"
-              ],
-              "key": "publisher"
-            },
-            {
-              "values": [
-                "nv-ai-enterprise",
-                "nim-dev"
-              ],
-              "key": "productNames"
-            }
-          ],
-          "sharedWithTeams": [
-            "nim/microsoft"
-          ],
-          "teamName": "microsoft",
-          "msgTimestamp": 1729620896993,
-          "dateModified": "2024-10-22T18:14:56.808Z",
-          "sharedWithOrgs": [],
-          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
-          "dateCreated": "2024-10-18T04:04:45.314Z",
-          "weightPopular": 249.5,
-          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
-          "displayName": "Phi-3-Mini-4K-Instruct",
-          "name": "phi-3-mini-4k-instruct",
-          "resourceType": "CONTAINER",
-          "attributes": [
-            {
-              "key": "latestTag",
-              "value": "1.2.3"
-            },
-            {
-              "key": "size",
-              "value": "6835134649"
-            },
-            {
-              "key": "hasSignedTag",
-              "value": "true"
-            },
-            {
-              "key": "oneClickDeploy",
-              "value": "false"
-            },
-            {
-              "key": "latestTagPushedDate",
-              "value": "2024-10-18T04:07:55.199Z"
-            },
-            {
-              "key": "logo",
-              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
-            }
-          ]
-        },
         {
           "orgName": "nim",
           "resourceId": "nim/meta/llama-3.1-8b-instruct",

--- a/controllers/testdata/nvidia_api_mock.go
+++ b/controllers/testdata/nvidia_api_mock.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	"io"
 	"net/http"
@@ -40,7 +41,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		catParams := &utils.NimCatalogQuery{}
 		_ = json.Unmarshal([]byte(req.URL.Query().Get("q")), catParams)
 		if catParams.Query == "orgName:nim" {
-			f, _ := os.ReadFile("testdata/nim/ngc_catalog_response.json")
+			f, _ := os.ReadFile(fmt.Sprintf("testdata/nim/ngc_catalog_response_page_%d.json", catParams.Page))
 			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(f))}, nil
 		}
 	}
@@ -50,7 +51,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		if req.URL.Query().Get("account") == "$oauthtoken" && req.URL.Query().Get("offline_token") == "true" {
 			if req.URL.Query().Get("scope") == "repository:nim/microsoft/phi-3-mini-4k-instruct:pull" {
 				// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
-				// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+				// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_0.json
 				authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 				token, _ := base64.StdEncoding.DecodeString(authHeaderParts[1])
 				if authHeaderParts[0] == "Basic" && string(token) == "$oauthtoken:"+FakeApiKey {
@@ -65,7 +66,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	if req.URL.Host == "nvcr.io" && req.URL.Path == "/v2/nim/microsoft/phi-3-mini-4k-instruct/manifests/1.2.3" {
 		// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
 		// from runtimes returned by the ngc catalog endpoint, version "1.2.3" is the latestTag attribute for the runtime
-		// check testdata/nim/ngc_catalog_response.json
+		// check testdata/nim/ngc_catalog_response_page_0.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-my-fake-token-please-dont-share-it-with-anyone" {
 			// the token is returned by the nvcr.io/proxy-auth endpoint (stubbed), check testdata/nim/runtime_token_response.json
@@ -85,7 +86,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	// stub model info for the FIRST model we stub, requested by utils.GetNimModelData (nim)
 	if req.URL.Host == "api.ngc.nvidia.com" && req.URL.Path == "/v2/org/nim/team/microsoft/repos/phi-3-mini-4k-instruct" {
 		// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
-		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_0.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-yet-another-fake-token-of-mine-you-know-what-not-do-to" {
 			// the token is returned by the authn.nvidia.com/token endpoint (stubbed), check testdata/nim/ngc_token_response.json
@@ -97,7 +98,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	// stub model info for the SECOND model we stub, requested by utils.GetNimModelData (nim)
 	if req.URL.Host == "api.ngc.nvidia.com" && req.URL.Path == "/v2/org/nim/team/meta/repos/llama-3.1-8b-instruct" {
 		// repository name "nim/meta/llama-3.1-8b-instruct" is the SECOND resource from the available
-		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_1.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-yet-another-fake-token-of-mine-you-know-what-not-do-to" {
 			// the token is returned by the authn.nvidia.com/token endpoint (stubbed), check testdata/nim/ngc_token_response.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds pagination support for the NVIDIA NIM available runtimes endpoint. We use a page size of 100; a couple of weeks back, there were 39 runtimes available, and today, there are 48. NVIDIA's endpoint will paginate the results if the available runtimes exceed the set page size.

Jira: [NVPE-79](https://issues.redhat.com/browse/NVPE-79).

> [!NOTE]
> We have another Jira, [NVPE-80](https://issues.redhat.com/browse/NVPE-80), for exploring the right page size for us.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Besides updating the [API mock](https://github.com/opendatahub-io/odh-model-controller/blob/incubating/controllers/testdata/nvidia_api_mock.go) to return multiple pages for the available runtimes endpoint, I also used the [script in the hack folder](https://github.com/opendatahub-io/odh-model-controller/blob/incubating/hack/verify_nvidia_nim_api.go) to invoke the real API manually after setting the [page size to 10](https://github.com/opendatahub-io/odh-model-controller/blob/incubating/controllers/utils/nim.go#L110). I then confirmed we get five responses (48 runtimes). The page numbers are consistent and as expected.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
