### PR TITLE
Nim enablement change default to managed and add clean up job

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,7 @@ import (
 	corecontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/core"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/nim"
 	servingcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving"
-	utils "github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 	webhooknimv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/nim/v1"
 	webhookservingv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1"
 	webhookservingv1beta1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1beta1"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -42,13 +44,15 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
 	corecontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/core"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/nim"
 	servingcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving"
-	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	utils "github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 	webhooknimv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/nim/v1"
 	webhookservingv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1"
 	webhookservingv1beta1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -244,6 +248,39 @@ func main() {
 			setupLog.Error(err, "unable to create controller", "controller", "NIMAccount")
 			os.Exit(1)
 		}
+	} else {
+		accounts := &v1.AccountList{}
+		if err := mgr.GetClient().List(signalHandlerCtx, accounts); err != nil {
+			setupLog.Error(err, "failed to fetch accounts")
+		}
+		for _, account := range accounts.Items {
+			setupLog.V(1).Info("Cleaning up resources for account", "namespace", account.Namespace, "name", account.Name)
+			// Call CleanupResources for the current account
+			if err = utils.CleanupResources(signalHandlerCtx, &account, mgr.GetClient()); err != nil {
+				setupLog.Error(err, "failed to perform clean up on some accounts")
+			}
+
+			msg := "NIM has been disabled"
+			cleanStatus := v1.AccountStatus{
+				NIMConfig:       nil,
+				RuntimeTemplate: nil,
+				NIMPullSecret:   nil,
+				Conditions: []metav1.Condition{
+					utils.MakeNimCondition(utils.NimConditionAccountStatus, metav1.ConditionUnknown, account.Generation, "AccountNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionAPIKeyValidation, metav1.ConditionUnknown, account.Generation, "ApiKeyNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionConfigMapUpdate, metav1.ConditionUnknown, account.Generation, "ConfigMapNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionTemplateUpdate, metav1.ConditionUnknown, account.Generation, "TemplateNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionSecretUpdate, metav1.ConditionUnknown, account.Generation, "SecretNotReconciled", msg),
+				},
+			}
+			subject := types.NamespacedName{Name: account.Name, Namespace: account.Namespace}
+
+			if err = utils.UpdateStatus(signalHandlerCtx, subject, cleanStatus, mgr.GetClient()); err != nil {
+				setupLog.Error(err, "failed to perform clean up on some accounts")
+			}
+
+		}
+
 	}
 
 	// nolint:goconst

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -266,11 +266,16 @@ func main() {
 				RuntimeTemplate: nil,
 				NIMPullSecret:   nil,
 				Conditions: []metav1.Condition{
-					utils.MakeNimCondition(utils.NimConditionAccountStatus, metav1.ConditionUnknown, account.Generation, "AccountNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionAPIKeyValidation, metav1.ConditionUnknown, account.Generation, "ApiKeyNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionConfigMapUpdate, metav1.ConditionUnknown, account.Generation, "ConfigMapNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionTemplateUpdate, metav1.ConditionUnknown, account.Generation, "TemplateNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionSecretUpdate, metav1.ConditionUnknown, account.Generation, "SecretNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionAccountStatus, metav1.ConditionUnknown, account.Generation,
+						"AccountNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionAPIKeyValidation, metav1.ConditionUnknown, account.Generation,
+						"ApiKeyNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionConfigMapUpdate, metav1.ConditionUnknown, account.Generation,
+						"ConfigMapNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionTemplateUpdate, metav1.ConditionUnknown, account.Generation,
+						"TemplateNotReconciled", msg),
+					utils.MakeNimCondition(utils.NimConditionSecretUpdate, metav1.ConditionUnknown, account.Generation,
+						"SecretNotReconciled", msg),
 				},
 			}
 			subject := types.NamespacedName{Name: account.Name, Namespace: account.Namespace}

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -4,4 +4,4 @@ caikit-standalone-image=quay.io/opendatahub/caikit-nlp:fast
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2024.3-release
 vllm-image=quay.io/opendatahub/vllm:fast
-nim-state=removed
+nim-state=managed

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -116,7 +116,6 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	ctx = log.IntoContext(ctx, logger)
 
 	account := &v1.Account{}
-
 	if err := r.Client.Get(ctx, req.NamespacedName, account); err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.V(1).Info("account deleted")

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -116,6 +116,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	ctx = log.IntoContext(ctx, logger)
 
 	account := &v1.Account{}
+
 	if err := r.Client.Get(ctx, req.NamespacedName, account); err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.V(1).Info("account deleted")

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -418,8 +418,7 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 	return sr, nil
 }
 
-// Newly added Public function
-// cleanupResources is used for deleting the integration related resources (configmap, template, pull secret)
+// CleanupResources is used for deleting the integration related resources (configmap, template, pull secret)
 func CleanupResources(ctx context.Context, account *v1.Account, kubeClient client.Client) error {
 
 	var delObjs []client.Object
@@ -464,7 +463,7 @@ func CleanupResources(ctx context.Context, account *v1.Account, kubeClient clien
 
 }
 
-// updateStatus is used for fetching an updating the status of the account
+// UpdateStatus is used for fetching an updating the status of the account
 func UpdateStatus(ctx context.Context, subject types.NamespacedName, status v1.AccountStatus, kubeClient client.Client) error {
 
 	account := &v1.Account{}

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -16,6 +16,7 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -24,12 +25,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
+	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
+	templatev1 "github.com/openshift/api/template/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -409,4 +416,67 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 	sr.SetGroupVersionKind(gvk)
 
 	return sr, nil
+}
+
+// Newly added Public function
+// cleanupResources is used for deleting the integration related resources (configmap, template, pull secret)
+func CleanupResources(ctx context.Context, account *v1.Account, kubeClient client.Client) error {
+
+	var delObjs []client.Object
+
+	if account.Status.NIMPullSecret != nil {
+		delObjs = append(delObjs, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      account.Status.NIMPullSecret.Name,
+				Namespace: account.Status.NIMPullSecret.Namespace,
+			},
+		})
+	}
+
+	if account.Status.NIMConfig != nil {
+		delObjs = append(delObjs, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      account.Status.NIMConfig.Name,
+				Namespace: account.Status.NIMConfig.Namespace,
+			},
+		})
+	}
+
+	if account.Status.RuntimeTemplate != nil {
+		delObjs = append(delObjs, &templatev1.Template{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      account.Status.RuntimeTemplate.Name,
+				Namespace: account.Status.RuntimeTemplate.Namespace,
+			},
+		})
+	}
+
+	var deleteErrors *multierror.Error
+
+	for _, obj := range delObjs {
+		if err := kubeClient.Delete(ctx, obj); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				deleteErrors = multierror.Append(deleteErrors, err)
+			}
+		}
+	}
+	return deleteErrors.ErrorOrNil()
+
+}
+
+// updateStatus is used for fetching an updating the status of the account
+func UpdateStatus(ctx context.Context, subject types.NamespacedName, status v1.AccountStatus, kubeClient client.Client) error {
+
+	account := &v1.Account{}
+	if err := kubeClient.Get(ctx, subject, account); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		account.Status = *status.DeepCopy()
+		if err = kubeClient.Status().Update(ctx, account); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Update the nim enablement flag to managed and add clean up job
The changes include:
- Updating the default state of the nim flag to managed for odh-model-controller
- Add the necessary logic to perform clean up of nim resources if nim has been set removed

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
