### PR TITLE
fix: cleanup fails for disabled NIM

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,10 +31,8 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -47,8 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/go-logr/logr"
-
-	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
 	corecontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/core"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/nim"
 	servingcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving"
@@ -191,40 +187,8 @@ func setupNim(mgr manager.Manager, signalHandlerCtx context.Context, kubeClient 
 			os.Exit(1)
 		}
 	} else {
-		accounts := &v1.AccountList{}
-		if err := mgr.GetClient().List(signalHandlerCtx, accounts); err != nil {
-			setupLog.Error(err, "failed to fetch accounts")
-		}
-		for _, account := range accounts.Items {
-			setupLog.V(1).Info("Cleaning up resources for account", "namespace", account.Namespace, "name", account.Name)
-			// Call CleanupResources for the current account
-			if err = utils.CleanupResources(signalHandlerCtx, &account, mgr.GetClient()); err != nil {
-				setupLog.Error(err, "failed to perform clean up on some accounts")
-			}
-
-			msg := "NIM has been disabled"
-			cleanStatus := v1.AccountStatus{
-				NIMConfig:       nil,
-				RuntimeTemplate: nil,
-				NIMPullSecret:   nil,
-				Conditions: []metav1.Condition{
-					utils.MakeNimCondition(utils.NimConditionAccountStatus, metav1.ConditionUnknown, account.Generation,
-						"AccountNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionAPIKeyValidation, metav1.ConditionUnknown, account.Generation,
-						"ApiKeyNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionConfigMapUpdate, metav1.ConditionUnknown, account.Generation,
-						"ConfigMapNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionTemplateUpdate, metav1.ConditionUnknown, account.Generation,
-						"TemplateNotReconciled", msg),
-					utils.MakeNimCondition(utils.NimConditionSecretUpdate, metav1.ConditionUnknown, account.Generation,
-						"SecretNotReconciled", msg),
-				},
-			}
-			subject := types.NamespacedName{Name: account.Name, Namespace: account.Namespace}
-
-			if err = utils.UpdateStatus(signalHandlerCtx, subject, cleanStatus, mgr.GetClient()); err != nil {
-				setupLog.Error(err, "failed to perform clean up on some accounts")
-			}
+		if err = mgr.Add(&utils.NIMCleanupRunner{Client: mgr.GetClient(), Logger: setupLog}); err != nil {
+			setupLog.Error(err, "failed to add NIM cleanup runner")
 		}
 	}
 

--- a/internal/controller/utils/nim_test.go
+++ b/internal/controller/utils/nim_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("NIMCleanupRunner test cases", func() {
+
+	It("should not fail if no accounts exist", func(ctx SpecContext) {
+		By("Not creating accounts")
+		cleaner := &NIMCleanupRunner{Client: testClient}
+		Expect(cleaner.Start(ctx)).To(Succeed())
+	})
+
+	It("should cleanup owned resources", func(ctx SpecContext) {
+		By("Creating a namespace")
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "dummy-acct-test"}}
+		Expect(testClient.Create(ctx, ns)).To(Succeed())
+
+		By("Creating an Account")
+		account := &v1.Account{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-dummy-acct-test",
+				Namespace: ns.Name,
+			},
+			Spec: v1.AccountSpec{APIKeySecret: corev1.ObjectReference{Name: "dummy-api-secret-name-acct-test"}},
+		}
+		Expect(testClient.Create(ctx, account)).To(Succeed())
+
+		By("Creating supporting resources")
+		pull := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "fake-pull-secret-acct-test", Namespace: ns.Name}}
+		Expect(testClient.Create(ctx, pull)).To(Succeed())
+
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "fake-cm-acct-test", Namespace: ns.Name}}
+		Expect(testClient.Create(ctx, cm)).To(Succeed())
+
+		template := &templatev1.Template{
+			ObjectMeta: metav1.ObjectMeta{Name: "fake-template-acct-test", Namespace: ns.Name},
+			Objects:    []runtime.RawExtension{},
+		}
+		Expect(testClient.Create(ctx, template)).To(Succeed())
+
+		By("Updating the Account status")
+		acctStatusUp := &v1.Account{}
+		Expect(testClient.Get(ctx, types.NamespacedName{Name: account.Name, Namespace: ns.Name}, acctStatusUp)).To(Succeed())
+
+		acctStatusUp.Status = v1.AccountStatus{
+			RuntimeTemplate: &corev1.ObjectReference{Name: template.Name, Namespace: ns.Name},
+			NIMConfig:       &corev1.ObjectReference{Name: cm.Name, Namespace: ns.Name},
+			NIMPullSecret:   &corev1.ObjectReference{Name: pull.Name, Namespace: ns.Name},
+			Conditions: []metav1.Condition{
+				MakeNimCondition(NimConditionAccountStatus, metav1.ConditionTrue, 1, "testing", "because-i-said-so"),
+				MakeNimCondition(NimConditionTemplateUpdate, metav1.ConditionTrue, 1, "testing", "because-i-said-so"),
+				MakeNimCondition(NimConditionSecretUpdate, metav1.ConditionTrue, 1, "testing", "because-i-said-so"),
+				MakeNimCondition(NimConditionConfigMapUpdate, metav1.ConditionTrue, 1, "testing", "because-i-said-so"),
+				MakeNimCondition(NimConditionAPIKeyValidation, metav1.ConditionTrue, 1, "testing", "because-i-said-so"),
+			},
+		}
+		Expect(testClient.Status().Update(ctx, acctStatusUp)).To(Succeed())
+
+		By("Running the Cleaner")
+		cleaner := &NIMCleanupRunner{Client: testClient}
+		Expect(cleaner.Start(ctx)).To(Succeed())
+
+		By("Fetching the updated Account")
+		updatedAccount := &v1.Account{}
+		Expect(testClient.Get(ctx, types.NamespacedName{Name: account.Name, Namespace: ns.Name}, updatedAccount)).To(Succeed())
+
+		By("Verifying supporting resources deletion")
+		Expect(testClient.Get(ctx, types.NamespacedName{Name: pull.Name, Namespace: ns.Name}, &corev1.Secret{})).NotTo(Succeed())
+		Expect(testClient.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: ns.Name}, &corev1.ConfigMap{})).NotTo(Succeed())
+		Expect(testClient.Get(ctx, types.NamespacedName{Name: template.Name, Namespace: ns.Name}, &templatev1.Template{})).NotTo(Succeed())
+
+		By("Fetching Account status")
+		Expect(updatedAccount.Status.RuntimeTemplate).To(BeNil())
+		Expect(updatedAccount.Status.NIMConfig).To(BeNil())
+		Expect(updatedAccount.Status.NIMPullSecret).To(BeNil())
+
+		for _, cond := range []NimConditionType{NimConditionAccountStatus, NimConditionAPIKeyValidation, NimConditionConfigMapUpdate, NimConditionTemplateUpdate, NimConditionSecretUpdate} {
+			Expect(updatedAccount.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+				"Type":    Equal(cond.String()),
+				"Message": Equal("NIM has been disabled"),
+				"Status":  Equal(metav1.ConditionUnknown),
+				"Reason":  ContainSubstring("NotReconciled"),
+			})))
+		}
+	})
+})

