### PR TITLE
only create CRB for raw if isvc has auth

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -239,10 +239,21 @@ rules:
   - serving.kserve.io
   resources:
   - inferenceservices
-  - inferenceservices/finalizers
   verbs:
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -242,6 +242,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -18,7 +18,8 @@ package constants
 type KServeDeploymentMode string
 
 const (
-	InferenceServiceKind = "InferenceService"
+	InferenceServiceKind             = "InferenceService"
+	InferenceServiceODHFinalizerName = "odh.inferenceservice.finalizers"
 
 	ServiceMeshMemberRollName        = "default"
 	ServiceMeshMemberName            = "default"

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -89,7 +89,7 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 	return isvcReconciler
 }
 
-// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;list;watch;update;create;patch;delete
 
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -19,8 +19,11 @@ package serving
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -34,9 +37,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/serving/reconcilers"
@@ -85,7 +90,7 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 }
 
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;list;watch;update;create;patch;delete
 
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -132,8 +137,41 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 		return ctrl.Result{}, err
 	}
 
-	if isvc.GetDeletionTimestamp() != nil {
-		return reconcile.Result{}, r.onDeletion(ctx, logger, isvc)
+	if isvc.GetDeletionTimestamp() == nil {
+		// The object is not being deleted, so if it does not have our finalizer,
+		// then lets add the finalizer and update the object. This is equivalent
+		// registering our finalizer.
+		logger.Info("Adding Finalizer")
+		if !controllerutil.ContainsFinalizer(isvc, constants.InferenceServiceODHFinalizerName) {
+			controllerutil.AddFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
+			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
+			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
+			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	} else {
+		var deleteErrors *multierror.Error
+		logger.Info("InferenceService being deleted")
+		if controllerutil.ContainsFinalizer(isvc, constants.InferenceServiceODHFinalizerName) {
+			err := r.onDeletion(ctx, logger, isvc)
+			if err != nil {
+				deleteErrors = multierror.Append(deleteErrors, err)
+			}
+			// Check if we need to also perform cleanup on the namespace
+			err1 := r.DeleteResourcesIfNoIsvcExists(ctx, logger, req.Namespace)
+			if err1 != nil {
+				deleteErrors = multierror.Append(deleteErrors, err1)
+			}
+			controllerutil.RemoveFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
+			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
+			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
+			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
+				return reconcile.Result{}, err
+			}
+
+		}
+		return reconcile.Result{}, deleteErrors.ErrorOrNil()
 	}
 
 	// Check what deployment mode is used by the InferenceService. We have differing reconciliation logic for Kserve and ModelMesh
@@ -259,7 +297,8 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // general clean-up, mostly resources in different namespaces from kservev1beta1.InferenceService
 func (r *InferenceServiceReconciler) onDeletion(ctx context.Context, log logr.Logger, inferenceService *kservev1beta1.InferenceService) error {
-	log.V(1).Info("Running cleanup logic")
+
+	log.V(1).Info("Triggering Delete for InferenceService: " + inferenceService.Name)
 
 	IsvcDeploymentMode, err := utils.GetDeploymentModeForKServeResource(ctx, r.Client, inferenceService.GetAnnotations())
 	if err != nil {
@@ -277,18 +316,58 @@ func (r *InferenceServiceReconciler) onDeletion(ctx context.Context, log logr.Lo
 }
 
 func (r *InferenceServiceReconciler) DeleteResourcesIfNoIsvcExists(ctx context.Context, log logr.Logger, namespace string) error {
+	inferenceServiceList := &kservev1beta1.InferenceServiceList{}
+	if err := r.Client.List(ctx, inferenceServiceList, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	var existingServerlessIsvcs []kservev1beta1.InferenceService
+	var existingRawIsvcs []kservev1beta1.InferenceService
+	var existingModelMeshIsvcs []kservev1beta1.InferenceService
+	for _, isvc := range inferenceServiceList.Items {
+		isvcDeploymentMode, err := utils.GetDeploymentModeForKServeResource(ctx, r.Client, isvc.GetAnnotations())
+		if err != nil {
+			return err
+		}
+		switch isvcDeploymentMode {
+		case constants.Serverless:
+			if isvc.GetDeletionTimestamp() == nil {
+				existingServerlessIsvcs = append(existingServerlessIsvcs, isvc)
+			}
+		case constants.RawDeployment:
+			if isvc.GetDeletionTimestamp() == nil {
+				existingRawIsvcs = append(existingRawIsvcs, isvc)
+			}
+		case constants.ModelMesh:
+			if isvc.GetDeletionTimestamp() == nil {
+				existingModelMeshIsvcs = append(existingModelMeshIsvcs, isvc)
+			}
+		default:
+			return fmt.Errorf("Unknown deployment mode for InferenceService: %v", isvc)
+		}
+	}
 	// If there are no ISVCs left, all 3 of these functions get called. Issue is that when the Serverless reconciler gets called
 	// and there is no servicemesh installed (which is the case with RawDeployment) the Serverless reconciler will fail when it calls
 	// the subresourcereconciler Cleanup function. This is because the Serverless reconciler will try to get the ServiceMesh resources and clean them up.
 	// Adding a no match error check will prevent this from erroring out due to that.
-	if err := r.kserveServerlessISVCReconciler.CleanupNamespaceIfNoKserveIsvcExists(ctx, log, namespace); err != nil {
-		return err
+
+	if len(existingServerlessIsvcs) == 0 {
+		log.V(1).Info("Triggering Serverless Cleanup for Namespace: " + namespace)
+		if err := r.kserveServerlessISVCReconciler.CleanupNamespaceIfNoKserveIsvcExists(ctx, log, namespace); err != nil {
+			return err
+		}
 	}
-	if err := r.mmISVCReconciler.DeleteModelMeshResourcesIfNoMMIsvcExists(ctx, log, namespace); err != nil {
-		return err
+	if len(existingRawIsvcs) == 0 {
+		log.V(1).Info("Triggering RawDeployment Cleanup for Namespace: " + namespace)
+		if err := r.kserveRawISVCReconciler.CleanupNamespaceIfNoRawKserveIsvcExists(ctx, log, namespace); err != nil {
+			return err
+		}
 	}
-	if err := r.kserveRawISVCReconciler.CleanupNamespaceIfNoKserveIsvcExists(ctx, log, namespace); err != nil {
-		return err
+	if len(existingModelMeshIsvcs) == 0 {
+		log.V(1).Info("Triggering ModelMesh Cleanup for Namespace: " + namespace)
+		if err := r.mmISVCReconciler.DeleteModelMeshResourcesIfNoMMIsvcExists(ctx, log, namespace); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/controller/serving/reconcilers/kserve_istio_smm_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_istio_smm_reconciler.go
@@ -52,6 +52,7 @@ func (r *KserveServiceMeshMemberReconciler) Reconcile(ctx context.Context, log l
 }
 
 func (r *KserveServiceMeshMemberReconciler) Cleanup(ctx context.Context, log logr.Logger, namespace string) error {
+	log.V(1).Info("Deleting Istio Telemetry object for target namespace")
 	existingSMM, getError := r.getExistingResource(ctx, log, namespace)
 	if getError != nil {
 		return getError

--- a/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
@@ -22,9 +22,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
-	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 )
 
 var _ Reconciler = (*KserveRawInferenceServiceReconciler)(nil)
@@ -68,30 +65,10 @@ func (r *KserveRawInferenceServiceReconciler) OnDeletionOfKserveInferenceService
 	return deleteErrors.ErrorOrNil()
 }
 
-func (r *KserveRawInferenceServiceReconciler) CleanupNamespaceIfNoKserveIsvcExists(ctx context.Context, log logr.Logger, namespace string) error {
-	inferenceServiceList := &kservev1beta1.InferenceServiceList{}
-	if err := r.client.List(ctx, inferenceServiceList, client.InNamespace(namespace)); err != nil {
-		return err
-	}
-
-	for i := len(inferenceServiceList.Items) - 1; i >= 0; i-- {
-		inferenceService := inferenceServiceList.Items[i]
-		isvcDeploymentMode, err := utils.GetDeploymentModeForKServeResource(ctx, r.client, inferenceService.GetAnnotations())
-		if err != nil {
-			return err
-		}
-		if isvcDeploymentMode != constants.RawDeployment {
-			inferenceServiceList.Items = append(inferenceServiceList.Items[:i], inferenceServiceList.Items[i+1:]...)
-		}
-	}
-
-	// If there are no Kserve Raw InferenceServices in the namespace, delete namespace-scoped resources needed for Kserve Raw
+func (r *KserveRawInferenceServiceReconciler) CleanupNamespaceIfNoRawKserveIsvcExists(ctx context.Context, log logr.Logger, namespace string) error {
 	var cleanupErrors *multierror.Error
-	if len(inferenceServiceList.Items) == 0 {
-		for _, reconciler := range r.subResourceReconcilers {
-			cleanupErrors = multierror.Append(cleanupErrors, reconciler.Cleanup(ctx, log, namespace))
-		}
+	for _, reconciler := range r.subResourceReconcilers {
+		cleanupErrors = multierror.Append(cleanupErrors, reconciler.Cleanup(ctx, log, namespace))
 	}
-
 	return cleanupErrors.ErrorOrNil()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes: [RHOAIENG-18658](https://issues.redhat.com/browse/RHOAIENG-18658) 
- Only Create CRB for raw if isvc has auth label 
- Delete CRB only when all isvcs using the associated service-account are removed
- add odh finalizer to ensure deterministic resource deletion in the reconcile loop. 
- minor unit test changes to fix `update` conflicts caused in existing tests due adding a finalizer
- modified namespace cleanup functions to reduce the amount of repeated logic executions 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests added
- tested on cluster 
```
kserve:
      defaultDeploymentMode: RawDeployment
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/VedantMahabaleshwarkar/kserve/tarball/devflags'
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/VedantMahabaleshwarkar/odh-model-controller/tarball/devflags'
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
