### PR TITLE
Prevent InferenceGraphs to refer to other namespaces

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -29,8 +29,8 @@ resources:
   path: github.com/kserve/kserve/pkg/apis/serving/v1beta1
   version: v1beta1
   webhooks:
-    validation: true
     defaulting: true
+    validation: true
     webhookVersion: v1
 - controller: true
   core: true
@@ -69,5 +69,6 @@ resources:
   version: v1alpha1
   webhooks:
     defaulting: true
+    validation: true
     webhookVersion: v1
 version: "3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,10 +30,10 @@ import (
 
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -53,7 +53,6 @@ import (
 	webhookservingv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1"
 	webhookservingv1alpha1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1alpha1"
 	webhookservingv1beta1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -27,6 +27,10 @@ patches:
       clientConfig:
         service:
           name: odh-model-controller-webhook-service
+    - name: vinferencegraph-v1alpha1.odh-model-controller.opendatahub.io
+      clientConfig:
+        service:
+          name: odh-model-controller-webhook-service
   target:
     group: admissionregistration.k8s.io
     kind: ValidatingWebhookConfiguration

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -93,6 +93,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-serving-kserve-io-v1alpha1-inferencegraph
+  failurePolicy: Fail
+  name: vinferencegraph-v1alpha1.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferencegraphs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-serving-kserve-io-v1beta1-inferenceservice
   failurePolicy: Fail
   name: validating.isvc.odh-model-controller.opendatahub.io

--- a/internal/webhook/serving/v1alpha1/inferencegraph_webhook.go
+++ b/internal/webhook/serving/v1alpha1/inferencegraph_webhook.go
@@ -19,13 +19,19 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	servingv1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"knative.dev/pkg/network"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving"
 )
@@ -37,6 +43,7 @@ var inferencegraphlog = logf.Log.WithName("inferencegraph-resource")
 // SetupInferenceGraphWebhookWithManager registers the webhook for InferenceGraph in the manager.
 func SetupInferenceGraphWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&servingv1alpha1.InferenceGraph{}).
+		WithValidator(&InferenceGraphCustomValidator{}).
 		WithDefaulter(&InferenceGraphCustomDefaulter{client: mgr.GetClient()}).
 		Complete()
 }
@@ -70,4 +77,104 @@ func (d *InferenceGraphCustomDefaulter) Default(ctx context.Context, obj runtime
 	}
 
 	return nil
