### PR TITLE
fix: added accept header to nim manifest pull requests accepting oci

### DIFF
--- a/internal/controller/testdata/nvidia_api_mock.go
+++ b/internal/controller/testdata/nvidia_api_mock.go
@@ -70,8 +70,10 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		// check testdata/ngc_catalog_response_page_0.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-my-fake-token-please-dont-share-it-with-anyone" {
-			// the token is returned by the nvcr.io/proxy-auth endpoint (stubbed), check testdata/runtime_token_response.json
-			return &http.Response{StatusCode: 200}, nil
+			if req.Header.Get("Accept") == "application/vnd.oci.image.index.v1+json" {
+				// the token is returned by the nvcr.io/proxy-auth endpoint (stubbed), check testdata/runtime_token_response.json
+				return &http.Response{StatusCode: 200}, nil
+			}
 		}
 	}
 

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -275,7 +275,6 @@ func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) erro
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
 	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
-	fmt.Println(req.Header.Get("Accept"))
 	resp, respErr := NimHttpClient.Do(req)
 	if respErr != nil {
 		return respErr

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -273,7 +273,9 @@ func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) erro
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
+	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
+	fmt.Println(req.Header.Get("Accept"))
 	resp, respErr := NimHttpClient.Do(req)
 	if respErr != nil {
 		return respErr


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, 14 runtimes out of the overall 67 runtimes we get from NVIDIA’s API, are OCI-based and support multi-arch. When attempting to pull a manifest for one of the said runtimes, we get a 404 with a message hidden in the body, indicating we need to explicitly accept OCI images:

```json
{
  "errors": [
    {
      "code": "MANIFEST_UNKNOWN",
      "message": "OCI index found, but accept header does not support OCI indexes"
    }
  ]
}
```

We fetch the available runtime list from NVIDIA on reconciling, this list is not ordered, and although the response appears cached, the item slots may differ between calls. We use the first runtime from the list for validating the API key, in cases when an OCI-based image is the first one, the API key validation fails, we cleanup and update the status accordingly.

This can be fixed by adding a header indicating the accepted media type to requests for manifest pulling:
(see [OpenContainers spec](https://github.com/opencontainers/image-spec/blob/main/image-index.md)).
```
Accept: application/vnd.oci.image.index.v1+json
```

Adding this header means that, for OCI images, the manifest pull will now include a body with details about the different underlying architecture-based manifests. In our case, we don't work the body, we only care about the status code, and we treat 200 as a successful validation.

### Without the header

**Successful non-OCI image**:
![image](https://github.com/user-attachments/assets/4b8db621-bea4-4431-ab92-65f02b0e86cf)

**Faild OCI image**:
![image](https://github.com/user-attachments/assets/3c200b77-d6eb-45a2-b8e0-b30851b943d4)

### With the header

**Successful non-OCI image**:
![image](https://github.com/user-attachments/assets/0f4590e2-03b3-4fb4-87ff-52290c538998)

**Successful OCI image**:
![image](https://github.com/user-attachments/assets/ee36ae2a-8f29-474c-8e6a-6064a77b9013)

Jira: https://issues.redhat.com/browse/NVPE-137
Addendum doc: https://docs.google.com/document/d/1MNERaPIS__5eQCh-ad9GmX_KosleRCbYb20F1Wdarss/edit?tab=t.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using a slightly modified version of the [verify_nvidia_nim_api script](https://github.com/opendatahub-io/odh-model-controller/blob/incubating/hack/verify_nvidia_nim_api.go), verifying every runtime out of the 67 existing ones, is validated successfully with the new header.

Follow the [Reproduce Steps](https://docs.google.com/document/d/1MNERaPIS__5eQCh-ad9GmX_KosleRCbYb20F1Wdarss/edit?tab=t.0#heading=h.sc9u2xn4gmsv) section in the addendum [doc](https://docs.google.com/document/d/1MNERaPIS__5eQCh-ad9GmX_KosleRCbYb20F1Wdarss/edit?tab=t.0#heading=h.sc9u2xn4gmsv).

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
