### PR TITLE
chore: use naming convention for resources created by nim

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -93,7 +93,4 @@ const (
 // NIM
 const (
 	NimApplyConfigFieldManager = "nim-account-controller"
-	NimDataConfigMapName       = "nvidia-nim-images-data"
-	NimRuntimeTemplateName     = "nvidia-nim-serving-template"
-	NimPullSecretName          = "nvidia-nim-image-pull"
 )

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -285,7 +285,7 @@ func (r *AccountReconciler) reconcileNimConfig(
 		return nil, dErr
 	}
 
-	cmCfg := ssacorev1.ConfigMap(constants.NimDataConfigMapName, namespace).
+	cmCfg := ssacorev1.ConfigMap(fmt.Sprintf("%s-cm", *ownerCfg.Name), namespace).
 		WithData(data).
 		WithOwnerReferences(ownerCfg).
 		WithLabels(labels)
@@ -303,7 +303,7 @@ func (r *AccountReconciler) reconcileNimConfig(
 func (r *AccountReconciler) reconcileRuntimeTemplate(ctx context.Context, account *v1.Account) (*templatev1.Template, error) {
 	template := &templatev1.Template{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.NimRuntimeTemplateName,
+			Name:      fmt.Sprintf("%s-template", account.Name),
 			Namespace: account.Namespace,
 		},
 	}
@@ -355,7 +355,7 @@ func (r *AccountReconciler) reconcileNimPullSecret(
 	}
 
 	secretCfg := ssacorev1.
-		Secret(constants.NimPullSecretName, namespace).
+		Secret(fmt.Sprintf("%s-pull", *ownerCfg.Name), namespace).
 		WithData(map[string][]byte{corev1.DockerConfigJsonKey: credsJson}).
 		WithType(corev1.SecretTypeDockerConfigJson).
 		WithOwnerReferences(ownerCfg).

--- a/internal/controller/nim/account_controller_test.go
+++ b/internal/controller/nim/account_controller_test.go
@@ -65,16 +65,19 @@ var _ = Describe("NIM Account Controller Test Cases", func() {
 		dataCmap := &corev1.ConfigMap{}
 		dataCmapSubject := namespacedNameFromReference(account.Status.NIMConfig)
 		Expect(k8sClient.Get(ctx, dataCmapSubject, dataCmap)).To(Succeed())
+		Expect(dataCmapSubject.Name).To(HavePrefix(account.Name + "-"))
 		Expect(dataCmap.OwnerReferences[0]).To(Equal(expectedOwner))
 
 		runtimeTemplate := &templatev1.Template{}
 		runtimeTemplateSubject := namespacedNameFromReference(account.Status.RuntimeTemplate)
 		Expect(k8sClient.Get(ctx, runtimeTemplateSubject, runtimeTemplate)).To(Succeed())
+		Expect(runtimeTemplateSubject.Name).To(HavePrefix(account.Name + "-"))
 		Expect(runtimeTemplate.OwnerReferences[0]).To(Equal(expectedOwner))
 
 		pullSecret := &corev1.Secret{}
 		pullSecretSubject := namespacedNameFromReference(account.Status.NIMPullSecret)
 		Expect(k8sClient.Get(ctx, pullSecretSubject, pullSecret)).To(Succeed())
+		Expect(pullSecretSubject.Name).To(HavePrefix(account.Name + "-"))
 		Expect(pullSecret.OwnerReferences[0]).To(Equal(expectedOwner))
 
 		By("Verify models info")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Following the merge of https://github.com/opendatahub-io/odh-dashboard/pull/3535, we can use a naming convention to create the resources owned by NIM runtimes instead of static names.

This will also require cleanups when upgrading; see https://github.com/opendatahub-io/opendatahub-operator/pull/1472.

Jira: [NVPE-29](https://issues.redhat.com/browse/NVPE-29)
Slack: [thread](https://redhat-internal.slack.com/archives/C07CZDA6DE1/p1734382422391069)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
make test
make build
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
