### PR TITLE
fix: nim containers terminated prematurely

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -331,8 +331,9 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 		Spec: v1alpha1.ServingRuntimeSpec{
 			ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
 				Annotations: map[string]string{
-					"prometheus.io/path": "/metrics",
-					"prometheus.io/port": "8000",
+					"prometheus.io/path":                    "/metrics",
+					"prometheus.io/port":                    "8000",
+					"serving.knative.dev/progress-deadline": "30m",
 				},
 				Containers: []corev1.Container{
 					{Env: []corev1.EnvVar{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

NIM deployments, depending on the model size and PVC state and class, can take some time to start. Kserve's 10-minute default limitation doesn't always suffice, and we've been handling this setting the _progress-deadline_ annotation manually to 30 minutes. See https://ai-on-openshift.io/odh-rhoai/kserve-timeout/.

This PR injects the said annotation using the ServingRuntime template for NIM deployments.

Jira: https://issues.redhat.com/browse/NVPE-138

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This is a known practice, we've been using it ourselves and offering it to others.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
