### PR TITLE
Add upstream community release version metadata

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,0 +1,22 @@
+releases:
+  - name: KServe
+    version: v0.14.0
+    repoUrl: https://github.com/kserve/kserve/
+  - name: ModelMesh Serving
+    version: v0.12.0
+    repoUrl: https://github.com/kserve/modelmesh-serving
+  - name: vLLM
+    version: v0.6.4.post1
+    repoUrl: https://github.com/vllm-project/vllm
+  - name: OpenVINO Model Server
+    version: v2024.5
+    repoUrl: https://github.com/openvinotoolkit/model_server
+  - name: Caikit
+    version: v0.27.7
+    repoUrl: https://github.com/caikit/caikit
+  - name: Caikit-nlp
+    version: v0.5.8
+    repoUrl: https://github.com/caikit/caikit-nlp
+  - name: Text Generation Inference Server
+    version: commit 8a8c55dd0884b8e4e420d22f10bcce6752455edf
+    repoUrl: https://github.com/IBM/text-generation-inference/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Continuation of PR #333 . 
Addressing:
https://issues.redhat.com/browse/RHOAISTRAT-327
https://issues.redhat.com/browse/RHOAIENG-16305
https://issues.redhat.com/browse/RHOAIENG-14290
https://issues.redhat.com/browse/RHOAIENG-15498

In a nutshell, adding the release versions of upstream projects that our components deliver to ODH and RHOAI. These will be fetched for DSC status and displayed in UI.

This PR is specific to RHOAI releases, starting potentially from RHOAI 2.17.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No testing necessary. The feature owner and other teams will perform UI and backend testing once all components have their metadatas in.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