+}
+
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-inferencegraph,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferencegraphs,verbs=create;update,versions=v1alpha1,name=vinferencegraph-v1alpha1.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
+
+// InferenceGraphCustomValidator struct is responsible for validating the InferenceGraph resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type InferenceGraphCustomValidator struct{}
+
+var _ webhook.CustomValidator = &InferenceGraphCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type InferenceGraph.
+func (v *InferenceGraphCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	inferencegraph, ok := obj.(*servingv1alpha1.InferenceGraph)
+	if !ok {
+		return nil, fmt.Errorf("expected a InferenceGraph object but got %T", obj)
+	}
+	inferencegraphlog.Info("Validation for InferenceGraph upon creation", "name", inferencegraph.GetName())
+	return validateInferenceGraph(inferencegraph)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type InferenceGraph.
+func (v *InferenceGraphCustomValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	inferencegraph, ok := newObj.(*servingv1alpha1.InferenceGraph)
+	if !ok {
+		return nil, fmt.Errorf("expected a InferenceGraph object for the newObj but got %T", newObj)
+	}
+	inferencegraphlog.Info("Validation for InferenceGraph upon update", "name", inferencegraph.GetName())
+	return validateInferenceGraph(inferencegraph)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type InferenceGraph.
+func (v *InferenceGraphCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	// ODH does not do any validations when an InferenceGraph is being deleted
+	return nil, nil
+}
+
+func validateInferenceGraph(inferenceGraph *servingv1alpha1.InferenceGraph) (admission.Warnings, error) {
+	clusterDomainName := network.GetClusterDomainName()
+	var validationErrors field.ErrorList
+	for igNodeName, igNode := range inferenceGraph.Spec.Nodes {
+		for stepIdx, step := range igNode.Steps {
+			if len(step.ServiceURL) != 0 {
+				fieldPath := field.NewPath("spec").Child("nodes").Key(igNodeName).Child("steps").Index(stepIdx).Child("serviceUrl")
+				stepUrl, urlParseErr := url.Parse(step.ServiceURL)
+
+				if urlParseErr != nil {
+					validationErrors = append(validationErrors, field.Invalid(
+						fieldPath,
+						step.ServiceURL,
+						fmt.Sprintf("error when parsing serviceUrl: %s", urlParseErr.Error())))
+					continue
+				}
+
+				serviceHost := stepUrl.Hostname()
+				if strings.HasSuffix(serviceHost, ".svc") || strings.HasSuffix(serviceHost, ".svc."+clusterDomainName) {
+					serviceHost = strings.TrimSuffix(serviceHost, ".svc")
+					serviceHost = strings.TrimSuffix(serviceHost, ".svc."+clusterDomainName)
+
+					// There should be only two components in the resulting serviceHost
+					serviceHostComponents := strings.Split(serviceHost, ".")
+					if len(serviceHostComponents) != 2 {
+						validationErrors = append(validationErrors, field.Invalid(
+							fieldPath,
+							step.ServiceURL,
+							"unexpected number of subdomain entries in hostname"))
+						continue
+					}
+
+					// Namespace is the second entry. Require it to be the same as the InferenceGraph namespace
+					targetNamespace := serviceHostComponents[1]
+					if targetNamespace != inferenceGraph.GetNamespace() {
+						validationErrors = append(validationErrors, field.Invalid(
+							fieldPath,
+							step.ServiceURL,
+							"an InferenceGraph cannot refer InferenceServices in other namespaces"))
+					}
+				} else {
+					// For the time being, reject using non-internal hostnames. Specially because of
+					// security (e.g ensuring TLS), it may not be OK that IGs are using workloads that
+					// aren't inside the cluster (e.g. preventing a leak of the Authorization header).
+					validationErrors = append(validationErrors, field.Invalid(
+						fieldPath, step.ServiceURL, "using public hostnames is not allowed"))
+				}
+			}
+		}
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, errors.NewInvalid(
+			inferenceGraph.GroupVersionKind().GroupKind(),
+			inferenceGraph.GetName(),
+			validationErrors,
+		)
+	}
+	return nil, nil
 }

--- a/internal/webhook/serving/v1alpha1/inferencegraph_webhook_test.go
+++ b/internal/webhook/serving/v1alpha1/inferencegraph_webhook_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
@@ -31,7 +33,6 @@ import (
 const InferenceServiceConfigPath1 = "../../../controller/serving/testdata/configmaps/inferenceservice-config.yaml"
 
 var _ = Describe("InferenceGraph Webhook", func() {
-
 	Context("When creating InferenceGraph under Defaulting Webhook", func() {
 		var defaulter InferenceGraphCustomDefaulter
 
@@ -107,5 +108,130 @@ var _ = Describe("InferenceGraph Webhook", func() {
 			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/inject"))
 			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/rewriteAppHTTPProbers"))
 		})
+	})
+
+	Context("When creating or updating InferenceGraph under Validating Webhook", func() {
+		const testingNamespace = "namespace-ig"
+		var validator InferenceGraphCustomValidator
+
+		buildInferenceGraphWithSteps := func(steps []kservev1alpha1.InferenceStep) kservev1alpha1.InferenceGraph {
+			return kservev1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ig",
+					Namespace: testingNamespace,
+				},
+				Spec: kservev1alpha1.InferenceGraphSpec{
+					Nodes: map[string]kservev1alpha1.InferenceRouter{
+						"root": {
+							RouterType: kservev1alpha1.Sequence,
+							Steps:      steps,
+						},
+					},
+				},
+			}
+		}
+
+		BeforeEach(func() {
+			validator = InferenceGraphCustomValidator{}
+		})
+
+		It("Should allow a reference to another node in the InferenceGraph", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						NodeName: "another-inferencegraph-node",
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().To(Succeed())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().To(Succeed())
+		})
+
+		It("Should allow a reference to an InferenceService by name", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceName: "isvc-by-name",
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().ToNot(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().ToNot(HaveOccurred())
+		})
+
+		It("Should allow using FQDN for the same namespace as the InferenceGraph", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceURL: fmt.Sprintf("https://isvc-name.%s.svc.cluster.local", testingNamespace),
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().ToNot(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().ToNot(HaveOccurred())
+		})
+
+		It("Should allow using short hostname for the same namespace as the InferenceGraph", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceURL: fmt.Sprintf("https://isvc-name.%s.svc", testingNamespace),
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().ToNot(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().ToNot(HaveOccurred())
+		})
+
+		It("Should reject using FQDN for a different namespace than the InferenceGraph", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceURL: fmt.Sprintf("https://isvc-name.%s.svc.cluster.local", testingNamespace+"-different"),
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().To(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().To(HaveOccurred())
+		})
+
+		It("Should reject using short hostname for a different namespace than the InferenceGraph", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceURL: fmt.Sprintf("https://isvc-name.%s.svc", testingNamespace+"-different"),
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().To(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().To(HaveOccurred())
+		})
+
+		It("Should reject using public hostnames", func() {
+			inferenceGraph := buildInferenceGraphWithSteps([]kservev1alpha1.InferenceStep{
+				{
+					StepName: "first",
+					InferenceTarget: kservev1alpha1.InferenceTarget{
+						ServiceURL: "https://example.com",
+					},
+				},
+			})
+
+			Expect(validator.ValidateCreate(ctx, &inferenceGraph)).Error().To(HaveOccurred())
+			Expect(validator.ValidateUpdate(ctx, nil, &inferenceGraph)).Error().To(HaveOccurred())
+		})
+
 	})
 })


### PR DESCRIPTION
## Description
In ODH we prefer isolation between projects/namespaces. For InferenceGraph CRD, KServe doesn't do any validation on the used hostname when a node/step is using `serviceUrl`. This can break isolation between projects, because it is allowed to specify a hostname from another namespace.

This adds a validating webhook to prevent the user from using an in-cluster hostname that would be referring to a different namespace from the created/updated InferenceGraph.

Fixes: https://issues.redhat.com/browse/RHOAIENG-17828

## How Has This Been Tested?
**TODO**

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
