### PR TITLE
Authorization for InferenceGraph (Serverless)

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -60,7 +60,8 @@ resources:
   webhooks:
     validation: true
     webhookVersion: v1
-- domain: kserve.io
+- controller: true
+  domain: kserve.io
   external: true
   group: serving
   kind: InferenceGraph

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -326,6 +326,10 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if err = servingcontroller.NewInferenceGraphReconciler(mgr).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/external/authorino.kuadrant.io_authconfigs.yaml
+++ b/config/crd/external/authorino.kuadrant.io_authconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: authconfigs.authorino.kuadrant.io
 spec:
   group: authorino.kuadrant.io
@@ -53,14 +53,19 @@ spec:
         description: AuthConfig is the schema for Authorino's AuthConfig API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -70,38 +75,13 @@ spec:
               service hosts.
             properties:
               authorization:
-                description: Authorization is the list of authorization policies.
-                  All policies in this list MUST evaluate to "true" for a request
-                  be successful in the authorization phase.
+                description: |-
+                  Authorization is the list of authorization policies.
+                  All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
                 items:
-                  description: 'Authorization policy to be enforced. Apart from "name",
-                    one of the following parameters is required and only one of the
-                    following parameters is allowed: "opa", "json" or "kubernetes".'
-                  oneOf:
-                  - properties:
-                      name: {}
-                      opa: {}
-                    required:
-                    - name
-                    - opa
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      kubernetes: {}
-                      name: {}
-                    required:
-                    - name
-                    - kubernetes
-                  - properties:
-                      authzed: {}
-                      name: {}
-                    required:
-                    - name
-                    - authzed
+                  description: |-
+                    Authorization policy to be enforced.
+                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".
                   properties:
                     authzed:
                       description: Authzed authorization
@@ -124,15 +104,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -153,17 +130,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -180,17 +152,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -229,17 +196,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -256,17 +218,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -275,14 +232,14 @@ spec:
                       - endpoint
                       type: object
                     cache:
-                      description: Caching options for the policy evaluation results
-                        when enforcing this config. Omit it to avoid caching policy
-                        evaluation results for this config.
+                      description: |-
+                        Caching options for the policy evaluation results when enforcing this config.
+                        Omit it to avoid caching policy evaluation results for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache
-                            entries from different metadata configs are stored and
-                            managed separately regardless of the key.
+                          description: |-
+                            Key used to store the entry in the cache.
+                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -291,15 +248,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -318,26 +272,6 @@ spec:
                           description: The rules that must all evaluate to "true"
                             for the request to be authorized.
                           items:
-                            oneOf:
-                            - properties:
-                                patternRef: {}
-                              required:
-                              - patternRef
-                            - properties:
-                                operator: {}
-                                selector: {}
-                                value: {}
-                              required:
-                              - operator
-                              - selector
-                            - properties:
-                                all: {}
-                              required:
-                              - all
-                            - properties:
-                                any: {}
-                              required:
-                              - any
                             properties:
                               all:
                                 description: A list of pattern expressions to be evaluated
@@ -354,12 +288,9 @@ spec:
                                   x-kubernetes-preserve-unknown-fields: true
                                 type: array
                               operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
+                                description: |-
+                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                                 enum:
                                 - eq
                                 - neq
@@ -371,16 +302,14 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                                  The value is used to fetch content from the input
-                                  authorization JSON built by Authorino along the
-                                  identity and metadata phases.
+                                description: |-
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  JSON. If used with the "matches" operator, the value
-                                  must compile to a valid Golang regex.
+                                description: |-
+                                  The value of reference for the comparison with the content fetched from the authorization JSON.
+                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -388,7 +317,8 @@ spec:
                       - rules
                       type: object
                     kubernetes:
-                      description: Kubernetes authorization policy based on `SubjectAccessReview`
+                      description: |-
+                        Kubernetes authorization policy based on `SubjectAccessReview`
                         Path and Verb are inferred from the request.
                       properties:
                         groups:
@@ -397,10 +327,9 @@ spec:
                             type: string
                           type: array
                         resourceAttributes:
-                          description: Use ResourceAttributes for checking permissions
-                            on Kubernetes resources If omitted, it performs a non-resource
-                            `SubjectAccessReview`, with verb and path inferred from
-                            the request.
+                          description: |-
+                            Use ResourceAttributes for checking permissions on Kubernetes resources
+                            If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
                           properties:
                             group:
                               description: StaticOrDynamicValue is either a constant
@@ -415,17 +344,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -442,17 +366,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -469,17 +388,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -496,17 +410,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -523,17 +432,12 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
@@ -550,25 +454,20 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from
-                                        the authorization JSON. It can be any path
-                                        pattern to fetch from the authorization JSON
-                                        (e.g. ''context.request.http.host'') or a
-                                        string template with variable placeholders
-                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following string modifiers
-                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                        @case:upper|lower, @base64:encode|decode and
-                                        @strip.'
+                                      description: |-
+                                        Selector to fetch a value from the authorization JSON.
+                                        It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                        or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                       type: string
                                   type: object
                               type: object
                           type: object
                         user:
-                          description: User to test for. If without "Groups", then
-                            is it interpreted as "What if User were not a member of
-                            any groups"
+                          description: |-
+                            User to test for.
+                            If without "Groups", then is it interpreted as "What if User were not a member of any groups"
                           properties:
                             value:
                               description: Static value
@@ -577,15 +476,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -598,30 +494,27 @@ spec:
                         individual observability metrics
                       type: boolean
                     name:
-                      description: Name of the authorization policy. It can be used
-                        to refer to the resolved authorization object in other configs.
+                      description: |-
+                        Name of the authorization policy.
+                        It can be used to refer to the resolved authorization object in other configs.
                       type: string
                     opa:
                       description: Open Policy Agent (OPA) authorization policy.
                       properties:
                         allValues:
                           default: false
-                          description: Returns the value of all Rego rules in the
-                            virtual document. Values can be read in subsequent evaluators/phases
-                            of the Auth Pipeline. Otherwise, only the default `allow`
-                            rule will be exposed. Returning all Rego rules can affect
-                            performance of OPA policies during reconciliation (policy
-                            precompile) and at runtime.
+                          description: |-
+                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
                           type: boolean
                         externalRegistry:
                           description: External registry of OPA policies.
                           properties:
                             credentials:
-                              description: Defines where client credentials will be
-                                passed in the request to the service. If omitted,
-                                it defaults to client credentials passed in the HTTP
-                                Authorization header and the "Bearer" prefix expected
-                                prepended to the secret value.
+                              description: |-
+                                Defines where client credentials will be passed in the request to the service.
+                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                               properties:
                                 in:
                                   default: authorization_header
@@ -635,32 +528,24 @@ spec:
                                   - cookie
                                   type: string
                                 keySelector:
-                                  description: Used in conjunction with the `in` parameter.
-                                    When used with `authorization_header`, the value
-                                    is the prefix of the client credentials string,
-                                    separated by a white-space, in the HTTP Authorization
-                                    header (e.g. "Bearer", "Basic"). When used with
-                                    `custom_header`, `query` or `cookie`, the value
-                                    is the name of the HTTP header, query string parameter
-                                    or cookie key, respectively.
+                                  description: |-
+                                    Used in conjunction with the `in` parameter.
+                                    When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
+                                    When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                                   type: string
                               required:
                               - keySelector
                               type: object
                             endpoint:
-                              description: Endpoint of the HTTP external registry.
-                                The endpoint must respond with either plain/text or
-                                application/json content-type. In the latter case,
-                                the JSON returned in the body must include a path
-                                `result.raw`, where the raw Rego policy will be extracted
-                                from. This complies with the specification of the
-                                OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                              description: |-
+                                Endpoint of the HTTP external registry.
+                                The endpoint must respond with either plain/text or application/json content-type.
+                                In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
                               type: string
                             sharedSecretRef:
-                              description: Reference to a Secret key whose value will
-                                be passed by Authorino in the request. The HTTP service
-                                can use the shared secret to authenticate the origin
-                                of the request.
+                              description: |-
+                                Reference to a Secret key whose value will be passed by Authorino in the request.
+                                The HTTP service can use the shared secret to authenticate the origin of the request.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -680,45 +565,24 @@ spec:
                               type: integer
                           type: object
                         inlineRego:
-                          description: Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition,
-                            set by Authorino to "false" by default (i.e. requests
-                            are unauthorized unless changed). The Rego document must
-                            NOT include the "package" declaration in line 1.
+                          description: |-
+                            Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                            The Rego document must NOT include the "package" declaration in line 1.
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this authorization
-                        policy. If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                      description: |-
+                        Conditions for Authorino to enforce this authorization policy.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -735,11 +599,9 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                             enum:
                             - eq
                             - neq
@@ -751,16 +613,14 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: |-
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -769,8 +629,9 @@ spec:
                   type: object
                 type: array
               callbacks:
-                description: List of callback configs. Authorino sends callbacks to
-                  specified endpoints at the end of the auth pipeline.
+                description: |-
+                  List of callback configs.
+                  Authorino sends callbacks to specified endpoints at the end of the auth pipeline.
                 items:
                   description: Endpoints to callback at the end of each auth pipeline.
                   properties:
@@ -779,10 +640,10 @@ spec:
                         metadata from a HTTP service.
                       properties:
                         body:
-                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
-                            use either one or the other. Use it with method=POST;
-                            for GET requests, set parameters as query string in the
-                            'endpoint' (placeholders can be used).
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           properties:
                             value:
                               description: Static value
@@ -791,24 +652,20 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
                         bodyParameters:
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Superseded by 'body'; use either one
-                            or the other. Use it with method=POST; for GET requests,
-                            set parameters as query string in the 'endpoint' (placeholders
-                            can be used).
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           items:
                             properties:
                               name:
@@ -821,16 +678,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -839,20 +692,17 @@ spec:
                           type: array
                         contentType:
                           default: application/x-www-form-urlencoded
-                          description: Content-Type of the request body. Shapes how
-                            'bodyParameters' are encoded. Use it with method=POST;
-                            for GET requests, Content-Type is automatically set to
-                            'text/plain'.
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
                           enum:
                           - application/x-www-form-urlencoded
                           - application/json
                           type: string
                         credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
                             in:
                               default: authorization_header
@@ -866,23 +716,20 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is
-                                the prefix of the client credentials string, separated
-                                by a white-space, in the HTTP Authorization header
-                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
-                                `query` or `cookie`, the value is the name of the
-                                HTTP header, query string parameter or cookie key,
-                                respectively.
+                              description: |-
+                                Used in conjunction with the `in` parameter.
+                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
+                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         endpoint:
-                          description: Endpoint of the HTTP service. The endpoint
-                            accepts variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          description: |-
+                            Endpoint of the HTTP service.
+                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
                         headers:
                           description: Custom headers in the HTTP request.
@@ -898,16 +745,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -916,10 +759,9 @@ spec:
                           type: array
                         method:
                           default: GET
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
                           enum:
                           - GET
                           - POST
@@ -930,9 +772,9 @@ spec:
                           properties:
                             cache:
                               default: true
-                              description: Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every
-                                authorization request regardless of expiration.
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
                               type: boolean
                             clientId:
                               description: OAuth2 Client ID.
@@ -975,10 +817,10 @@ spec:
                           - tokenUrl
                           type: object
                         sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request. Ignored if used together with oauth2.
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -1001,20 +843,21 @@ spec:
                         observability metrics
                       type: boolean
                     name:
-                      description: Name of the callback. It can be used to refer to
-                        the resolved callback response in other configs.
+                      description: |-
+                        Name of the callback.
+                        It can be used to refer to the resolved callback response in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to perform this callback.
+                      description: |-
+                        Conditions for Authorino to perform this callback.
                         If omitted, the callback will be attempted for all requests.
-                        If present, all conditions must match for the callback to
-                        be attempted; otherwise, the callback will be skipped.
+                        If present, all conditions must match for the callback to be attempted; otherwise, the callback will be skipped.
                       items:
                         properties:
                           all:
@@ -1032,11 +875,9 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                             enum:
                             - eq
                             - neq
@@ -1048,16 +889,14 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: |-
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -1084,15 +923,12 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization
-                                  JSON. It can be any path pattern to fetch from the
-                                  authorization JSON (e.g. ''context.request.http.host'')
-                                  or a string template with variable placeholders
-                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following string modifiers are
-                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                description: |-
+                                  Selector to fetch a value from the authorization JSON.
+                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                             type: object
                         type: object
@@ -1118,15 +954,12 @@ spec:
                               description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           required:
@@ -1143,15 +976,12 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization
-                                  JSON. It can be any path pattern to fetch from the
-                                  authorization JSON (e.g. ''context.request.http.host'')
-                                  or a string template with variable placeholders
-                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following string modifiers are
-                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                description: |-
+                                  Selector to fetch a value from the authorization JSON.
+                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                             type: object
                         type: object
@@ -1170,15 +1000,12 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization
-                                  JSON. It can be any path pattern to fetch from the
-                                  authorization JSON (e.g. ''context.request.http.host'')
-                                  or a string template with variable placeholders
-                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following string modifiers are
-                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                description: |-
+                                  Selector to fetch a value from the authorization JSON.
+                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                             type: object
                         type: object
@@ -1204,15 +1031,12 @@ spec:
                               description: Dynamic value of the JSON property
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           required:
@@ -1229,87 +1053,32 @@ spec:
                             description: Dynamic value
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization
-                                  JSON. It can be any path pattern to fetch from the
-                                  authorization JSON (e.g. ''context.request.http.host'')
-                                  or a string template with variable placeholders
-                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following string modifiers are
-                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                description: |-
+                                  Selector to fetch a value from the authorization JSON.
+                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                             type: object
                         type: object
                     type: object
                 type: object
               hosts:
-                description: The list of public host names of the services protected
-                  by this authentication/authorization scheme. Authorino uses the
-                  requested host to lookup for the corresponding authentication/authorization
-                  configs to enforce.
+                description: |-
+                  The list of public host names of the services protected by this authentication/authorization scheme.
+                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
                 items:
                   type: string
                 type: array
               identity:
-                description: List of identity sources/authentication modes. At least
-                  one config of this list MUST evaluate to a valid identity for a
-                  request to be successful in the identity verification phase.
+                description: |-
+                  List of identity sources/authentication modes.
+                  At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
                 items:
-                  description: 'The identity source/authentication mode config. Apart
-                    from "name", one of the following parameters is required and only
-                    one of the following parameters is allowed: "oicd", "apiKey" or
-                    "kubernetes".'
-                  oneOf:
-                  - properties:
-                      credentials: {}
-                      name: {}
-                      oauth2: {}
-                    required:
-                    - name
-                    - oauth2
-                  - properties:
-                      credentials: {}
-                      name: {}
-                      oidc: {}
-                    required:
-                    - name
-                    - oidc
-                  - properties:
-                      apiKey: {}
-                      credentials: {}
-                      name: {}
-                    required:
-                    - name
-                    - apiKey
-                  - properties:
-                      credentials: {}
-                      mtls: {}
-                      name: {}
-                    required:
-                    - name
-                    - mtls
-                  - properties:
-                      credentials: {}
-                      kubernetes: {}
-                      name: {}
-                    required:
-                    - name
-                    - kubernetes
-                  - properties:
-                      anonymous: {}
-                      credentials: {}
-                      name: {}
-                    required:
-                    - name
-                    - anonymous
-                  - properties:
-                      credentials: {}
-                      name: {}
-                      plain: {}
-                    required:
-                    - name
-                    - plain
+                  description: |-
+                    The identity source/authentication mode config.
+                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".
                   properties:
                     anonymous:
                       type: object
@@ -1317,10 +1086,9 @@ spec:
                       properties:
                         allNamespaces:
                           default: false
-                          description: Whether Authorino should look for API key secrets
-                            in all namespaces or only in the same namespace as the
-                            AuthConfig. Enabling this option in namespaced Authorino
-                            instances has no effect.
+                          description: |-
+                            Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
                           type: boolean
                         selector:
                           description: Label selector used by Authorino to match secrets
@@ -1331,8 +1099,8 @@ spec:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -1340,17 +1108,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1362,25 +1129,25 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - selector
                       type: object
                     cache:
-                      description: Caching options for the identity resolved when
-                        applying this config. Omit it to avoid caching identity objects
-                        for this config.
+                      description: |-
+                        Caching options for the identity resolved when applying this config.
+                        Omit it to avoid caching identity objects for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache
-                            entries from different metadata configs are stored and
-                            managed separately regardless of the key.
+                          description: |-
+                            Key used to store the entry in the cache.
+                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -1389,15 +1156,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -1410,11 +1174,9 @@ spec:
                       - key
                       type: object
                     credentials:
-                      description: Defines where client credentials are required to
-                        be passed in the request for this identity source/authentication
-                        mode. If omitted, it defaults to client credentials passed
-                        in the HTTP Authorization header and the "Bearer" prefix expected
-                        prepended to the credentials value (token, API key, etc).
+                      description: |-
+                        Defines where client credentials are required to be passed in the request for this identity source/authentication mode.
+                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
                       properties:
                         in:
                           default: authorization_header
@@ -1428,23 +1190,18 @@ spec:
                           - cookie
                           type: string
                         keySelector:
-                          description: Used in conjunction with the `in` parameter.
-                            When used with `authorization_header`, the value is the
-                            prefix of the client credentials string, separated by
-                            a white-space, in the HTTP Authorization header (e.g.
-                            "Bearer", "Basic"). When used with `custom_header`, `query`
-                            or `cookie`, the value is the name of the HTTP header,
-                            query string parameter or cookie key, respectively.
+                          description: |-
+                            Used in conjunction with the `in` parameter.
+                            When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
+                            When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                           type: string
                       required:
                       - keySelector
                       type: object
                     extendedProperties:
-                      description: Extends the resolved identity object with additional
-                        custom properties before appending to the authorization JSON.
-                        It requires the resolved identity object to always be of the
-                        JSON type 'object'. Other JSON types (array, string, etc)
-                        will break.
+                      description: |-
+                        Extends the resolved identity object with additional custom properties before appending to the authorization JSON.
+                        It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
                       items:
                         properties:
                           name:
@@ -1462,15 +1219,12 @@ spec:
                             description: Dynamic value of the JSON property
                             properties:
                               authJSON:
-                                description: 'Selector to fetch a value from the authorization
-                                  JSON. It can be any path pattern to fetch from the
-                                  authorization JSON (e.g. ''context.request.http.host'')
-                                  or a string template with variable placeholders
-                                  that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following string modifiers are
-                                  available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
+                                description: |-
+                                  Selector to fetch a value from the authorization JSON.
+                                  It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                  or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                 type: string
                             type: object
                         required:
@@ -1480,11 +1234,9 @@ spec:
                     kubernetes:
                       properties:
                         audiences:
-                          description: The list of audiences (scopes) that must be
-                            claimed in a Kubernetes authentication token supplied
-                            in the request, and reviewed by Authorino. If omitted,
-                            Authorino will review tokens expecting the host name of
-                            the requested protected service amongst the audiences.
+                          description: |-
+                            The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino.
+                            If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
                           items:
                             type: string
                           type: array
@@ -1498,10 +1250,9 @@ spec:
                       properties:
                         allNamespaces:
                           default: false
-                          description: Whether Authorino should look for TLS secrets
-                            in all namespaces or only in the same namespace as the
-                            AuthConfig. Enabling this option in namespaced Authorino
-                            instances has no effect.
+                          description: |-
+                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
                           type: boolean
                         selector:
                           description: Label selector used by Authorino to match secrets
@@ -1512,8 +1263,8 @@ spec:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -1521,17 +1272,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1543,21 +1293,21 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                       required:
                       - selector
                       type: object
                     name:
-                      description: The name of this identity source/authentication
-                        mode. It usually identifies a source of identities or group
-                        of users/clients of the protected service. It can be used
-                        to refer to the resolved identity object in other configs.
+                      description: |-
+                        The name of this identity source/authentication mode.
+                        It usually identifies a source of identities or group of users/clients of the protected service.
+                        It can be used to refer to the resolved identity object in other configs.
                       type: string
                     oauth2:
                       properties:
@@ -1567,15 +1317,19 @@ spec:
                             server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         tokenIntrospectionUrl:
                           description: The full URL of the token introspection endpoint.
                           type: string
                         tokenTypeHint:
-                          description: The token type hint for the token introspection.
+                          description: |-
+                            The token type hint for the token introspection.
                             If omitted, it defaults to "access_token".
                           type: string
                       required:
@@ -1585,14 +1339,10 @@ spec:
                     oidc:
                       properties:
                         endpoint:
-                          description: Endpoint of the OIDC issuer. Authorino will
-                            append to this value the well-known path to the OpenID
-                            Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
-                            used to automatically discover the OpenID Connect configuration,
-                            whose set of claims is expected to include (among others)
-                            the "jkws_uri" claim. The value must coincide with the
-                            value of  the "iss" (issuer) claim of the discovered OpenID
-                            Connect configuration.
+                          description: |-
+                            Endpoint of the OIDC issuer.
+                            Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim.
+                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
                           type: string
                         ttl:
                           description: Decides how long to wait before refreshing
@@ -1604,49 +1354,26 @@ spec:
                     plain:
                       properties:
                         authJSON:
-                          description: 'Selector to fetch a value from the authorization
-                            JSON. It can be any path pattern to fetch from the authorization
-                            JSON (e.g. ''context.request.http.host'') or a string
-                            template with variable placeholders that resolve to patterns
-                            (e.g. "Hello, {auth.identity.name}!"). Any patterns supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson can be
-                            used. The following string modifiers are available: @extract:{sep:"
-                            ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                            @base64:encode|decode and @strip.'
+                          description: |-
+                            Selector to fetch a value from the authorization JSON.
+                            It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                            or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                            Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                           type: string
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this identity
-                        config. If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
+                      description: |-
+                        Conditions for Authorino to enforce this identity config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -1663,11 +1390,9 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                             enum:
                             - eq
                             - neq
@@ -1679,16 +1404,14 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: |-
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -1697,41 +1420,23 @@ spec:
                   type: object
                 type: array
               metadata:
-                description: List of metadata source configs. Authorino fetches JSON
-                  content from sources on this list on every request.
+                description: |-
+                  List of metadata source configs.
+                  Authorino fetches JSON content from sources on this list on every request.
                 items:
-                  description: 'The metadata config. Apart from "name", one of the
-                    following parameters is required and only one of the following
-                    parameters is allowed: "http", userInfo" or "uma".'
-                  oneOf:
-                  - properties:
-                      name: {}
-                      userInfo: {}
-                    required:
-                    - name
-                    - userInfo
-                  - properties:
-                      name: {}
-                      uma: {}
-                    required:
-                    - name
-                    - uma
-                  - properties:
-                      http: {}
-                      name: {}
-                    required:
-                    - name
-                    - http
+                  description: |-
+                    The metadata config.
+                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".
                   properties:
                     cache:
-                      description: Caching options for the external metadata fetched
-                        when applying this config. Omit it to avoid caching metadata
-                        from this source.
+                      description: |-
+                        Caching options for the external metadata fetched when applying this config.
+                        Omit it to avoid caching metadata from this source.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache
-                            entries from different metadata configs are stored and
-                            managed separately regardless of the key.
+                          description: |-
+                            Key used to store the entry in the cache.
+                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -1740,15 +1445,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -1765,10 +1467,10 @@ spec:
                         metadata from a HTTP service.
                       properties:
                         body:
-                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
-                            use either one or the other. Use it with method=POST;
-                            for GET requests, set parameters as query string in the
-                            'endpoint' (placeholders can be used).
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           properties:
                             value:
                               description: Static value
@@ -1777,24 +1479,20 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
                         bodyParameters:
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Superseded by 'body'; use either one
-                            or the other. Use it with method=POST; for GET requests,
-                            set parameters as query string in the 'endpoint' (placeholders
-                            can be used).
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
                           items:
                             properties:
                               name:
@@ -1807,16 +1505,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -1825,20 +1519,17 @@ spec:
                           type: array
                         contentType:
                           default: application/x-www-form-urlencoded
-                          description: Content-Type of the request body. Shapes how
-                            'bodyParameters' are encoded. Use it with method=POST;
-                            for GET requests, Content-Type is automatically set to
-                            'text/plain'.
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
                           enum:
                           - application/x-www-form-urlencoded
                           - application/json
                           type: string
                         credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
                           properties:
                             in:
                               default: authorization_header
@@ -1852,23 +1543,20 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter.
-                                When used with `authorization_header`, the value is
-                                the prefix of the client credentials string, separated
-                                by a white-space, in the HTTP Authorization header
-                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
-                                `query` or `cookie`, the value is the name of the
-                                HTTP header, query string parameter or cookie key,
-                                respectively.
+                              description: |-
+                                Used in conjunction with the `in` parameter.
+                                When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic").
+                                When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         endpoint:
-                          description: Endpoint of the HTTP service. The endpoint
-                            accepts variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                          description: |-
+                            Endpoint of the HTTP service.
+                            The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
                           type: string
                         headers:
                           description: Custom headers in the HTTP request.
@@ -1884,16 +1572,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -1902,10 +1586,9 @@ spec:
                           type: array
                         method:
                           default: GET
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
                           enum:
                           - GET
                           - POST
@@ -1916,9 +1599,9 @@ spec:
                           properties:
                             cache:
                               default: true
-                              description: Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every
-                                authorization request regardless of expiration.
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
                               type: boolean
                             clientId:
                               description: OAuth2 Client ID.
@@ -1961,10 +1644,10 @@ spec:
                           - tokenUrl
                           type: object
                         sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request. Ignored if used together with oauth2.
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -1987,14 +1670,15 @@ spec:
                         observability metrics
                       type: boolean
                     name:
-                      description: The name of the metadata source. It can be used
-                        to refer to the resolved metadata object in other configs.
+                      description: |-
+                        The name of the metadata source.
+                        It can be used to refer to the resolved metadata object in other configs.
                       type: string
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     uma:
                       description: User-Managed Access (UMA) source of resource data.
@@ -2005,14 +1689,17 @@ spec:
                             registration API of the UMA server.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         endpoint:
-                          description: The endpoint of the UMA server. The value must
-                            coincide with the "issuer" claim of the UMA config discovered
-                            from the well-known uma configuration endpoint.
+                          description: |-
+                            The endpoint of the UMA server.
+                            The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
                           type: string
                       required:
                       - credentialsRef
@@ -2031,31 +1718,11 @@ spec:
                       - identitySource
                       type: object
                     when:
-                      description: Conditions for Authorino to apply this metadata
-                        config. If omitted, the config will be applied for all requests.
-                        If present, all conditions must match for the config to be
-                        applied; otherwise, the config will be skipped.
+                      description: |-
+                        Conditions for Authorino to apply this metadata config.
+                        If omitted, the config will be applied for all requests.
+                        If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
                       items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -2072,11 +1739,9 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                             enum:
                             - eq
                             - neq
@@ -2088,16 +1753,14 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: |-
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
@@ -2110,11 +1773,9 @@ spec:
                   items:
                     properties:
                       operator:
-                        description: 'The binary operator to be applied to the content
-                          fetched from the authorization JSON, for comparison with
-                          "value". Possible values are: "eq" (equal to), "neq" (not
-                          equal to), "incl" (includes; for arrays), "excl" (excludes;
-                          for arrays), "matches" (regex)'
+                        description: |-
+                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                         enum:
                         - eq
                         - neq
@@ -2123,16 +1784,14 @@ spec:
                         - matches
                         type: string
                       selector:
-                        description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                          The value is used to fetch content from the input authorization
-                          JSON built by Authorino along the identity and metadata
-                          phases.
+                        description: |-
+                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                          The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                         type: string
                       value:
-                        description: The value of reference for the comparison with
-                          the content fetched from the authorization JSON. If used
-                          with the "matches" operator, the value must compile to a
-                          valid Golang regex.
+                        description: |-
+                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                          If used with the "matches" operator, the value must compile to a valid Golang regex.
                         type: string
                     type: object
                   type: array
@@ -2140,41 +1799,23 @@ spec:
                   conditionals and in JSON-pattern matching policy rules.
                 type: object
               response:
-                description: List of response configs. Authorino gathers data from
-                  the auth pipeline to build custom responses for the client.
+                description: |-
+                  List of response configs.
+                  Authorino gathers data from the auth pipeline to build custom responses for the client.
                 items:
-                  description: 'Dynamic response to return to the client. Apart from
-                    "name", one of the following parameters is required and only one
-                    of the following parameters is allowed: "wristband" or "json".'
-                  oneOf:
-                  - properties:
-                      name: {}
-                      wristband: {}
-                    required:
-                    - name
-                    - wristband
-                  - properties:
-                      json: {}
-                      name: {}
-                    required:
-                    - name
-                    - json
-                  - properties:
-                      name: {}
-                      plain: {}
-                    required:
-                    - name
-                    - plain
+                  description: |-
+                    Dynamic response to return to the client.
+                    Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".
                   properties:
                     cache:
-                      description: Caching options for dynamic responses built when
-                        applying this config. Omit it to avoid caching dynamic responses
-                        for this config.
+                      description: |-
+                        Caching options for dynamic responses built when applying this config.
+                        Omit it to avoid caching dynamic responses for this config.
                       properties:
                         key:
-                          description: Key used to store the entry in the cache. Cache
-                            entries from different metadata configs are stored and
-                            managed separately regardless of the key.
+                          description: |-
+                            Key used to store the entry in the cache.
+                            Cache entries from different metadata configs are stored and managed separately regardless of the key.
                           properties:
                             value:
                               description: Static value
@@ -2183,15 +1824,12 @@ spec:
                               description: Dynamic value
                               properties:
                                 authJSON:
-                                  description: 'Selector to fetch a value from the
-                                    authorization JSON. It can be any path pattern
-                                    to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                    or a string template with variable placeholders
-                                    that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following string modifiers are
-                                    available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
+                                  description: |-
+                                    Selector to fetch a value from the authorization JSON.
+                                    It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                    or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                   type: string
                               type: object
                           type: object
@@ -2220,16 +1858,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -2245,8 +1879,9 @@ spec:
                         observability metrics
                       type: boolean
                     name:
-                      description: Name of the custom response. It can be used to
-                        refer to the resolved response object in other configs.
+                      description: |-
+                        Name of the custom response.
+                        It can be used to refer to the resolved response object in other configs.
                       type: string
                     plain:
                       description: StaticOrDynamicValue is either a constant static
@@ -2260,50 +1895,27 @@ spec:
                           description: Dynamic value
                           properties:
                             authJSON:
-                              description: 'Selector to fetch a value from the authorization
-                                JSON. It can be any path pattern to fetch from the
-                                authorization JSON (e.g. ''context.request.http.host'')
-                                or a string template with variable placeholders that
-                                resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following string modifiers are available:
-                                @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
+                              description: |-
+                                Selector to fetch a value from the authorization JSON.
+                                It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                               type: string
                           type: object
                       type: object
                     priority:
                       default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
                       type: integer
                     when:
-                      description: Conditions for Authorino to enforce this custom
-                        response config. If omitted, the config will be enforced for
-                        all requests. If present, all conditions must match for the
-                        config to be enforced; otherwise, the config will be skipped.
+                      description: |-
+                        Conditions for Authorino to enforce this custom response config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
                       items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
                         properties:
                           all:
                             description: A list of pattern expressions to be evaluated
@@ -2320,11 +1932,9 @@ spec:
                               x-kubernetes-preserve-unknown-fields: true
                             type: array
                           operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                             enum:
                             - eq
                             - neq
@@ -2336,32 +1946,30 @@ spec:
                             description: Name of a named pattern
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                              The value is used to fetch content from the input authorization
-                              JSON built by Authorino along the identity and metadata
-                              phases.
+                            description: |-
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
                     wrapper:
                       default: httpHeader
-                      description: How Authorino wraps the response. Use "httpHeader"
-                        (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
-                        to wrap the response as Envoy Dynamic Metadata
+                      description: |-
+                        How Authorino wraps the response.
+                        Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
                       enum:
                       - httpHeader
                       - envoyDynamicMetadata
                       type: string
                     wrapperKey:
-                      description: The name of key used in the wrapped response (name
-                        of the HTTP header or property of the Envoy Dynamic Metadata
-                        JSON). If omitted, it will be set to the name of the configuration.
+                      description: |-
+                        The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON).
+                        If omitted, it will be set to the name of the configuration.
                       type: string
                     wristband:
                       properties:
@@ -2381,16 +1989,12 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the
-                                      authorization JSON. It can be any path pattern
-                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
-                                      or a string template with variable placeholders
-                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following string modifiers
-                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                      @case:upper|lower, @base64:encode|decode and
-                                      @strip.'
+                                    description: |-
+                                      Selector to fetch a value from the authorization JSON.
+                                      It can be any path pattern to fetch from the authorization JSON (e.g. 'context.request.http.host')
+                                      or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
                                     type: string
                                 type: object
                             required:
@@ -2403,10 +2007,9 @@ spec:
                             where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
                           type: string
                         signingKeyRefs:
-                          description: Reference by name to Kubernetes secrets and
-                            corresponding signing algorithms. The secrets must contain
-                            a `key.pem` entry whose value is the signing key formatted
-                            as PEM.
+                          description: |-
+                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
                           items:
                             properties:
                               algorithm:
@@ -2421,10 +2024,9 @@ spec:
                                 - RS512
                                 type: string
                               name:
-                                description: Name of the signing key. The value is
-                                  used to reference the Kubernetes secret that stores
-                                  the key and in the `kid` claim of the wristband
-                                  token header.
+                                description: |-
+                                  Name of the signing key.
+                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
                                 type: string
                             required:
                             - algorithm
@@ -2444,32 +2046,11 @@ spec:
                   type: object
                 type: array
               when:
-                description: Conditions for the AuthConfig to be enforced. If omitted,
-                  the AuthConfig will be enforced for all requests. If present, all
-                  conditions must match for the AuthConfig to be enforced; otherwise,
-                  Authorino skips the AuthConfig and returns immediately with status
-                  OK.
+                description: |-
+                  Conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced for all requests.
+                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
                 items:
-                  oneOf:
-                  - properties:
-                      patternRef: {}
-                    required:
-                    - patternRef
-                  - properties:
-                      operator: {}
-                      selector: {}
-                      value: {}
-                    required:
-                    - operator
-                    - selector
-                  - properties:
-                      all: {}
-                    required:
-                    - all
-                  - properties:
-                      any: {}
-                    required:
-                    - any
                   properties:
                     all:
                       description: A list of pattern expressions to be evaluated as
@@ -2486,11 +2067,9 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                       type: array
                     operator:
-                      description: 'The binary operator to be applied to the content
-                        fetched from the authorization JSON, for comparison with "value".
-                        Possible values are: "eq" (equal to), "neq" (not equal to),
-                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
-                        "matches" (regex)'
+                      description: |-
+                        The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                        Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
                       enum:
                       - eq
                       - neq
@@ -2502,2789 +2081,14 @@ spec:
                       description: Name of a named pattern
                       type: string
                     selector:
-                      description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
-                        The value is used to fetch content from the input authorization
-                        JSON built by Authorino along the identity and metadata phases.
+                      description: |-
+                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                        The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
                       type: string
                     value:
-                      description: The value of reference for the comparison with
-                        the content fetched from the authorization JSON. If used with
-                        the "matches" operator, the value must compile to a valid
-                        Golang regex.
-                      type: string
-                  type: object
-                type: array
-            required:
-            - hosts
-            type: object
-          status:
-            description: AuthConfigStatus defines the observed state of AuthConfig
-            properties:
-              conditions:
-                items:
-                  properties:
-                    lastTransitionTime:
-                      description: Last time the condition transit from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    lastUpdatedTime:
-                      description: Last time the condition was updated
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human readable message indicating details about
-                        last transition.
-                      type: string
-                    reason:
-                      description: (brief) reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              summary:
-                properties:
-                  festivalWristbandEnabled:
-                    description: Indicator of whether the AuthConfig issues Festival
-                      Wristband tokens on successful evaluation of the AuthConfig
-                      (access granted)
-                    type: boolean
-                  hostsReady:
-                    description: Lists the hosts from spec.hosts linked to the resource
-                      in the index
-                    items:
-                      type: string
-                    type: array
-                  numAuthorizationPolicies:
-                    description: Number of authorization policies in the AuthConfig
-                    format: int64
-                    type: integer
-                  numHostsReady:
-                    description: Number of hosts from spec.hosts linked to the resource
-                      in the index, compared to the total number of hosts in spec.hosts
-                    type: string
-                  numIdentitySources:
-                    description: Number of trusted sources of identity for authentication
-                      in the AuthConfig
-                    format: int64
-                    type: integer
-                  numMetadataSources:
-                    description: Number of sources of external metadata in the AuthConfig
-                    format: int64
-                    type: integer
-                  numResponseItems:
-                    description: Number of custom authorization response items in
-                      the AuthConfig
-                    format: int64
-                    type: integer
-                  ready:
-                    description: Whether all hosts from spec.hosts have been linked
-                      to the resource in the index
-                    type: boolean
-                required:
-                - festivalWristbandEnabled
-                - hostsReady
-                - numAuthorizationPolicies
-                - numHostsReady
-                - numIdentitySources
-                - numMetadataSources
-                - numResponseItems
-                - ready
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: Ready for all hosts
-      jsonPath: .status.summary.ready
-      name: Ready
-      type: string
-    - description: Number of hosts ready
-      jsonPath: .status.summary.numHostsReady
-      name: Hosts
-      type: string
-    - description: Number of trusted identity sources
-      jsonPath: .status.summary.numIdentitySources
-      name: Authentication
-      priority: 2
-      type: integer
-    - description: Number of external metadata sources
-      jsonPath: .status.summary.numMetadataSources
-      name: Metadata
-      priority: 2
-      type: integer
-    - description: Number of authorization policies
-      jsonPath: .status.summary.numAuthorizationPolicies
-      name: Authorization
-      priority: 2
-      type: integer
-    - description: Number of items added to the authorization response
-      jsonPath: .status.summary.numResponseItems
-      name: Response
-      priority: 2
-      type: integer
-    - description: Whether issuing Festival Wristbands
-      jsonPath: .status.summary.festivalWristbandEnabled
-      name: Wristband
-      priority: 2
-      type: boolean
-    name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: AuthConfig is the schema for Authorino's AuthConfig API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Specifies the desired state of the AuthConfig resource, i.e.
-              the authencation/authorization scheme to be applied to protect the matching
-              service hosts.
-            properties:
-              authentication:
-                additionalProperties:
-                  oneOf:
-                  - properties:
-                      credentials: {}
-                      oauth2Introspection: {}
-                    required:
-                    - oauth2Introspection
-                  - properties:
-                      credentials: {}
-                      jwt: {}
-                    required:
-                    - jwt
-                  - properties:
-                      apiKey: {}
-                      credentials: {}
-                    required:
-                    - apiKey
-                  - properties:
-                      credentials: {}
-                      x509: {}
-                    required:
-                    - x509
-                  - properties:
-                      credentials: {}
-                      kubernetesTokenReview: {}
-                    required:
-                    - kubernetesTokenReview
-                  - properties:
-                      anonymous: {}
-                      credentials: {}
-                    required:
-                    - anonymous
-                  - properties:
-                      credentials: {}
-                      plain: {}
-                    required:
-                    - plain
-                  properties:
-                    anonymous:
-                      description: Anonymous access.
-                      type: object
-                    apiKey:
-                      description: Authentication based on API keys stored in Kubernetes
-                        secrets.
-                      properties:
-                        allNamespaces:
-                          default: false
-                          description: Whether Authorino should look for API key secrets
-                            in all namespaces or only in the same namespace as the
-                            AuthConfig. Enabling this option in namespaced Authorino
-                            instances has no effect.
-                          type: boolean
-                        selector:
-                          description: Label selector used by Authorino to match secrets
-                            from the cluster storing valid credentials to authenticate
-                            to this service
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                      required:
-                      - selector
-                      type: object
-                    cache:
-                      description: Caching options for the resolved object returned
-                        when applying this config. Omit it to avoid caching objects
-                        for this config.
-                      properties:
-                        key:
-                          description: Key used to store the entry in the cache. The
-                            resolved key must be unique within the scope of this particular
-                            config.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    credentials:
-                      description: Defines where credentials are required to be passed
-                        in the request for authentication based on this config. If
-                        omitted, it defaults to credentials passed in the HTTP Authorization
-                        header and the "Bearer" prefix prepended to the secret credential
-                        value.
-                      properties:
-                        authorizationHeader:
-                          properties:
-                            prefix:
-                              type: string
-                          type: object
-                        cookie:
-                          properties:
-                            name:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        customHeader:
-                          properties:
-                            name:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        queryString:
-                          properties:
-                            name:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                      type: object
-                    defaults:
-                      additionalProperties:
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      description: Set default property values (claims) for the resolved
-                        identity object, that are set before appending the object
-                        to the authorization JSON. If the property is already present
-                        in the resolved identity object, the default value is ignored.
-                        It requires the resolved identity object to always be a JSON
-                        object. Do not use this option with identity objects of other
-                        JSON types (array, string, etc).
-                      type: object
-                    jwt:
-                      description: Authentication based on JWT tokens.
-                      properties:
-                        issuerUrl:
-                          description: URL of the issuer of the JWT. If `jwksUrl`
-                            is omitted, Authorino will append the path to the OpenID
-                            Connect Well-Known Discovery endpoint (i.e. "/.well-known/openid-configuration")
-                            to this URL, to discover the OIDC configuration where
-                            to obtain the "jkws_uri" claim from. The value must coincide
-                            with the value of  the "iss" (issuer) claim of the discovered
-                            OpenID Connect configuration.
-                          type: string
-                        ttl:
-                          description: Decides how long to wait before refreshing
-                            the JWKS (in seconds). If omitted, Authorino will never
-                            refresh the JWKS.
-                          type: integer
-                      type: object
-                    kubernetesTokenReview:
-                      description: Authentication by Kubernetes token review.
-                      properties:
-                        audiences:
-                          description: The list of audiences (scopes) that must be
-                            claimed in a Kubernetes authentication token supplied
-                            in the request, and reviewed by Authorino. If omitted,
-                            Authorino will review tokens expecting the host name of
-                            the requested protected service amongst the audiences.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this config should generate individual
-                        observability metrics
-                      type: boolean
-                    oauth2Introspection:
-                      description: Authentication by OAuth2 token introspection.
-                      properties:
-                        credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the OAuth2
-                            server.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        endpoint:
-                          description: The full URL of the token introspection endpoint.
-                          type: string
-                        tokenTypeHint:
-                          description: The token type hint for the token introspection.
-                            If omitted, it defaults to "access_token".
-                          type: string
-                      required:
-                      - credentialsRef
-                      - endpoint
-                      type: object
-                    overrides:
-                      additionalProperties:
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      description: Overrides the resolved identity object by setting
-                        the additional properties (claims) specified in this config,
-                        before appending the object to the authorization JSON. It
-                        requires the resolved identity object to always be a JSON
-                        object. Do not use this option with identity objects of other
-                        JSON types (array, string, etc).
-                      type: object
-                    plain:
-                      description: Identity object extracted from the context. Use
-                        this method when authentication is performed beforehand by
-                        a proxy and the resulting object passed to Authorino as JSON
-                        in the auth request.
-                      properties:
-                        selector:
-                          description: 'Simple path selector to fetch content from
-                            the authorization JSON (e.g. ''request.method'') or a
-                            string template with variables that resolve to patterns
-                            (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                            by https://pkg.go.dev/github.com/tidwall/gjson can be
-                            used. The following Authorino custom modifiers are supported:
-                            @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                            @base64:encode|decode and @strip.'
-                          type: string
-                      required:
-                      - selector
-                      type: object
-                    priority:
-                      default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: Conditions for Authorino to enforce this config.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Reference to a named set of pattern expressions
-                            type: string
-                          selector:
-                            description: Path selector to fetch content from the authorization
-                              JSON (e.g. 'request.method'). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. Authorino custom JSON path modifiers are also
-                              supported.
-                            type: string
-                          value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                    x509:
-                      description: Authentication based on client X.509 certificates.
-                        The certificates presented by the clients must be signed by
-                        a trusted CA whose certificates are stored in Kubernetes secrets.
-                      properties:
-                        allNamespaces:
-                          default: false
-                          description: Whether Authorino should look for TLS secrets
-                            in all namespaces or only in the same namespace as the
-                            AuthConfig. Enabling this option in namespaced Authorino
-                            instances has no effect.
-                          type: boolean
-                        selector:
-                          description: Label selector used by Authorino to match secrets
-                            from the cluster storing trusted CA certificates to validate
-                            clients trying to authenticate to this service
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                      required:
-                      - selector
-                      type: object
-                  type: object
-                description: Authentication configs. At least one config MUST evaluate
-                  to a valid identity object for the auth request to be successful.
-                type: object
-              authorization:
-                additionalProperties:
-                  oneOf:
-                  - properties:
-                      opa: {}
-                    required:
-                    - opa
-                  - properties:
-                      patternMatching: {}
-                    required:
-                    - patternMatching
-                  - properties:
-                      kubernetesSubjectAccessReview: {}
-                    required:
-                    - kubernetesSubjectAccessReview
-                  - properties:
-                      spicedb: {}
-                    required:
-                    - spicedb
-                  properties:
-                    cache:
-                      description: Caching options for the resolved object returned
-                        when applying this config. Omit it to avoid caching objects
-                        for this config.
-                      properties:
-                        key:
-                          description: Key used to store the entry in the cache. The
-                            resolved key must be unique within the scope of this particular
-                            config.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    kubernetesSubjectAccessReview:
-                      description: Authorization by Kubernetes SubjectAccessReview
-                      properties:
-                        groups:
-                          description: Groups the user must be a member of or, if
-                            `user` is omitted, the groups to check for authorization
-                            in the Kubernetes RBAC.
-                          items:
-                            type: string
-                          type: array
-                        resourceAttributes:
-                          description: Use resourceAttributes to check permissions
-                            on Kubernetes resources. If omitted, it performs a non-resource
-                            SubjectAccessReview, with verb and path inferred from
-                            the request.
-                          properties:
-                            group:
-                              description: API group of the resource. Use '*' for
-                                all API groups.
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            name:
-                              description: Resource name Omit it to check for authorization
-                                on all resources of the specified kind.
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            namespace:
-                              description: Namespace where the user must have permissions
-                                on the resource.
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            resource:
-                              description: Resource kind Use '*' for all resource
-                                kinds.
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            subresource:
-                              description: Subresource kind
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            verb:
-                              description: Verb to check for authorization on the
-                                resource. Use '*' for all verbs.
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                          type: object
-                        user:
-                          description: User to check for authorization in the Kubernetes
-                            RBAC. Omit it to check for group authorization only.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this config should generate individual
-                        observability metrics
-                      type: boolean
-                    opa:
-                      description: Open Policy Agent (OPA) Rego policy.
-                      properties:
-                        allValues:
-                          default: false
-                          description: Returns the value of all Rego rules in the
-                            virtual document. Values can be read in subsequent evaluators/phases
-                            of the Auth Pipeline. Otherwise, only the default `allow`
-                            rule will be exposed. Returning all Rego rules can affect
-                            performance of OPA policies during reconciliation (policy
-                            precompile) and at runtime.
-                          type: boolean
-                        externalPolicy:
-                          description: 'Settings for fetching the OPA policy from
-                            an external registry. Use it alternatively to ''rego''.
-                            For the configurations of the HTTP request, the following
-                            options are not implemented: ''method'', ''body'', ''bodyParameters'',
-                            ''contentType'', ''headers'', ''oauth2''. Use it only
-                            with: ''url'', ''sharedSecret'', ''credentials''.'
-                          properties:
-                            body:
-                              description: Raw body of the HTTP request. Supersedes
-                                'bodyParameters'; use either one or the other. Use
-                                it with method=POST; for GET requests, set parameters
-                                as query string in the 'endpoint' (placeholders can
-                                be used).
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            bodyParameters:
-                              additionalProperties:
-                                properties:
-                                  selector:
-                                    description: 'Simple path selector to fetch content
-                                      from the authorization JSON (e.g. ''request.method'')
-                                      or a string template with variables that resolve
-                                      to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following Authorino custom
-                                      modifiers are supported: @extract:{sep:" ",pos:0},
-                                      @replace{old:"",new:""}, @case:upper|lower,
-                                      @base64:encode|decode and @strip.'
-                                    type: string
-                                  value:
-                                    description: Static value
-                                    x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                              description: Custom parameters to encode in the body
-                                of the HTTP request. Superseded by 'body'; use either
-                                one or the other. Use it with method=POST; for GET
-                                requests, set parameters as query string in the 'endpoint'
-                                (placeholders can be used).
-                              type: object
-                            contentType:
-                              default: application/x-www-form-urlencoded
-                              description: Content-Type of the request body. Shapes
-                                how 'bodyParameters' are encoded. Use it with method=POST;
-                                for GET requests, Content-Type is automatically set
-                                to 'text/plain'.
-                              enum:
-                              - application/x-www-form-urlencoded
-                              - application/json
-                              type: string
-                            credentials:
-                              description: Defines where client credentials will be
-                                passed in the request to the service. If omitted,
-                                it defaults to client credentials passed in the HTTP
-                                Authorization header and the "Bearer" prefix expected
-                                prepended to the secret value.
-                              properties:
-                                authorizationHeader:
-                                  properties:
-                                    prefix:
-                                      type: string
-                                  type: object
-                                cookie:
-                                  properties:
-                                    name:
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                customHeader:
-                                  properties:
-                                    name:
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                queryString:
-                                  properties:
-                                    name:
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                              type: object
-                            headers:
-                              additionalProperties:
-                                properties:
-                                  selector:
-                                    description: 'Simple path selector to fetch content
-                                      from the authorization JSON (e.g. ''request.method'')
-                                      or a string template with variables that resolve
-                                      to patterns (e.g. "Hello, {auth.identity.name}!").
-                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. The following Authorino custom
-                                      modifiers are supported: @extract:{sep:" ",pos:0},
-                                      @replace{old:"",new:""}, @case:upper|lower,
-                                      @base64:encode|decode and @strip.'
-                                    type: string
-                                  value:
-                                    description: Static value
-                                    x-kubernetes-preserve-unknown-fields: true
-                                type: object
-                              description: Custom headers in the HTTP request.
-                              type: object
-                            method:
-                              default: GET
-                              description: 'HTTP verb used in the request to the service.
-                                Accepted values: GET (default), POST. When the request
-                                method is POST, the authorization JSON is passed in
-                                the body of the request.'
-                              enum:
-                              - GET
-                              - POST
-                              - PUT
-                              - PATCH
-                              - DELETE
-                              - HEAD
-                              - OPTIONS
-                              - CONNECT
-                              - TRACE
-                              type: string
-                            oauth2:
-                              description: Authentication with the HTTP service by
-                                OAuth2 Client Credentials grant.
-                              properties:
-                                cache:
-                                  default: true
-                                  description: Caches and reuses the token until expired.
-                                    Set it to false to force fetch the token at every
-                                    authorization request regardless of expiration.
-                                  type: boolean
-                                clientId:
-                                  description: OAuth2 Client ID.
-                                  type: string
-                                clientSecretRef:
-                                  description: Reference to a Kuberentes Secret key
-                                    that stores that OAuth2 Client Secret.
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: The name of the secret in the Authorino's
-                                        namespace to select from.
-                                      type: string
-                                  required:
-                                  - key
-                                  - name
-                                  type: object
-                                extraParams:
-                                  additionalProperties:
-                                    type: string
-                                  description: Optional extra parameters for the requests
-                                    to the token URL.
-                                  type: object
-                                scopes:
-                                  description: Optional scopes for the client credentials
-                                    grant, if supported by he OAuth2 server.
-                                  items:
-                                    type: string
-                                  type: array
-                                tokenUrl:
-                                  description: Token endpoint URL of the OAuth2 resource
-                                    server.
-                                  type: string
-                              required:
-                              - clientId
-                              - clientSecretRef
-                              - tokenUrl
-                              type: object
-                            sharedSecretRef:
-                              description: Reference to a Secret key whose value will
-                                be passed by Authorino in the request. The HTTP service
-                                can use the shared secret to authenticate the origin
-                                of the request. Ignored if used together with oauth2.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            ttl:
-                              description: Duration (in seconds) of the external data
-                                in the cache before pulled again from the source.
-                              type: integer
-                            url:
-                              description: Endpoint URL of the HTTP service. The value
-                                can include variable placeholders in the format "{selector}",
-                                where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                and selects value from the authorization JSON. E.g.
-                                https://ext-auth-server.io/metadata?p={request.path}
-                              type: string
-                          required:
-                          - url
-                          type: object
-                        rego:
-                          description: Authorization policy as a Rego language document.
-                            The Rego document must include the "allow" condition,
-                            set by Authorino to "false" by default (i.e. requests
-                            are unauthorized unless changed). The Rego document must
-                            NOT include the "package" declaration in line 1.
-                          type: string
-                      type: object
-                    patternMatching:
-                      description: Pattern-matching authorization rules.
-                      properties:
-                        patterns:
-                          items:
-                            oneOf:
-                            - properties:
-                                patternRef: {}
-                              required:
-                              - patternRef
-                            - properties:
-                                operator: {}
-                                selector: {}
-                                value: {}
-                              required:
-                              - operator
-                              - selector
-                            - properties:
-                                all: {}
-                              required:
-                              - all
-                            - properties:
-                                any: {}
-                              required:
-                              - any
-                            properties:
-                              all:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical AND.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              any:
-                                description: A list of pattern expressions to be evaluated
-                                  as a logical OR.
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                                type: array
-                              operator:
-                                description: 'The binary operator to be applied to
-                                  the content fetched from the authorization JSON,
-                                  for comparison with "value". Possible values are:
-                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
-                                  for arrays), "excl" (excludes; for arrays), "matches"
-                                  (regex)'
-                                enum:
-                                - eq
-                                - neq
-                                - incl
-                                - excl
-                                - matches
-                                type: string
-                              patternRef:
-                                description: Reference to a named set of pattern expressions
-                                type: string
-                              selector:
-                                description: Path selector to fetch content from the
-                                  authorization JSON (e.g. 'request.method'). Any
-                                  pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. Authorino custom JSON path modifiers
-                                  are also supported.
-                                type: string
-                              value:
-                                description: The value of reference for the comparison
-                                  with the content fetched from the authorization
-                                  JSON. If used with the "matches" operator, the value
-                                  must compile to a valid Golang regex.
-                                type: string
-                            type: object
-                          type: array
-                      required:
-                      - patterns
-                      type: object
-                    priority:
-                      default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
-                      type: integer
-                    spicedb:
-                      description: Authorization decision delegated to external Authzed/SpiceDB
-                        server.
-                      properties:
-                        endpoint:
-                          description: Hostname and port number to the GRPC interface
-                            of the SpiceDB server (e.g. spicedb:50051).
-                          type: string
-                        insecure:
-                          description: Insecure HTTP connection (i.e. disables TLS
-                            verification)
-                          type: boolean
-                        permission:
-                          description: The name of the permission (or relation) on
-                            which to execute the check.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        resource:
-                          description: The resource on which to check the permission
-                            or relation.
-                          properties:
-                            kind:
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            name:
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be used by Authorino to authenticate with the Authzed
-                            service.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        subject:
-                          description: The subject that will be checked for the permission
-                            or relation.
-                          properties:
-                            kind:
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            name:
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                          type: object
-                      required:
-                      - endpoint
-                      type: object
-                    when:
-                      description: Conditions for Authorino to enforce this config.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Reference to a named set of pattern expressions
-                            type: string
-                          selector:
-                            description: Path selector to fetch content from the authorization
-                              JSON (e.g. 'request.method'). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. Authorino custom JSON path modifiers are also
-                              supported.
-                            type: string
-                          value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                description: Authorization policies. All policies MUST evaluate to
-                  "allowed = true" for the auth request be successful.
-                type: object
-              callbacks:
-                additionalProperties:
-                  properties:
-                    cache:
-                      description: Caching options for the resolved object returned
-                        when applying this config. Omit it to avoid caching objects
-                        for this config.
-                      properties:
-                        key:
-                          description: Key used to store the entry in the cache. The
-                            resolved key must be unique within the scope of this particular
-                            config.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    http:
-                      description: Settings of the external HTTP request
-                      properties:
-                        body:
-                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
-                            use either one or the other. Use it with method=POST;
-                            for GET requests, set parameters as query string in the
-                            'endpoint' (placeholders can be used).
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        bodyParameters:
-                          additionalProperties:
-                            properties:
-                              selector:
-                                description: 'Simple path selector to fetch content
-                                  from the authorization JSON (e.g. ''request.method'')
-                                  or a string template with variables that resolve
-                                  to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following Authorino custom modifiers
-                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
-                                type: string
-                              value:
-                                description: Static value
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Superseded by 'body'; use either one
-                            or the other. Use it with method=POST; for GET requests,
-                            set parameters as query string in the 'endpoint' (placeholders
-                            can be used).
-                          type: object
-                        contentType:
-                          default: application/x-www-form-urlencoded
-                          description: Content-Type of the request body. Shapes how
-                            'bodyParameters' are encoded. Use it with method=POST;
-                            for GET requests, Content-Type is automatically set to
-                            'text/plain'.
-                          enum:
-                          - application/x-www-form-urlencoded
-                          - application/json
-                          type: string
-                        credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
-                          properties:
-                            authorizationHeader:
-                              properties:
-                                prefix:
-                                  type: string
-                              type: object
-                            cookie:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            customHeader:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            queryString:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          type: object
-                        headers:
-                          additionalProperties:
-                            properties:
-                              selector:
-                                description: 'Simple path selector to fetch content
-                                  from the authorization JSON (e.g. ''request.method'')
-                                  or a string template with variables that resolve
-                                  to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following Authorino custom modifiers
-                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
-                                type: string
-                              value:
-                                description: Static value
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          description: Custom headers in the HTTP request.
-                          type: object
-                        method:
-                          default: GET
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
-                          enum:
-                          - GET
-                          - POST
-                          - PUT
-                          - PATCH
-                          - DELETE
-                          - HEAD
-                          - OPTIONS
-                          - CONNECT
-                          - TRACE
-                          type: string
-                        oauth2:
-                          description: Authentication with the HTTP service by OAuth2
-                            Client Credentials grant.
-                          properties:
-                            cache:
-                              default: true
-                              description: Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every
-                                authorization request regardless of expiration.
-                              type: boolean
-                            clientId:
-                              description: OAuth2 Client ID.
-                              type: string
-                            clientSecretRef:
-                              description: Reference to a Kuberentes Secret key that
-                                stores that OAuth2 Client Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            extraParams:
-                              additionalProperties:
-                                type: string
-                              description: Optional extra parameters for the requests
-                                to the token URL.
-                              type: object
-                            scopes:
-                              description: Optional scopes for the client credentials
-                                grant, if supported by he OAuth2 server.
-                              items:
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: Token endpoint URL of the OAuth2 resource
-                                server.
-                              type: string
-                          required:
-                          - clientId
-                          - clientSecretRef
-                          - tokenUrl
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request. Ignored if used together with oauth2.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        url:
-                          description: Endpoint URL of the HTTP service. The value
-                            can include variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
-                          type: string
-                      required:
-                      - url
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this config should generate individual
-                        observability metrics
-                      type: boolean
-                    priority:
-                      default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
-                      type: integer
-                    when:
-                      description: Conditions for Authorino to enforce this config.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
-                      items:
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Reference to a named set of pattern expressions
-                            type: string
-                          selector:
-                            description: Path selector to fetch content from the authorization
-                              JSON (e.g. 'request.method'). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. Authorino custom JSON path modifiers are also
-                              supported.
-                            type: string
-                          value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - http
-                  type: object
-                description: Callback functions. Authorino sends callbacks at the
-                  end of the auth pipeline to the endpoints specified in this config.
-                type: object
-              hosts:
-                description: The list of public host names of the services protected
-                  by this authentication/authorization scheme. Authorino uses the
-                  requested host to lookup for the corresponding authentication/authorization
-                  configs to enforce.
-                items:
-                  type: string
-                type: array
-              metadata:
-                additionalProperties:
-                  oneOf:
-                  - properties:
-                      userInfo: {}
-                    required:
-                    - userInfo
-                  - properties:
-                      uma: {}
-                    required:
-                    - uma
-                  - properties:
-                      http: {}
-                    required:
-                    - http
-                  properties:
-                    cache:
-                      description: Caching options for the resolved object returned
-                        when applying this config. Omit it to avoid caching objects
-                        for this config.
-                      properties:
-                        key:
-                          description: Key used to store the entry in the cache. The
-                            resolved key must be unique within the scope of this particular
-                            config.
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        ttl:
-                          default: 60
-                          description: Duration (in seconds) of the external data
-                            in the cache before pulled again from the source.
-                          type: integer
-                      required:
-                      - key
-                      type: object
-                    http:
-                      description: External source of auth metadata via HTTP request
-                      properties:
-                        body:
-                          description: Raw body of the HTTP request. Supersedes 'bodyParameters';
-                            use either one or the other. Use it with method=POST;
-                            for GET requests, set parameters as query string in the
-                            'endpoint' (placeholders can be used).
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        bodyParameters:
-                          additionalProperties:
-                            properties:
-                              selector:
-                                description: 'Simple path selector to fetch content
-                                  from the authorization JSON (e.g. ''request.method'')
-                                  or a string template with variables that resolve
-                                  to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following Authorino custom modifiers
-                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
-                                type: string
-                              value:
-                                description: Static value
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          description: Custom parameters to encode in the body of
-                            the HTTP request. Superseded by 'body'; use either one
-                            or the other. Use it with method=POST; for GET requests,
-                            set parameters as query string in the 'endpoint' (placeholders
-                            can be used).
-                          type: object
-                        contentType:
-                          default: application/x-www-form-urlencoded
-                          description: Content-Type of the request body. Shapes how
-                            'bodyParameters' are encoded. Use it with method=POST;
-                            for GET requests, Content-Type is automatically set to
-                            'text/plain'.
-                          enum:
-                          - application/x-www-form-urlencoded
-                          - application/json
-                          type: string
-                        credentials:
-                          description: Defines where client credentials will be passed
-                            in the request to the service. If omitted, it defaults
-                            to client credentials passed in the HTTP Authorization
-                            header and the "Bearer" prefix expected prepended to the
-                            secret value.
-                          properties:
-                            authorizationHeader:
-                              properties:
-                                prefix:
-                                  type: string
-                              type: object
-                            cookie:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            customHeader:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            queryString:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                          type: object
-                        headers:
-                          additionalProperties:
-                            properties:
-                              selector:
-                                description: 'Simple path selector to fetch content
-                                  from the authorization JSON (e.g. ''request.method'')
-                                  or a string template with variables that resolve
-                                  to patterns (e.g. "Hello, {auth.identity.name}!").
-                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                  can be used. The following Authorino custom modifiers
-                                  are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                  @case:upper|lower, @base64:encode|decode and @strip.'
-                                type: string
-                              value:
-                                description: Static value
-                                x-kubernetes-preserve-unknown-fields: true
-                            type: object
-                          description: Custom headers in the HTTP request.
-                          type: object
-                        method:
-                          default: GET
-                          description: 'HTTP verb used in the request to the service.
-                            Accepted values: GET (default), POST. When the request
-                            method is POST, the authorization JSON is passed in the
-                            body of the request.'
-                          enum:
-                          - GET
-                          - POST
-                          - PUT
-                          - PATCH
-                          - DELETE
-                          - HEAD
-                          - OPTIONS
-                          - CONNECT
-                          - TRACE
-                          type: string
-                        oauth2:
-                          description: Authentication with the HTTP service by OAuth2
-                            Client Credentials grant.
-                          properties:
-                            cache:
-                              default: true
-                              description: Caches and reuses the token until expired.
-                                Set it to false to force fetch the token at every
-                                authorization request regardless of expiration.
-                              type: boolean
-                            clientId:
-                              description: OAuth2 Client ID.
-                              type: string
-                            clientSecretRef:
-                              description: Reference to a Kuberentes Secret key that
-                                stores that OAuth2 Client Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: The name of the secret in the Authorino's
-                                    namespace to select from.
-                                  type: string
-                              required:
-                              - key
-                              - name
-                              type: object
-                            extraParams:
-                              additionalProperties:
-                                type: string
-                              description: Optional extra parameters for the requests
-                                to the token URL.
-                              type: object
-                            scopes:
-                              description: Optional scopes for the client credentials
-                                grant, if supported by he OAuth2 server.
-                              items:
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: Token endpoint URL of the OAuth2 resource
-                                server.
-                              type: string
-                          required:
-                          - clientId
-                          - clientSecretRef
-                          - tokenUrl
-                          type: object
-                        sharedSecretRef:
-                          description: Reference to a Secret key whose value will
-                            be passed by Authorino in the request. The HTTP service
-                            can use the shared secret to authenticate the origin of
-                            the request. Ignored if used together with oauth2.
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: The name of the secret in the Authorino's
-                                namespace to select from.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        url:
-                          description: Endpoint URL of the HTTP service. The value
-                            can include variable placeholders in the format "{selector}",
-                            where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                            and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}
-                          type: string
-                      required:
-                      - url
-                      type: object
-                    metrics:
-                      default: false
-                      description: Whether this config should generate individual
-                        observability metrics
-                      type: boolean
-                    priority:
-                      default: 0
-                      description: Priority group of the config. All configs in the
-                        same priority group are evaluated concurrently; consecutive
-                        priority groups are evaluated sequentially.
-                      type: integer
-                    uma:
-                      description: User-Managed Access (UMA) source of resource data.
-                      properties:
-                        credentialsRef:
-                          description: Reference to a Kubernetes secret in the same
-                            namespace, that stores client credentials to the resource
-                            registration API of the UMA server.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                        endpoint:
-                          description: The endpoint of the UMA server. The value must
-                            coincide with the "issuer" claim of the UMA config discovered
-                            from the well-known uma configuration endpoint.
-                          type: string
-                      required:
-                      - credentialsRef
-                      - endpoint
-                      type: object
-                    userInfo:
-                      description: OpendID Connect UserInfo linked to an OIDC authentication
-                        config specified in this same AuthConfig.
-                      properties:
-                        identitySource:
-                          description: The name of an OIDC-enabled JWT authentication
-                            config whose OpenID Connect configuration discovered includes
-                            the OIDC "userinfo_endpoint" claim.
-                          type: string
-                      required:
-                      - identitySource
-                      type: object
-                    when:
-                      description: Conditions for Authorino to enforce this config.
-                        If omitted, the config will be enforced for all requests.
-                        If present, all conditions must match for the config to be
-                        enforced; otherwise, the config will be skipped.
-                      items:
-                        oneOf:
-                        - properties:
-                            patternRef: {}
-                          required:
-                          - patternRef
-                        - properties:
-                            operator: {}
-                            selector: {}
-                            value: {}
-                          required:
-                          - operator
-                          - selector
-                        - properties:
-                            all: {}
-                          required:
-                          - all
-                        - properties:
-                            any: {}
-                          required:
-                          - any
-                        properties:
-                          all:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical AND.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          any:
-                            description: A list of pattern expressions to be evaluated
-                              as a logical OR.
-                            items:
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                          operator:
-                            description: 'The binary operator to be applied to the
-                              content fetched from the authorization JSON, for comparison
-                              with "value". Possible values are: "eq" (equal to),
-                              "neq" (not equal to), "incl" (includes; for arrays),
-                              "excl" (excludes; for arrays), "matches" (regex)'
-                            enum:
-                            - eq
-                            - neq
-                            - incl
-                            - excl
-                            - matches
-                            type: string
-                          patternRef:
-                            description: Reference to a named set of pattern expressions
-                            type: string
-                          selector:
-                            description: Path selector to fetch content from the authorization
-                              JSON (e.g. 'request.method'). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. Authorino custom JSON path modifiers are also
-                              supported.
-                            type: string
-                          value:
-                            description: The value of reference for the comparison
-                              with the content fetched from the authorization JSON.
-                              If used with the "matches" operator, the value must
-                              compile to a valid Golang regex.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                description: Metadata sources. Authorino fetches auth metadata as
-                  JSON from sources specified in this config.
-                type: object
-              patterns:
-                additionalProperties:
-                  items:
-                    properties:
-                      operator:
-                        description: 'The binary operator to be applied to the content
-                          fetched from the authorization JSON, for comparison with
-                          "value". Possible values are: "eq" (equal to), "neq" (not
-                          equal to), "incl" (includes; for arrays), "excl" (excludes;
-                          for arrays), "matches" (regex)'
-                        enum:
-                        - eq
-                        - neq
-                        - incl
-                        - excl
-                        - matches
-                        type: string
-                      selector:
-                        description: Path selector to fetch content from the authorization
-                          JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                          can be used. Authorino custom JSON path modifiers are also
-                          supported.
-                        type: string
-                      value:
-                        description: The value of reference for the comparison with
-                          the content fetched from the authorization JSON. If used
-                          with the "matches" operator, the value must compile to a
-                          valid Golang regex.
-                        type: string
-                    type: object
-                  type: array
-                description: Named sets of patterns that can be referred in `when`
-                  conditions and in pattern-matching authorization policy rules.
-                type: object
-              response:
-                description: Response items. Authorino builds custom responses to
-                  the client of the auth request.
-                properties:
-                  success:
-                    description: Response items to be included in the auth response
-                      when the request is authenticated and authorized. For integration
-                      of Authorino via proxy, the proxy must use these settings to
-                      propagate dynamic metadata and/or inject data in the request.
-                    properties:
-                      dynamicMetadata:
-                        additionalProperties:
-                          description: Settings of the success custom response item.
-                          oneOf:
-                          - properties:
-                              wristband: {}
-                            required:
-                            - wristband
-                          - properties:
-                              json: {}
-                            required:
-                            - json
-                          - properties:
-                              plain: {}
-                            required:
-                            - plain
-                          properties:
-                            cache:
-                              description: Caching options for the resolved object
-                                returned when applying this config. Omit it to avoid
-                                caching objects for this config.
-                              properties:
-                                key:
-                                  description: Key used to store the entry in the
-                                    cache. The resolved key must be unique within
-                                    the scope of this particular config.
-                                  properties:
-                                    selector:
-                                      description: 'Simple path selector to fetch
-                                        content from the authorization JSON (e.g.
-                                        ''request.method'') or a string template with
-                                        variables that resolve to patterns (e.g. "Hello,
-                                        {auth.identity.name}!"). Any pattern supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following Authorino custom
-                                        modifiers are supported: @extract:{sep:" ",pos:0},
-                                        @replace{old:"",new:""}, @case:upper|lower,
-                                        @base64:encode|decode and @strip.'
-                                      type: string
-                                    value:
-                                      description: Static value
-                                      x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                ttl:
-                                  default: 60
-                                  description: Duration (in seconds) of the external
-                                    data in the cache before pulled again from the
-                                    source.
-                                  type: integer
-                              required:
-                              - key
-                              type: object
-                            json:
-                              description: JSON object Specify it as the list of properties
-                                of the object, whose values can combine static values
-                                and values selected from the authorization JSON.
-                              properties:
-                                properties:
-                                  additionalProperties:
-                                    properties:
-                                      selector:
-                                        description: 'Simple path selector to fetch
-                                          content from the authorization JSON (e.g.
-                                          ''request.method'') or a string template
-                                          with variables that resolve to patterns
-                                          (e.g. "Hello, {auth.identity.name}!"). Any
-                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                          can be used. The following Authorino custom
-                                          modifiers are supported: @extract:{sep:"
-                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                          @base64:encode|decode and @strip.'
-                                        type: string
-                                      value:
-                                        description: Static value
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    type: object
-                                  type: object
-                              required:
-                              - properties
-                              type: object
-                            key:
-                              description: The key used to add the custom response
-                                item (name of the HTTP header or root property of
-                                the Dynamic Metadata object). If omitted, it will
-                                be set to the name of the response config.
-                              type: string
-                            metrics:
-                              default: false
-                              description: Whether this config should generate individual
-                                observability metrics
-                              type: boolean
-                            plain:
-                              description: Plain text content
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            priority:
-                              default: 0
-                              description: Priority group of the config. All configs
-                                in the same priority group are evaluated concurrently;
-                                consecutive priority groups are evaluated sequentially.
-                              type: integer
-                            when:
-                              description: Conditions for Authorino to enforce this
-                                config. If omitted, the config will be enforced for
-                                all requests. If present, all conditions must match
-                                for the config to be enforced; otherwise, the config
-                                will be skipped.
-                              items:
-                                oneOf:
-                                - properties:
-                                    patternRef: {}
-                                  required:
-                                  - patternRef
-                                - properties:
-                                    operator: {}
-                                    selector: {}
-                                    value: {}
-                                  required:
-                                  - operator
-                                  - selector
-                                - properties:
-                                    all: {}
-                                  required:
-                                  - all
-                                - properties:
-                                    any: {}
-                                  required:
-                                  - any
-                                properties:
-                                  all:
-                                    description: A list of pattern expressions to
-                                      be evaluated as a logical AND.
-                                    items:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  any:
-                                    description: A list of pattern expressions to
-                                      be evaluated as a logical OR.
-                                    items:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  operator:
-                                    description: 'The binary operator to be applied
-                                      to the content fetched from the authorization
-                                      JSON, for comparison with "value". Possible
-                                      values are: "eq" (equal to), "neq" (not equal
-                                      to), "incl" (includes; for arrays), "excl" (excludes;
-                                      for arrays), "matches" (regex)'
-                                    enum:
-                                    - eq
-                                    - neq
-                                    - incl
-                                    - excl
-                                    - matches
-                                    type: string
-                                  patternRef:
-                                    description: Reference to a named set of pattern
-                                      expressions
-                                    type: string
-                                  selector:
-                                    description: Path selector to fetch content from
-                                      the authorization JSON (e.g. 'request.method').
-                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. Authorino custom JSON path modifiers
-                                      are also supported.
-                                    type: string
-                                  value:
-                                    description: The value of reference for the comparison
-                                      with the content fetched from the authorization
-                                      JSON. If used with the "matches" operator, the
-                                      value must compile to a valid Golang regex.
-                                    type: string
-                                type: object
-                              type: array
-                            wristband:
-                              description: Authorino Festival Wristband token
-                              properties:
-                                customClaims:
-                                  additionalProperties:
-                                    properties:
-                                      selector:
-                                        description: 'Simple path selector to fetch
-                                          content from the authorization JSON (e.g.
-                                          ''request.method'') or a string template
-                                          with variables that resolve to patterns
-                                          (e.g. "Hello, {auth.identity.name}!"). Any
-                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                          can be used. The following Authorino custom
-                                          modifiers are supported: @extract:{sep:"
-                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                          @base64:encode|decode and @strip.'
-                                        type: string
-                                      value:
-                                        description: Static value
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    type: object
-                                  description: Any claims to be added to the wristband
-                                    token apart from the standard JWT claims (iss,
-                                    iat, exp) added by default.
-                                  type: object
-                                issuer:
-                                  description: 'The endpoint to the Authorino service
-                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
-                                  type: string
-                                signingKeyRefs:
-                                  description: Reference by name to Kubernetes secrets
-                                    and corresponding signing algorithms. The secrets
-                                    must contain a `key.pem` entry whose value is
-                                    the signing key formatted as PEM.
-                                  items:
-                                    properties:
-                                      algorithm:
-                                        description: Algorithm to sign the wristband
-                                          token using the signing key provided
-                                        enum:
-                                        - ES256
-                                        - ES384
-                                        - ES512
-                                        - RS256
-                                        - RS384
-                                        - RS512
-                                        type: string
-                                      name:
-                                        description: Name of the signing key. The
-                                          value is used to reference the Kubernetes
-                                          secret that stores the key and in the `kid`
-                                          claim of the wristband token header.
-                                        type: string
-                                    required:
-                                    - algorithm
-                                    - name
-                                    type: object
-                                  type: array
-                                tokenDuration:
-                                  description: Time span of the wristband token, in
-                                    seconds.
-                                  format: int64
-                                  type: integer
-                              required:
-                              - issuer
-                              - signingKeyRefs
-                              type: object
-                          type: object
-                        description: Custom success response items wrapped as HTTP
-                          headers. For integration of Authorino via proxy, the proxy
-                          must use these settings to propagate dynamic metadata. See
-                          https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-                        type: object
-                      headers:
-                        additionalProperties:
-                          oneOf:
-                          - properties:
-                              wristband: {}
-                            required:
-                            - wristband
-                          - properties:
-                              json: {}
-                            required:
-                            - json
-                          - properties:
-                              plain: {}
-                            required:
-                            - plain
-                          properties:
-                            cache:
-                              description: Caching options for the resolved object
-                                returned when applying this config. Omit it to avoid
-                                caching objects for this config.
-                              properties:
-                                key:
-                                  description: Key used to store the entry in the
-                                    cache. The resolved key must be unique within
-                                    the scope of this particular config.
-                                  properties:
-                                    selector:
-                                      description: 'Simple path selector to fetch
-                                        content from the authorization JSON (e.g.
-                                        ''request.method'') or a string template with
-                                        variables that resolve to patterns (e.g. "Hello,
-                                        {auth.identity.name}!"). Any pattern supported
-                                        by https://pkg.go.dev/github.com/tidwall/gjson
-                                        can be used. The following Authorino custom
-                                        modifiers are supported: @extract:{sep:" ",pos:0},
-                                        @replace{old:"",new:""}, @case:upper|lower,
-                                        @base64:encode|decode and @strip.'
-                                      type: string
-                                    value:
-                                      description: Static value
-                                      x-kubernetes-preserve-unknown-fields: true
-                                  type: object
-                                ttl:
-                                  default: 60
-                                  description: Duration (in seconds) of the external
-                                    data in the cache before pulled again from the
-                                    source.
-                                  type: integer
-                              required:
-                              - key
-                              type: object
-                            json:
-                              description: JSON object Specify it as the list of properties
-                                of the object, whose values can combine static values
-                                and values selected from the authorization JSON.
-                              properties:
-                                properties:
-                                  additionalProperties:
-                                    properties:
-                                      selector:
-                                        description: 'Simple path selector to fetch
-                                          content from the authorization JSON (e.g.
-                                          ''request.method'') or a string template
-                                          with variables that resolve to patterns
-                                          (e.g. "Hello, {auth.identity.name}!"). Any
-                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                          can be used. The following Authorino custom
-                                          modifiers are supported: @extract:{sep:"
-                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                          @base64:encode|decode and @strip.'
-                                        type: string
-                                      value:
-                                        description: Static value
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    type: object
-                                  type: object
-                              required:
-                              - properties
-                              type: object
-                            key:
-                              description: The key used to add the custom response
-                                item (name of the HTTP header or root property of
-                                the Dynamic Metadata object). If omitted, it will
-                                be set to the name of the response config.
-                              type: string
-                            metrics:
-                              default: false
-                              description: Whether this config should generate individual
-                                observability metrics
-                              type: boolean
-                            plain:
-                              description: Plain text content
-                              properties:
-                                selector:
-                                  description: 'Simple path selector to fetch content
-                                    from the authorization JSON (e.g. ''request.method'')
-                                    or a string template with variables that resolve
-                                    to patterns (e.g. "Hello, {auth.identity.name}!").
-                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                    can be used. The following Authorino custom modifiers
-                                    are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                    @case:upper|lower, @base64:encode|decode and @strip.'
-                                  type: string
-                                value:
-                                  description: Static value
-                                  x-kubernetes-preserve-unknown-fields: true
-                              type: object
-                            priority:
-                              default: 0
-                              description: Priority group of the config. All configs
-                                in the same priority group are evaluated concurrently;
-                                consecutive priority groups are evaluated sequentially.
-                              type: integer
-                            when:
-                              description: Conditions for Authorino to enforce this
-                                config. If omitted, the config will be enforced for
-                                all requests. If present, all conditions must match
-                                for the config to be enforced; otherwise, the config
-                                will be skipped.
-                              items:
-                                oneOf:
-                                - properties:
-                                    patternRef: {}
-                                  required:
-                                  - patternRef
-                                - properties:
-                                    operator: {}
-                                    selector: {}
-                                    value: {}
-                                  required:
-                                  - operator
-                                  - selector
-                                - properties:
-                                    all: {}
-                                  required:
-                                  - all
-                                - properties:
-                                    any: {}
-                                  required:
-                                  - any
-                                properties:
-                                  all:
-                                    description: A list of pattern expressions to
-                                      be evaluated as a logical AND.
-                                    items:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  any:
-                                    description: A list of pattern expressions to
-                                      be evaluated as a logical OR.
-                                    items:
-                                      type: object
-                                      x-kubernetes-preserve-unknown-fields: true
-                                    type: array
-                                  operator:
-                                    description: 'The binary operator to be applied
-                                      to the content fetched from the authorization
-                                      JSON, for comparison with "value". Possible
-                                      values are: "eq" (equal to), "neq" (not equal
-                                      to), "incl" (includes; for arrays), "excl" (excludes;
-                                      for arrays), "matches" (regex)'
-                                    enum:
-                                    - eq
-                                    - neq
-                                    - incl
-                                    - excl
-                                    - matches
-                                    type: string
-                                  patternRef:
-                                    description: Reference to a named set of pattern
-                                      expressions
-                                    type: string
-                                  selector:
-                                    description: Path selector to fetch content from
-                                      the authorization JSON (e.g. 'request.method').
-                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                      can be used. Authorino custom JSON path modifiers
-                                      are also supported.
-                                    type: string
-                                  value:
-                                    description: The value of reference for the comparison
-                                      with the content fetched from the authorization
-                                      JSON. If used with the "matches" operator, the
-                                      value must compile to a valid Golang regex.
-                                    type: string
-                                type: object
-                              type: array
-                            wristband:
-                              description: Authorino Festival Wristband token
-                              properties:
-                                customClaims:
-                                  additionalProperties:
-                                    properties:
-                                      selector:
-                                        description: 'Simple path selector to fetch
-                                          content from the authorization JSON (e.g.
-                                          ''request.method'') or a string template
-                                          with variables that resolve to patterns
-                                          (e.g. "Hello, {auth.identity.name}!"). Any
-                                          pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                          can be used. The following Authorino custom
-                                          modifiers are supported: @extract:{sep:"
-                                          ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                                          @base64:encode|decode and @strip.'
-                                        type: string
-                                      value:
-                                        description: Static value
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    type: object
-                                  description: Any claims to be added to the wristband
-                                    token apart from the standard JWT claims (iss,
-                                    iat, exp) added by default.
-                                  type: object
-                                issuer:
-                                  description: 'The endpoint to the Authorino service
-                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
-                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
-                                  type: string
-                                signingKeyRefs:
-                                  description: Reference by name to Kubernetes secrets
-                                    and corresponding signing algorithms. The secrets
-                                    must contain a `key.pem` entry whose value is
-                                    the signing key formatted as PEM.
-                                  items:
-                                    properties:
-                                      algorithm:
-                                        description: Algorithm to sign the wristband
-                                          token using the signing key provided
-                                        enum:
-                                        - ES256
-                                        - ES384
-                                        - ES512
-                                        - RS256
-                                        - RS384
-                                        - RS512
-                                        type: string
-                                      name:
-                                        description: Name of the signing key. The
-                                          value is used to reference the Kubernetes
-                                          secret that stores the key and in the `kid`
-                                          claim of the wristband token header.
-                                        type: string
-                                    required:
-                                    - algorithm
-                                    - name
-                                    type: object
-                                  type: array
-                                tokenDuration:
-                                  description: Time span of the wristband token, in
-                                    seconds.
-                                  format: int64
-                                  type: integer
-                              required:
-                              - issuer
-                              - signingKeyRefs
-                              type: object
-                          type: object
-                        description: Custom success response items wrapped as HTTP
-                          headers. For integration of Authorino via proxy, the proxy
-                          must use these settings to inject data in the request.
-                        type: object
-                    type: object
-                  unauthenticated:
-                    description: 'Customizations on the denial status attributes when
-                      the request is unauthenticated. For integration of Authorino
-                      via proxy, the proxy must honour the response status attributes
-                      specified in this config. Default: 401 Unauthorized'
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        additionalProperties:
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        type: object
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                    type: object
-                  unauthorized:
-                    description: 'Customizations on the denial status attributes when
-                      the request is unauthorized. For integration of Authorino via
-                      proxy, the proxy must honour the response status attributes
-                      specified in this config. Default: 403 Forbidden'
-                    properties:
-                      body:
-                        description: HTTP response body to override the default denial
-                          body.
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                      code:
-                        description: HTTP status code to override the default denial
-                          status code.
-                        format: int64
-                        maximum: 599
-                        minimum: 300
-                        type: integer
-                      headers:
-                        additionalProperties:
-                          properties:
-                            selector:
-                              description: 'Simple path selector to fetch content
-                                from the authorization JSON (e.g. ''request.method'')
-                                or a string template with variables that resolve to
-                                patterns (e.g. "Hello, {auth.identity.name}!"). Any
-                                pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                                can be used. The following Authorino custom modifiers
-                                are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
-                                @case:upper|lower, @base64:encode|decode and @strip.'
-                              type: string
-                            value:
-                              description: Static value
-                              x-kubernetes-preserve-unknown-fields: true
-                          type: object
-                        description: HTTP response headers to override the default
-                          denial headers.
-                        type: object
-                      message:
-                        description: HTTP message to override the default denial message.
-                        properties:
-                          selector:
-                            description: 'Simple path selector to fetch content from
-                              the authorization JSON (e.g. ''request.method'') or
-                              a string template with variables that resolve to patterns
-                              (e.g. "Hello, {auth.identity.name}!"). Any pattern supported
-                              by https://pkg.go.dev/github.com/tidwall/gjson can be
-                              used. The following Authorino custom modifiers are supported:
-                              @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower,
-                              @base64:encode|decode and @strip.'
-                            type: string
-                          value:
-                            description: Static value
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                    type: object
-                type: object
-              when:
-                description: Overall conditions for the AuthConfig to be enforced.
-                  If omitted, the AuthConfig will be enforced at all requests. If
-                  present, all conditions must match for the AuthConfig to be enforced;
-                  otherwise, Authorino skips the AuthConfig and returns to the auth
-                  request with status OK.
-                items:
-                  oneOf:
-                  - properties:
-                      patternRef: {}
-                    required:
-                    - patternRef
-                  - properties:
-                      operator: {}
-                      selector: {}
-                      value: {}
-                    required:
-                    - operator
-                    - selector
-                  - properties:
-                      all: {}
-                    required:
-                    - all
-                  - properties:
-                      any: {}
-                    required:
-                    - any
-                  properties:
-                    all:
-                      description: A list of pattern expressions to be evaluated as
-                        a logical AND.
-                      items:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    any:
-                      description: A list of pattern expressions to be evaluated as
-                        a logical OR.
-                      items:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      type: array
-                    operator:
-                      description: 'The binary operator to be applied to the content
-                        fetched from the authorization JSON, for comparison with "value".
-                        Possible values are: "eq" (equal to), "neq" (not equal to),
-                        "incl" (includes; for arrays), "excl" (excludes; for arrays),
-                        "matches" (regex)'
-                      enum:
-                      - eq
-                      - neq
-                      - incl
-                      - excl
-                      - matches
-                      type: string
-                    patternRef:
-                      description: Reference to a named set of pattern expressions
-                      type: string
-                    selector:
-                      description: Path selector to fetch content from the authorization
-                        JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
-                        can be used. Authorino custom JSON path modifiers are also
-                        supported.
-                      type: string
-                    value:
-                      description: The value of reference for the comparison with
-                        the content fetched from the authorization JSON. If used with
-                        the "matches" operator, the value must compile to a valid
-                        Golang regex.
+                      description: |-
+                        The value of reference for the comparison with the content fetched from the authorization JSON.
+                        If used with the "matches" operator, the value must compile to a valid Golang regex.
                       type: string
                   type: object
                 type: array
@@ -5379,22 +2183,2305 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: AuthConfig
-    listKind: AuthConfigList
-    plural: authconfigs
-    singular: authconfig
-  conditions:
-  - lastTransitionTime: "2023-11-21T17:56:45Z"
-    message: no conflicts found
-    reason: NoConflicts
-    status: "True"
-    type: NamesAccepted
-  - lastTransitionTime: "2023-11-21T17:56:45Z"
-    message: the initial names have been accepted
-    reason: InitialNamesAccepted
-    status: "True"
-    type: Established
-  storedVersions:
-  - v1beta1
+  - additionalPrinterColumns:
+    - description: Ready for all hosts
+      jsonPath: .status.summary.ready
+      name: Ready
+      type: string
+    - description: Number of hosts ready
+      jsonPath: .status.summary.numHostsReady
+      name: Hosts
+      type: string
+    - description: Number of trusted identity sources
+      jsonPath: .status.summary.numIdentitySources
+      name: Authentication
+      priority: 2
+      type: integer
+    - description: Number of external metadata sources
+      jsonPath: .status.summary.numMetadataSources
+      name: Metadata
+      priority: 2
+      type: integer
+    - description: Number of authorization policies
+      jsonPath: .status.summary.numAuthorizationPolicies
+      name: Authorization
+      priority: 2
+      type: integer
+    - description: Number of items added to the authorization response
+      jsonPath: .status.summary.numResponseItems
+      name: Response
+      priority: 2
+      type: integer
+    - description: Whether issuing Festival Wristbands
+      jsonPath: .status.summary.festivalWristbandEnabled
+      name: Wristband
+      priority: 2
+      type: boolean
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: AuthConfig is the schema for Authorino's AuthConfig API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specifies the desired state of the AuthConfig resource, i.e.
+              the authencation/authorization scheme to be applied to protect the matching
+              service hosts.
+            properties:
+              authentication:
+                additionalProperties:
+                  properties:
+                    anonymous:
+                      description: Anonymous access.
+                      type: object
+                    apiKey:
+                      description: Authentication based on API keys stored in Kubernetes
+                        secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: |-
+                            Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
+                          type: boolean
+                        selector:
+                          description: Label selector used by Authorino to match secrets
+                            from the cluster storing valid credentials to authenticate
+                            to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - selector
+                      type: object
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    credentials:
+                      description: |-
+                        Defines where credentials are required to be passed in the request for authentication based on this config.
+                        If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
+                      properties:
+                        authorizationHeader:
+                          properties:
+                            prefix:
+                              type: string
+                          type: object
+                        cookie:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        customHeader:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        queryString:
+                          properties:
+                            name:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    defaults:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: |-
+                        Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                        the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
+                    jwt:
+                      description: Authentication based on JWT tokens.
+                      properties:
+                        issuerUrl:
+                          description: |-
+                            URL of the issuer of the JWT.
+                            If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                            (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                            the "jkws_uri" claim from.
+                            The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                          type: string
+                        ttl:
+                          description: |-
+                            Decides how long to wait before refreshing the JWKS (in seconds).
+                            If omitted, Authorino will never refresh the JWKS.
+                          type: integer
+                      type: object
+                    kubernetesTokenReview:
+                      description: Authentication by Kubernetes token review.
+                      properties:
+                        audiences:
+                          description: |-
+                            The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino.
+                            If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    oauth2Introspection:
+                      description: Authentication by OAuth2 token introspection.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the OAuth2
+                            server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpoint:
+                          description: The full URL of the token introspection endpoint.
+                          type: string
+                        tokenTypeHint:
+                          description: |-
+                            The token type hint for the token introspection.
+                            If omitted, it defaults to "access_token".
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    overrides:
+                      additionalProperties:
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      description: |-
+                        Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                        before appending the object to the authorization JSON.
+                        It requires the resolved identity object to always be a JSON object.
+                        Do not use this option with identity objects of other JSON types (array, string, etc).
+                      type: object
+                    plain:
+                      description: |-
+                        Identity object extracted from the context.
+                        Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
+                      properties:
+                        selector:
+                          description: |-
+                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                          type: string
+                      required:
+                      - selector
+                      type: object
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                    x509:
+                      description: |-
+                        Authentication based on client X.509 certificates.
+                        The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                      properties:
+                        allNamespaces:
+                          default: false
+                          description: |-
+                            Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                            Enabling this option in namespaced Authorino instances has no effect.
+                          type: boolean
+                        selector:
+                          description: |-
+                            Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                            clients trying to authenticate to this service
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - selector
+                      type: object
+                  type: object
+                description: |-
+                  Authentication configs.
+                  At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                type: object
+              authorization:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    kubernetesSubjectAccessReview:
+                      description: Authorization by Kubernetes SubjectAccessReview
+                      properties:
+                        groups:
+                          description: Groups the user must be a member of or, if
+                            `user` is omitted, the groups to check for authorization
+                            in the Kubernetes RBAC.
+                          items:
+                            type: string
+                          type: array
+                        resourceAttributes:
+                          description: |-
+                            Use resourceAttributes to check permissions on Kubernetes resources.
+                            If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                          properties:
+                            group:
+                              description: |-
+                                API group of the resource.
+                                Use '*' for all API groups.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              description: |-
+                                Resource name
+                                Omit it to check for authorization on all resources of the specified kind.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            namespace:
+                              description: Namespace where the user must have permissions
+                                on the resource.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            resource:
+                              description: |-
+                                Resource kind
+                                Use '*' for all resource kinds.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            subresource:
+                              description: Subresource kind
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            verb:
+                              description: |-
+                                Verb to check for authorization on the resource.
+                                Use '*' for all verbs.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        user:
+                          description: |-
+                            User to check for authorization in the Kubernetes RBAC.
+                            Omit it to check for group authorization only.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    opa:
+                      description: Open Policy Agent (OPA) Rego policy.
+                      properties:
+                        allValues:
+                          default: false
+                          description: |-
+                            Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                            Otherwise, only the default `allow` rule will be exposed.
+                            Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                          type: boolean
+                        externalPolicy:
+                          description: |-
+                            Settings for fetching the OPA policy from an external registry.
+                            Use it alternatively to 'rego'.
+                            For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                            'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                          properties:
+                            body:
+                              description: |-
+                                Raw body of the HTTP request.
+                                Supersedes 'bodyParameters'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            bodyParameters:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Custom parameters to encode in the body of the HTTP request.
+                                Superseded by 'body'; use either one or the other.
+                                Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                              type: object
+                            contentType:
+                              default: application/x-www-form-urlencoded
+                              description: |-
+                                Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                              enum:
+                              - application/x-www-form-urlencoded
+                              - application/json
+                              type: string
+                            credentials:
+                              description: |-
+                                Defines where client credentials will be passed in the request to the service.
+                                If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            headers:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: Custom headers in the HTTP request.
+                              type: object
+                            method:
+                              default: GET
+                              description: |-
+                                HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                When the request method is POST, the authorization JSON is passed in the body of the request.
+                              enum:
+                              - GET
+                              - POST
+                              - PUT
+                              - PATCH
+                              - DELETE
+                              - HEAD
+                              - OPTIONS
+                              - CONNECT
+                              - TRACE
+                              type: string
+                            oauth2:
+                              description: Authentication with the HTTP service by
+                                OAuth2 Client Credentials grant.
+                              properties:
+                                cache:
+                                  default: true
+                                  description: |-
+                                    Caches and reuses the token until expired.
+                                    Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                  type: boolean
+                                clientId:
+                                  description: OAuth2 Client ID.
+                                  type: string
+                                clientSecretRef:
+                                  description: Reference to a Kuberentes Secret key
+                                    that stores that OAuth2 Client Secret.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                extraParams:
+                                  additionalProperties:
+                                    type: string
+                                  description: Optional extra parameters for the requests
+                                    to the token URL.
+                                  type: object
+                                scopes:
+                                  description: Optional scopes for the client credentials
+                                    grant, if supported by he OAuth2 server.
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenUrl:
+                                  description: Token endpoint URL of the OAuth2 resource
+                                    server.
+                                  type: string
+                              required:
+                              - clientId
+                              - clientSecretRef
+                              - tokenUrl
+                              type: object
+                            sharedSecretRef:
+                              description: |-
+                                Reference to a Secret key whose value will be passed by Authorino in the request.
+                                The HTTP service can use the shared secret to authenticate the origin of the request.
+                                Ignored if used together with oauth2.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            ttl:
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
+                              type: integer
+                            url:
+                              description: |-
+                                Endpoint URL of the HTTP service.
+                                The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                E.g. https://ext-auth-server.io/metadata?p={request.path}
+                              type: string
+                          required:
+                          - url
+                          type: object
+                        rego:
+                          description: |-
+                            Authorization policy as a Rego language document.
+                            The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                            The Rego document must NOT include the "package" declaration in line 1.
+                          type: string
+                      type: object
+                    patternMatching:
+                      description: Pattern-matching authorization rules.
+                      properties:
+                        patterns:
+                          items:
+                            properties:
+                              all:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical AND.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              any:
+                                description: A list of pattern expressions to be evaluated
+                                  as a logical OR.
+                                items:
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                type: array
+                              operator:
+                                description: |-
+                                  The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                  Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                enum:
+                                - eq
+                                - neq
+                                - incl
+                                - excl
+                                - matches
+                                type: string
+                              patternRef:
+                                description: Reference to a named set of pattern expressions
+                                type: string
+                              selector:
+                                description: |-
+                                  Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  Authorino custom JSON path modifiers are also supported.
+                                type: string
+                              value:
+                                description: |-
+                                  The value of reference for the comparison with the content fetched from the authorization JSON.
+                                  If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - patterns
+                      type: object
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    spicedb:
+                      description: Authorization decision delegated to external Authzed/SpiceDB
+                        server.
+                      properties:
+                        endpoint:
+                          description: Hostname and port number to the GRPC interface
+                            of the SpiceDB server (e.g. spicedb:50051).
+                          type: string
+                        insecure:
+                          description: Insecure HTTP connection (i.e. disables TLS
+                            verification)
+                          type: boolean
+                        permission:
+                          description: The name of the permission (or relation) on
+                            which to execute the check.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        resource:
+                          description: The resource on which to check the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        sharedSecretRef:
+                          description: Reference to a Secret key whose value will
+                            be used by Authorino to authenticate with the Authzed
+                            service.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        subject:
+                          description: The subject that will be checked for the permission
+                            or relation.
+                          properties:
+                            kind:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            name:
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                      required:
+                      - endpoint
+                      type: object
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  Authorization policies.
+                  All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                type: object
+              callbacks:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: Settings of the external HTTP request
+                      properties:
+                        body:
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        method:
+                          default: GET
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - http
+                  type: object
+                description: |-
+                  Callback functions.
+                  Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                type: object
+              hosts:
+                description: |-
+                  The list of public host names of the services protected by this authentication/authorization scheme.
+                  Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                items:
+                  type: string
+                type: array
+              metadata:
+                additionalProperties:
+                  properties:
+                    cache:
+                      description: |-
+                        Caching options for the resolved object returned when applying this config.
+                        Omit it to avoid caching objects for this config.
+                      properties:
+                        key:
+                          description: |-
+                            Key used to store the entry in the cache.
+                            The resolved key must be unique within the scope of this particular config.
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        ttl:
+                          default: 60
+                          description: Duration (in seconds) of the external data
+                            in the cache before pulled again from the source.
+                          type: integer
+                      required:
+                      - key
+                      type: object
+                    http:
+                      description: External source of auth metadata via HTTP request
+                      properties:
+                        body:
+                          description: |-
+                            Raw body of the HTTP request.
+                            Supersedes 'bodyParameters'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        bodyParameters:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: |-
+                            Custom parameters to encode in the body of the HTTP request.
+                            Superseded by 'body'; use either one or the other.
+                            Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                          type: object
+                        contentType:
+                          default: application/x-www-form-urlencoded
+                          description: |-
+                            Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                            Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                          enum:
+                          - application/x-www-form-urlencoded
+                          - application/json
+                          type: string
+                        credentials:
+                          description: |-
+                            Defines where client credentials will be passed in the request to the service.
+                            If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                          properties:
+                            authorizationHeader:
+                              properties:
+                                prefix:
+                                  type: string
+                              type: object
+                            cookie:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            customHeader:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            queryString:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          type: object
+                        headers:
+                          additionalProperties:
+                            properties:
+                              selector:
+                                description: |-
+                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                type: string
+                              value:
+                                description: Static value
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          description: Custom headers in the HTTP request.
+                          type: object
+                        method:
+                          default: GET
+                          description: |-
+                            HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                            When the request method is POST, the authorization JSON is passed in the body of the request.
+                          enum:
+                          - GET
+                          - POST
+                          - PUT
+                          - PATCH
+                          - DELETE
+                          - HEAD
+                          - OPTIONS
+                          - CONNECT
+                          - TRACE
+                          type: string
+                        oauth2:
+                          description: Authentication with the HTTP service by OAuth2
+                            Client Credentials grant.
+                          properties:
+                            cache:
+                              default: true
+                              description: |-
+                                Caches and reuses the token until expired.
+                                Set it to false to force fetch the token at every authorization request regardless of expiration.
+                              type: boolean
+                            clientId:
+                              description: OAuth2 Client ID.
+                              type: string
+                            clientSecretRef:
+                              description: Reference to a Kuberentes Secret key that
+                                stores that OAuth2 Client Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            extraParams:
+                              additionalProperties:
+                                type: string
+                              description: Optional extra parameters for the requests
+                                to the token URL.
+                              type: object
+                            scopes:
+                              description: Optional scopes for the client credentials
+                                grant, if supported by he OAuth2 server.
+                              items:
+                                type: string
+                              type: array
+                            tokenUrl:
+                              description: Token endpoint URL of the OAuth2 resource
+                                server.
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecretRef
+                          - tokenUrl
+                          type: object
+                        sharedSecretRef:
+                          description: |-
+                            Reference to a Secret key whose value will be passed by Authorino in the request.
+                            The HTTP service can use the shared secret to authenticate the origin of the request.
+                            Ignored if used together with oauth2.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: The name of the secret in the Authorino's
+                                namespace to select from.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        url:
+                          description: |-
+                            Endpoint URL of the HTTP service.
+                            The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                            by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                            E.g. https://ext-auth-server.io/metadata?p={request.path}
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    metrics:
+                      default: false
+                      description: Whether this config should generate individual
+                        observability metrics
+                      type: boolean
+                    priority:
+                      default: 0
+                      description: |-
+                        Priority group of the config.
+                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                      type: integer
+                    uma:
+                      description: User-Managed Access (UMA) source of resource data.
+                      properties:
+                        credentialsRef:
+                          description: Reference to a Kubernetes secret in the same
+                            namespace, that stores client credentials to the resource
+                            registration API of the UMA server.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpoint:
+                          description: |-
+                            The endpoint of the UMA server.
+                            The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                          type: string
+                      required:
+                      - credentialsRef
+                      - endpoint
+                      type: object
+                    userInfo:
+                      description: OpendID Connect UserInfo linked to an OIDC authentication
+                        config specified in this same AuthConfig.
+                      properties:
+                        identitySource:
+                          description: The name of an OIDC-enabled JWT authentication
+                            config whose OpenID Connect configuration discovered includes
+                            the OIDC "userinfo_endpoint" claim.
+                          type: string
+                      required:
+                      - identitySource
+                      type: object
+                    when:
+                      description: |-
+                        Conditions for Authorino to enforce this config.
+                        If omitted, the config will be enforced for all requests.
+                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                      items:
+                        properties:
+                          all:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical AND.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          any:
+                            description: A list of pattern expressions to be evaluated
+                              as a logical OR.
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          patternRef:
+                            description: Reference to a named set of pattern expressions
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                description: |-
+                  Metadata sources.
+                  Authorino fetches auth metadata as JSON from sources specified in this config.
+                type: object
+              patterns:
+                additionalProperties:
+                  items:
+                    properties:
+                      operator:
+                        description: |-
+                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                        enum:
+                        - eq
+                        - neq
+                        - incl
+                        - excl
+                        - matches
+                        type: string
+                      selector:
+                        description: |-
+                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                          Authorino custom JSON path modifiers are also supported.
+                        type: string
+                      value:
+                        description: |-
+                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                        type: string
+                    type: object
+                  type: array
+                description: Named sets of patterns that can be referred in `when`
+                  conditions and in pattern-matching authorization policy rules.
+                type: object
+              response:
+                description: |-
+                  Response items.
+                  Authorino builds custom responses to the client of the auth request.
+                properties:
+                  success:
+                    description: |-
+                      Response items to be included in the auth response when the request is authenticated and authorized.
+                      For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                    properties:
+                      dynamicMetadata:
+                        additionalProperties:
+                          description: Settings of the success custom response item.
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                          See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                        type: object
+                      headers:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            json:
+                              description: |-
+                                JSON object
+                                Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                              properties:
+                                properties:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  type: object
+                              required:
+                              - properties
+                              type: object
+                            key:
+                              description: |-
+                                The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                If omitted, it will be set to the name of the response config.
+                              type: string
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            plain:
+                              description: Plain text content
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                                value:
+                                  description: Static value
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            wristband:
+                              description: Authorino Festival Wristband token
+                              properties:
+                                customClaims:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Any claims to be added to the wristband
+                                    token apart from the standard JWT claims (iss,
+                                    iat, exp) added by default.
+                                  type: object
+                                issuer:
+                                  description: 'The endpoint to the Authorino service
+                                    that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                    where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                  type: string
+                                signingKeyRefs:
+                                  description: |-
+                                    Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                    The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                  items:
+                                    properties:
+                                      algorithm:
+                                        description: Algorithm to sign the wristband
+                                          token using the signing key provided
+                                        enum:
+                                        - ES256
+                                        - ES384
+                                        - ES512
+                                        - RS256
+                                        - RS384
+                                        - RS512
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the signing key.
+                                          The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                        type: string
+                                    required:
+                                    - algorithm
+                                    - name
+                                    type: object
+                                  type: array
+                                tokenDuration:
+                                  description: Time span of the wristband token, in
+                                    seconds.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - issuer
+                              - signingKeyRefs
+                              type: object
+                          type: object
+                        description: |-
+                          Custom success response items wrapped as HTTP headers.
+                          For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                        type: object
+                    type: object
+                  unauthenticated:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthenticated.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 401 Unauthorized
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  unauthorized:
+                    description: |-
+                      Customizations on the denial status attributes when the request is unauthorized.
+                      For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                      Default: 403 Forbidden
+                    properties:
+                      body:
+                        description: HTTP response body to override the default denial
+                          body.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      code:
+                        description: HTTP status code to override the default denial
+                          status code.
+                        format: int64
+                        maximum: 599
+                        minimum: 300
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          properties:
+                            selector:
+                              description: |-
+                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                              type: string
+                            value:
+                              description: Static value
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        description: HTTP response headers to override the default
+                          denial headers.
+                        type: object
+                      message:
+                        description: HTTP message to override the default denial message.
+                        properties:
+                          selector:
+                            description: |-
+                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                            type: string
+                          value:
+                            description: Static value
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                type: object
+              when:
+                description: |-
+                  Overall conditions for the AuthConfig to be enforced.
+                  If omitted, the AuthConfig will be enforced at all requests.
+                  If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.
+                items:
+                  properties:
+                    all:
+                      description: A list of pattern expressions to be evaluated as
+                        a logical AND.
+                      items:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      type: array
+                    any:
+                      description: A list of pattern expressions to be evaluated as
+                        a logical OR.
+                      items:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      type: array
+                    operator:
+                      description: |-
+                        The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                        Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                      enum:
+                      - eq
+                      - neq
+                      - incl
+                      - excl
+                      - matches
+                      type: string
+                    patternRef:
+                      description: Reference to a named set of pattern expressions
+                      type: string
+                    selector:
+                      description: |-
+                        Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                        Authorino custom JSON path modifiers are also supported.
+                      type: string
+                    value:
+                      description: |-
+                        The value of reference for the comparison with the content fetched from the authorization JSON.
+                        If used with the "matches" operator, the value must compile to a valid Golang regex.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - hosts
+            type: object
+          status:
+            description: AuthConfigStatus defines the observed state of AuthConfig
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdatedTime:
+                      description: Last time the condition was updated
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              summary:
+                properties:
+                  festivalWristbandEnabled:
+                    description: Indicator of whether the AuthConfig issues Festival
+                      Wristband tokens on successful evaluation of the AuthConfig
+                      (access granted)
+                    type: boolean
+                  hostsReady:
+                    description: Lists the hosts from spec.hosts linked to the resource
+                      in the index
+                    items:
+                      type: string
+                    type: array
+                  numAuthorizationPolicies:
+                    description: Number of authorization policies in the AuthConfig
+                    format: int64
+                    type: integer
+                  numHostsReady:
+                    description: Number of hosts from spec.hosts linked to the resource
+                      in the index, compared to the total number of hosts in spec.hosts
+                    type: string
+                  numIdentitySources:
+                    description: Number of trusted sources of identity for authentication
+                      in the AuthConfig
+                    format: int64
+                    type: integer
+                  numMetadataSources:
+                    description: Number of sources of external metadata in the AuthConfig
+                    format: int64
+                    type: integer
+                  numResponseItems:
+                    description: Number of custom authorization response items in
+                      the AuthConfig
+                    format: int64
+                    type: integer
+                  ready:
+                    description: Whether all hosts from spec.hosts have been linked
+                      to the resource in the index
+                    type: boolean
+                required:
+                - festivalWristbandEnabled
+                - hostsReady
+                - numAuthorizationPolicies
+                - numHostsReady
+                - numIdentitySources
+                - numMetadataSources
+                - numResponseItems
+                - ready
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/external/serving.kserve.io_inferencegraphs.yaml
+++ b/config/crd/external/serving.kserve.io_inferencegraphs.yaml
@@ -1,0 +1,606 @@
+# https://github.com/kserve/kserve/blob/654d314f15af5a4ed5fd6114dbd2be1cfdc6d5a0/config/crd/full/serving.kserve.io_inferencegraphs.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.2
+  name: inferencegraphs.serving.kserve.io
+spec:
+  group: serving.kserve.io
+  names:
+    kind: InferenceGraph
+    listKind: InferenceGraphList
+    plural: inferencegraphs
+    shortNames:
+    - ig
+    singular: inferencegraph
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              affinity:
+                properties:
+                  nodeAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            preference:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        properties:
+                          nodeSelectorTerms:
+                            items:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            podAffinityTerm:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              maxReplicas:
+                type: integer
+              minReplicas:
+                type: integer
+              nodes:
+                additionalProperties:
+                  properties:
+                    routerType:
+                      enum:
+                      - Sequence
+                      - Splitter
+                      - Ensemble
+                      - Switch
+                      type: string
+                    steps:
+                      items:
+                        properties:
+                          condition:
+                            type: string
+                          data:
+                            type: string
+                          dependency:
+                            enum:
+                            - Soft
+                            - Hard
+                            type: string
+                          name:
+                            type: string
+                          nodeName:
+                            type: string
+                          serviceName:
+                            type: string
+                          serviceUrl:
+                            type: string
+                          weight:
+                            format: int64
+                            type: integer
+                        type: object
+                      type: array
+                  required:
+                  - routerType
+                  type: object
+                type: object
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              scaleMetric:
+                enum:
+                - cpu
+                - memory
+                - concurrency
+                - rps
+                type: string
+              scaleTarget:
+                type: integer
+              timeout:
+                format: int64
+                type: integer
+            required:
+            - nodes
+            type: object
+          status:
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    severity:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              url:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -216,6 +216,21 @@ rules:
 - apiGroups:
   - serving.kserve.io
   resources:
+  - inferencegraphs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferencegraphs/finalizers
+  - servingruntimes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - serving.kserve.io
+  resources:
   - inferenceservices
   - inferenceservices/finalizers
   verbs:
@@ -233,12 +248,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - serving.kserve.io
-  resources:
-  - servingruntimes/finalizers
-  verbs:
-  - update
 - apiGroups:
   - telemetry.istio.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - authorino.kuadrant.io
   resources:
   - authconfigs

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -86,6 +86,13 @@ const (
 	ServingCertAnnotationKey = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
+// Events
+const (
+	// AuthUnavailable is logged in an Event when an InferenceGraph is configured to
+	// be protected with auth, but Authorino is not configured.
+	AuthUnavailable = "AuthStackUnavailable"
+)
+
 // errors
 const (
 	NoSuitableRuntimeError = "not found error: no suitable runtime found."

--- a/internal/controller/resources/authconfig.go
+++ b/internal/controller/resources/authconfig.go
@@ -54,7 +54,7 @@ type AuthConfigTemplateLoader interface {
 }
 
 type AuthTypeDetector interface {
-	Detect(ctx context.Context, annotations map[string]string) (AuthType, error)
+	Detect(ctx context.Context, annotations map[string]string) AuthType
 }
 
 type AuthConfigStore interface {
@@ -207,17 +207,17 @@ func NewKServeAuthTypeDetector(client client.Client) AuthTypeDetector {
 	}
 }
 
-func (k *kserveAuthTypeDetector) Detect(_ context.Context, annotations map[string]string) (AuthType, error) {
+func (k *kserveAuthTypeDetector) Detect(_ context.Context, annotations map[string]string) AuthType {
 	if value, exist := annotations[constants.LabelEnableAuthODH]; exist {
 		if strings.ToLower(value) == "true" {
-			return UserDefined, nil
+			return UserDefined
 		}
 	} else { // backward compat
 		if strings.ToLower(annotations[constants.LabelEnableAuth]) == "true" {
-			return UserDefined, nil
+			return UserDefined
 		}
 	}
-	return Anonymous, nil
+	return Anonymous
 }
 
 type kserveInferenceEndpointsHostExtractor struct {

--- a/internal/controller/resources/template/authconfig_inferencegraph_userdefined.yaml
+++ b/internal/controller/resources/template/authconfig_inferencegraph_userdefined.yaml
@@ -24,12 +24,12 @@ spec:
           group:
             value: "serving.kserve.io"
           resource:
-            value: inferenceservices
+            value: inferencegraphs
           namespace:
             value: {{ .Namespace }}
           subresource:
             value: ""
           name:
-            value: "{{ .InferenceServiceName }}"
+            value: "{{ .ResourceName }}"
         user:
           selector: auth.identity.user.username

--- a/internal/controller/resources/template/authconfig_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authconfig_isvc_userdefined.yaml
@@ -1,0 +1,35 @@
+apiVersion: authorino.kuadrant.io/v1beta2
+kind: AuthConfig
+metadata:
+  labels:
+    {{ .AuthorinoLabel }}
+spec:
+  hosts:
+  - "UPDATED.RUNTIME"
+  authentication:
+    kubernetes-user:
+      credentials:
+        authorizationHeader: {}
+      kubernetesTokenReview:
+        audiences:
+{{- range .Audiences }}
+        - "{{ . }}"
+{{- end }}
+  authorization:
+    kubernetes-rbac:
+      kubernetesSubjectAccessReview:
+        resourceAttributes:
+          verb:
+            value: get
+          group:
+            value: "serving.kserve.io"
+          resource:
+            value: inferenceservices
+          namespace:
+            value: {{ .Namespace }}
+          subresource:
+            value: ""
+          name:
+            value: "{{ .ResourceName }}"
+        user:
+          selector: auth.identity.user.username

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	servingv1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/comparators"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/processors"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/resources"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+)
+
+// InferenceGraphReconciler reconciles a InferenceGraph object
+type InferenceGraphReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	deltaProcessor processors.DeltaProcessor
+	detector       resources.AuthTypeDetector
+	templateLoader resources.AuthConfigTemplateLoader
+	hostExtractor  resources.InferenceEndpointsHostExtractor
+}
+
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferencegraphs,verbs=get;list;watch
+// not needed: kubebuilder:rbac:groups=serving.kserve.io,resources=inferencegraphs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferencegraphs/finalizers,verbs=update
+
+// +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
+
+func NewInferenceGraphReconciler(mgr ctrl.Manager) *InferenceGraphReconciler {
+	return &InferenceGraphReconciler{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		deltaProcessor: processors.NewDeltaProcessor(),
+		detector:       resources.NewKServeAuthTypeDetector(mgr.GetClient()),
+		templateLoader: resources.NewStaticTemplateLoader(),
+		hostExtractor:  resources.NewKServeInferenceServiceHostExtractor(),
+	}
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("InferenceGraph", req.Name, "namespace", req.Namespace)
+
+	ig := &servingv1alpha1.InferenceGraph{}
+	err := r.Client.Get(ctx, req.NamespacedName, ig)
+	if err != nil && apierrs.IsNotFound(err) {
+		if apierrs.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Unable to get the InferenceGraph resource")
+	}
+
+	if err = r.reconcileAuthConfig(ctx, logger, ig); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *InferenceGraphReconciler) reconcileAuthConfig(ctx context.Context, logger logr.Logger, ig *servingv1alpha1.InferenceGraph) error {
+	logger.V(1).Info("Reconciling Authorino AuthConfig for InferenceGraph")
+	authorinoEnabled, capabilityErr := utils.VerifyIfMeshAuthorizationIsEnabled(ctx, r.Client)
+	if capabilityErr != nil {
+		logger.V(1).Error(capabilityErr, "Error while verifying if Authorino is enabled")
+		return capabilityErr
+	}
+	if !authorinoEnabled {
+		logger.V(1).Info("Skipping AuthConfig reconciliation, authorization is not enabled")
+		return nil
+	}
+
+	if ig.Status.URL == nil {
+		logger.V(1).Info("Inference graph URL not yet initialized")
+		return nil
+	}
+
+	desiredState, err := r.createDesiredAuthConfig(ctx, ig)
+	if err != nil {
+		return err
+	}
+
+	existingState, err := r.getExistingAuthConfig(ctx, ig)
+	if err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
+
+	if err = r.processAuthConfigDelta(ctx, logger, desiredState, existingState); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *InferenceGraphReconciler) createDesiredAuthConfig(ctx context.Context, ig *servingv1alpha1.InferenceGraph) (*authorinov1beta2.AuthConfig, error) {
+	authType, err := r.detector.Detect(ctx, ig.GetAnnotations())
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect auth type: %w", err)
+	}
+
+	template, err := r.templateLoader.Load(ctx, authType, ig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load template for AuthType %s: %w", authType, err)
+	}
+
+	template.Name = ig.GetName() + "-ig"
+	template.Namespace = ig.GetNamespace()
+	template.Spec.Hosts = r.hostExtractor.Extract(ig)
+	if template.Labels == nil {
+		template.Labels = map[string]string{}
+	}
+	template.Labels[constants.LabelAuthGroup] = "default"
+
+	err = ctrl.SetControllerReference(ig, &template, r.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return &template, nil
+}
+
+func (r *InferenceGraphReconciler) getExistingAuthConfig(ctx context.Context, ig *servingv1alpha1.InferenceGraph) (*authorinov1beta2.AuthConfig, error) {
+	typeName := types.NamespacedName{Namespace: ig.GetNamespace(), Name: ig.GetName()}
+	existing := authorinov1beta2.AuthConfig{}
+	err := r.Client.Get(ctx, typeName, &existing)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &existing, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&servingv1alpha1.InferenceGraph{}).
+		Owns(&authorinov1beta2.AuthConfig{}).
+		Named("serving-inferencegraph").
+		Complete(r)
+}
+
+func (r *InferenceGraphReconciler) processAuthConfigDelta(ctx context.Context, logger logr.Logger, desiredState *authorinov1beta2.AuthConfig, existingState *authorinov1beta2.AuthConfig) error {
+	logger.WithValues("auth_config_name", desiredState.GetName())
+	comparator := comparators.GetAuthConfigComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desiredState, existingState)
+
+	if !delta.HasChanges() {
+		logger.V(1).Info("No delta found")
+		return nil
+	}
+
+	if delta.IsAdded() {
+		logger.V(1).Info("Delta found", "action", "create")
+		err := r.Client.Create(ctx, desiredState)
+		if err != nil {
+			return fmt.Errorf("failed to create AuthConfig %s on namespace %s: %w", desiredState.GetName(), desiredState.GetNamespace(), err)
+		}
+	} else if delta.IsUpdated() {
+		logger.V(1).Info("Delta found", "action", "update")
+		existingCopy := existingState.DeepCopy()
+		existingCopy.Spec = desiredState.Spec
+		existingCopy.Labels = desiredState.Labels
+		err := r.Client.Update(ctx, existingCopy)
+		if err != nil {
+			return fmt.Errorf("failed to update AuthConfig %s on namespace %s: %w", desiredState.GetName(), desiredState.GetNamespace(), err)
+		}
+	}
+	return nil
+}

--- a/internal/controller/serving/inferencegraph_controller_test.go
+++ b/internal/controller/serving/inferencegraph_controller_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"context"
+
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kuadrant/authorino/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
+)
+
+var _ = Describe("InferenceGraph Controller", func() {
+	Context("When reconciling a Serverless InferenceGraph", func() {
+		var testNs string
+		var exampleComUrl *apis.URL
+
+		exampleComUrl, _ = apis.ParseURL("https://example.com")
+		emptyUrl, _ := apis.ParseURL("")
+
+		buildInferenceGraph := func(name string) kservev1alpha1.InferenceGraph {
+			return kservev1alpha1.InferenceGraph{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   testNs,
+					Name:        name,
+					Annotations: make(map[string]string),
+				},
+				Spec: kservev1alpha1.InferenceGraphSpec{
+					Nodes: map[string]kservev1alpha1.InferenceRouter{
+						"root": {
+							RouterType: kservev1alpha1.Sequence,
+							Steps: []kservev1alpha1.InferenceStep{
+								{StepName: "one", InferenceTarget: kservev1alpha1.InferenceTarget{
+									ServiceName: "isvc",
+								}},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		buildInferenceGraphStatus := func(url *apis.URL) kservev1alpha1.InferenceGraphStatus {
+			return kservev1alpha1.InferenceGraphStatus{
+				URL: url,
+			}
+		}
+
+		BeforeEach(func() {
+			ctx := context.Background()
+			testNamespace := testutils.Namespaces.Create(ctx, k8sClient)
+			testNs = testNamespace.Name
+
+			inferenceServiceConfig := &corev1.ConfigMap{}
+			Expect(testutils.ConvertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
+			if err := k8sClient.Create(ctx, inferenceServiceConfig); err != nil && !k8sErrors.IsAlreadyExists(err) {
+				Fail(err.Error())
+			}
+
+			// TODO: See utils.VerifyIfMeshAuthorizationIsEnabled func
+			if authPolicyErr := createAuthorizationPolicy(KServeAuthorizationPolicy); authPolicyErr != nil && !k8sErrors.IsAlreadyExists(authPolicyErr) {
+				Fail(authPolicyErr.Error())
+			}
+		})
+
+		AfterEach(func() {
+			Expect(deleteAuthorizationPolicy(KServeAuthorizationPolicy)).To(Succeed())
+		})
+
+		createInferenceGraph := func(inferenceGraph *kservev1alpha1.InferenceGraph, inferenceGraphStatus kservev1alpha1.InferenceGraphStatus) {
+			Expect(k8sClient.Create(ctx, inferenceGraph)).Should(Succeed())
+			inferenceGraph.Status = inferenceGraphStatus
+			Expect(k8sClient.Status().Update(ctx, inferenceGraph)).Should(Succeed())
+		}
+
+		createBaseInferenceGraph := func(igName string) *kservev1alpha1.InferenceGraph {
+			ig := buildInferenceGraph(igName)
+			igStatus := buildInferenceGraphStatus(exampleComUrl)
+			createInferenceGraph(&ig, igStatus)
+
+			return &ig
+		}
+
+		It("if no auth annotation is present, an anonymous AuthConfig should be created", func() {
+			inferenceGraph := createBaseInferenceGraph("no-auth-annotation")
+			defer func() { _ = k8sClient.Delete(ctx, inferenceGraph) }()
+
+			Consistently(func(g Gomega) {
+				authConfig := &v1beta2.AuthConfig{}
+				key := types.NamespacedName{Name: inferenceGraph.Name + "-ig", Namespace: inferenceGraph.Namespace}
+				g.Eventually(func() error { return k8sClient.Get(ctx, key, authConfig) }).Should(Succeed())
+
+				g.Expect(authConfig.Spec.Authentication).To(SatisfyAll(
+					HaveKey("anonymous-access"),
+					Not(HaveKey("kubernetes-user")),
+				))
+			}).WithPolling(interval).WithTimeout(timeout).Should(Succeed())
+		})
+
+		It("if auth is explicitly disabled, an anonymous AuthConfig should be created", func() {
+			inferenceGraph := buildInferenceGraph("auth-annotation-disabled")
+			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "false"
+			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
+			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
+
+			Consistently(func(g Gomega) {
+				authConfig := &v1beta2.AuthConfig{}
+				key := types.NamespacedName{Name: inferenceGraph.Name + "-ig", Namespace: inferenceGraph.Namespace}
+				g.Eventually(func() error { return k8sClient.Get(ctx, key, authConfig) }).Should(Succeed())
+
+				g.Expect(authConfig.Spec.Authentication).To(SatisfyAll(
+					HaveKey("anonymous-access"),
+					Not(HaveKey("kubernetes-user")),
+				))
+			}).WithPolling(interval).WithTimeout(timeout).Should(Succeed())
+		})
+
+		It("if auth is explicitly enabled, a user-defined AuthConfig should be created", func() {
+			inferenceGraph := buildInferenceGraph("auth-annotation-enabled")
+			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
+			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
+
+			Consistently(func(g Gomega) {
+				authConfig := &v1beta2.AuthConfig{}
+				key := types.NamespacedName{Name: inferenceGraph.Name + "-ig", Namespace: inferenceGraph.Namespace}
+				g.Eventually(func() error { return k8sClient.Get(ctx, key, authConfig) }).Should(Succeed())
+
+				g.Expect(authConfig.Spec.Authentication).To(SatisfyAll(
+					Not(HaveKey("anonymous-access")),
+					HaveKey("kubernetes-user"),
+				))
+			}).WithPolling(interval).WithTimeout(timeout).Should(Succeed())
+		})
+
+		It("if auth is explicitly enabled but InferenceGraph is not ready, no AuthConfig should be created", func() {
+			inferenceGraph := buildInferenceGraph("auth-annotation-enabled-ig-not-ready")
+			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(emptyUrl))
+			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
+
+			Consistently(func() error {
+				authConfig := &v1beta2.AuthConfig{}
+				key := types.NamespacedName{Name: inferenceGraph.Name + "-ig", Namespace: inferenceGraph.Namespace}
+				return k8sClient.Get(ctx, key, authConfig)
+			}).WithPolling(interval).WithTimeout(timeout).Should(WithTransform(k8sErrors.IsNotFound, BeTrue()))
+		})
+
+		It("if auth is explicitly enabled but Authorino is not configured, no AuthConfig should be created", func() {
+			inferenceGraph := buildInferenceGraph("auth-annotation-enabled-authorino-missing")
+			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
+			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
+
+			// Deleting the authorization policy means Authorino is not available
+			Expect(deleteAuthorizationPolicy(KServeAuthorizationPolicy)).To(Succeed())
+
+			Consistently(func() error {
+				authConfig := &v1beta2.AuthConfig{}
+				key := types.NamespacedName{Name: inferenceGraph.Name + "-ig", Namespace: inferenceGraph.Namespace}
+				return k8sClient.Get(ctx, key, authConfig)
+			}).WithPolling(interval).WithTimeout(timeout).Should(WithTransform(k8sErrors.IsNotFound, BeTrue()))
+		})
+	})
+})

--- a/internal/controller/serving/inferenceservice_controller_test.go
+++ b/internal/controller/serving/inferenceservice_controller_test.go
@@ -1355,5 +1355,6 @@ func deleteAuthorizationPolicy(authPolicyFile string) error {
 
 	gvr := istiosecv1b1.SchemeGroupVersion.WithResource("authorizationpolicies")
 	_, meshNamespace := utils.GetIstioControlPlaneName(ctx, k8sClient)
-	return dynamicClient.Resource(gvr).Namespace(meshNamespace).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
+	err = dynamicClient.Resource(gvr).Namespace(meshNamespace).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
+	return client.IgnoreNotFound(err)
 }

--- a/internal/controller/serving/reconcilers/kserve_authconfig_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_authconfig_reconciler.go
@@ -111,10 +111,7 @@ func (r *KserveAuthConfigReconciler) createDesiredResource(ctx context.Context, 
 		Namespace: isvc.GetNamespace(),
 	}
 
-	authType, err := r.detector.Detect(ctx, isvc.GetAnnotations())
-	if err != nil {
-		return nil, fmt.Errorf("could not detect AuthType for InferenceService %s. cause: %w", typeName, err)
-	}
+	authType := r.detector.Detect(ctx, isvc.GetAnnotations())
 	template, err := r.templateLoader.Load(ctx, authType, isvc)
 	if err != nil {
 		return nil, fmt.Errorf("could not load template for AuthType %s for InferenceService %s. cause: %w", authType, typeName, err)

--- a/internal/controller/serving/reconcilers/kserve_authconfig_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_authconfig_reconciler.go
@@ -43,7 +43,7 @@ type KserveAuthConfigReconciler struct {
 	detector       resources.AuthTypeDetector
 	store          resources.AuthConfigStore
 	templateLoader resources.AuthConfigTemplateLoader
-	hostExtractor  resources.InferenceServiceHostExtractor
+	hostExtractor  resources.InferenceEndpointsHostExtractor
 }
 
 func NewKserveAuthConfigReconciler(client client.Client) *KserveAuthConfigReconciler {
@@ -111,11 +111,11 @@ func (r *KserveAuthConfigReconciler) createDesiredResource(ctx context.Context, 
 		Namespace: isvc.GetNamespace(),
 	}
 
-	authType, err := r.detector.Detect(ctx, isvc)
+	authType, err := r.detector.Detect(ctx, isvc.GetAnnotations())
 	if err != nil {
 		return nil, fmt.Errorf("could not detect AuthType for InferenceService %s. cause: %w", typeName, err)
 	}
-	template, err := r.templateLoader.Load(ctx, authType, typeName)
+	template, err := r.templateLoader.Load(ctx, authType, isvc)
 	if err != nil {
 		return nil, fmt.Errorf("could not load template for AuthType %s for InferenceService %s. cause: %w", authType, typeName, err)
 	}

--- a/internal/controller/serving/suite_test.go
+++ b/internal/controller/serving/suite_test.go
@@ -178,6 +178,9 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = NewInferenceGraphReconciler(mgr).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)


### PR DESCRIPTION
## Description

This adds a new controller for KServe InferenceGraph resources. This new controller will have the responsibility of creating Authorino AuthConfig resources (similarly to InferenceServices case), when authorization is available in ODH platform.

InferenceGraphs can now be annotated with `security.opendatahub.io/enable-auth: "true"` to secure InferenceGraphs and only serve requests that are authorized.

Requires PRs:
* opendatahub-io/kserve#463
* opendatahub-io/opendatahub-operator#1491

Fixes: https://issues.redhat.com/browse/RHOAIENG-13449

## How Has This Been Tested?
* Deploy (since odh-operator is changed, it would be easier to use custom builds of everything):
  * odh-model-controller from this PR
  * KServe using code of dependent PR
  * operator using code of dependent PR
* Deploy InferenceGraph example of KServe website: https://kserve.github.io/website/latest/modelserving/inference_graph/image_pipeline/
* Check that the InferenceGraph is accessible
* Annotate the InferenceGraph with `security.opendatahub.io/enable-auth: "true"`
* Check that the InferenceGraph is accessible only to authorized requests

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
