### PR TITLE
Fix: Ensure odh-model-controller Deployment Waits for ConfigMap

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
-	"slices"
 	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -305,7 +304,7 @@ func setupNim(mgr manager.Manager, signalHandlerCtx context.Context, kubeClient 
 	var err error
 
 	nimState := os.Getenv("NIM_STATE")
-	if !slices.Contains([]string{"removed", ""}, nimState) {
+	if nimState != "removed" {
 		if err = (&nim.AccountReconciler{
 			Client:  mgr.GetClient(),
 			Scheme:  mgr.GetScheme(),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -304,6 +304,9 @@ func setupNim(mgr manager.Manager, signalHandlerCtx context.Context, kubeClient 
 	var err error
 
 	nimState := os.Getenv("NIM_STATE")
+	if nimState == "" {
+		nimState = "managed"
+	}
 	if nimState != "removed" {
 		if err = (&nim.AccountReconciler{
 			Client:  mgr.GetClient(),

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -105,7 +105,6 @@ spec:
               configMapKeyRef:
                 name: odh-model-controller-parameters
                 key: nim-state
-                optional: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -105,6 +105,7 @@ spec:
               configMapKeyRef:
                 name: odh-model-controller-parameters
                 key: nim-state
+                optional: false
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
### **Fix: Ensure `odh-model-controller` Deployment Waits for ConfigMap & Adjust NIM_STATE Handling**  

#### **Issue**  
- The Kustomization for `odh-model-controller` creates both the **Deployment** and the **ConfigMap**.  
- However, the Deployment is set with `optional: true` for the ConfigMap, meaning it can start **before** the ConfigMap is available.  
- If the Deployment starts first (as seen in QE), it runs **without** the `NIM_STATE` environment variable, causing the backend to **ignore Accounts**.  

#### **Fix 1: Ensure ConfigMap Availability**  
- Set `optional: false` for the ConfigMap in the Deployment.  
- This ensures the Deployment **waits** for the ConfigMap before starting.  
- Since both resources are managed by the same Kustomization and the ConfigMap has a default value, this change is safe.  

#### **Fix 2: Adjust `NIM_STATE` Handling**  
- Stop checking for an empty string when validating `NIM_STATE`.  
- Instead of:  
  ```go
  if !slices.Contains([]string{"removed", ""}, nimState) {
  ```  
  Change to:  
  ```go
  if nimState != "removed" {
  ```  
- This ensures that if `NIM_STATE` is not specified, **it defaults to enabled** instead of off.  

#### **Impact**  
- Ensures consistent deployment behavior.  
- Prevents the backend from ignoring Accounts due to missing `NIM_STATE`.  
- Enables NIM by default when not explicitly set.  

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
