### PR TITLE
chore: set nim runtime api call page size to 1000

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -107,7 +107,7 @@ func init() {
 
 // GetAvailableNimRuntimes is used for fetching a list of available NIM custom runtimes
 func GetAvailableNimRuntimes() ([]NimRuntime, error) {
-	return getNimRuntimes([]NimRuntime{}, 0, 100)
+	return getNimRuntimes([]NimRuntime{}, 0, 1000)
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Based on NVIDIA's recommendations and the benchmarks executed in https://github.com/opendatahub-io/odh-model-controller/pull/336, setting the page size to 1000 will reduce API calls but will not affect performance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
make test
```
Also, see benchmark functions in https://github.com/opendatahub-io/odh-model-controller/pull/336.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