--- a/internal/controller/utils/suite_test.go
+++ b/internal/controller/utils/suite_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"fmt"
+	"path/filepath"
+	osrt "runtime"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var testEnv *envtest.Environment
+var testClient client.Client
+
+func TestNIMUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "NIM Utils Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "config", "crd", "external"),
+		},
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.31.0-%s-%s", osrt.GOOS, osrt.GOARCH)),
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	RegisterSchemes(scheme)
+
+	testClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(testClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When setting _DataScienceCluster.spec.kserve.nim.managedState_ to _Removed_ and restarting _odh-model-controller_, NIM accounts require cleanups. The cleanup process is performed before the manager starts, hence the cache is not yet available, which ends up with the cleanup process failing and logging the following error:
```
ERROR setup failed to fetch accounts \{"error": "the cache is not started, can not read objects"}
```

This PR fixes this by moving the cleanup process to a runnable managed by the manager, the cleanup will be executed after the manager starts and the cache will be available. The new cleanup logic was moved from _main_ to the _utils_ and includes tests.

Jira: https://issues.redhat.com/browse/NVPE-147

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added unit test cases.
- Built an intermediate image as `quay.io/tomerfi/odh-model-controller:fix-cleanup` and used it as in our development environment. Testing process:
  - Successfully enable NIM
  - Set _DataScienceCluster.spec.kserve.nim.managedState_ to _Removed_
  - Verify _odh-model-controller-parameters.data.nim-state_ was reconciled to _removed_
  - Restart _odh-model-controller_
  - Verify the error is not logged
  - Verify the supported resources were removed (ConfigMap, Secret, Template)
  - Verify the Account status was updated

![nim-disabled](https://github.com/user-attachments/assets/34e17be7-8002-467c-aaf3-fbe5be7ad8dc)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
