### PR TITLE
add kserve-state and modelmesh-state as args

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,13 +137,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	kserveState := os.Getenv("KSERVE_STATE")
+	modelMeshState := os.Getenv("MODELMESH_STATE")
+	setupLog.Info("Installation status of Serving Components",
+		"kserve-state", kserveState, "modelmesh-state", modelMeshState)
+
 	kserveWithMeshEnabled, kserveWithMeshEnabledErr := utils.VerifyIfComponentIsEnabled(
 		context.Background(), mgr.GetClient(), utils.KServeWithServiceMeshComponent)
 	if kserveWithMeshEnabledErr != nil {
 		setupLog.Error(kserveWithMeshEnabledErr, "could not determine if kserve have service mesh enabled")
 	}
 
-	if err := setupReconcilers(mgr, setupLog, kubeClient, cfg); err != nil {
+	if err := setupReconcilers(mgr, setupLog, kubeClient, cfg, kserveState, modelMeshState); err != nil {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
@@ -310,7 +315,7 @@ func setupWebhooks(mgr ctrl.Manager, setupLog logr.Logger, kserveWithMeshEnabled
 }
 
 func setupReconcilers(mgr ctrl.Manager, setupLog logr.Logger,
-	kubeClient kubernetes.Interface, cfg *rest.Config) error {
+	kubeClient kubernetes.Interface, cfg *rest.Config, kserveState string, _ string) error {
 	if err := setupInferenceServiceReconciler(mgr, kubeClient, cfg); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InferenceService")
 		return err
@@ -332,21 +337,26 @@ func setupReconcilers(mgr ctrl.Manager, setupLog logr.Logger,
 		return err
 	}
 
-	inferenceGraphCrdAvailable, igCrdErr := utils.IsCrdAvailable(
-		mgr.GetConfig(),
-		v1alpha1.SchemeGroupVersion.String(),
-		"InferenceGraph")
-	if igCrdErr != nil {
-		setupLog.Error(igCrdErr, "unable to check if InferenceGraph CRD is available", "controller", "InferenceGraph")
-		return igCrdErr
-	} else if inferenceGraphCrdAvailable {
-		if err := setupInferenceGraphReconciler(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
-			return err
+	if kserveState == "managed" {
+		inferenceGraphCrdAvailable, igCrdErr := utils.IsCrdAvailable(
+			mgr.GetConfig(),
+			v1alpha1.SchemeGroupVersion.String(),
+			"InferenceGraph")
+		if igCrdErr != nil {
+			setupLog.Error(igCrdErr, "unable to check if InferenceGraph CRD is available", "controller", "InferenceGraph")
+			return igCrdErr
+		} else if inferenceGraphCrdAvailable {
+			if err := setupInferenceGraphReconciler(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
+				return err
+			}
+		} else {
+			setupLog.Info("crds unavailable, skipping controller", "controller", "InferenceGraph")
 		}
 	} else {
-		setupLog.Info("controller is turned off", "controller", "InferenceGraph")
+		setupLog.Info("kserve state is not managed, skipping controller", "controller", "InferenceGraph")
 	}
+
 	return nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,7 +28,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -338,20 +337,9 @@ func setupReconcilers(mgr ctrl.Manager, setupLog logr.Logger,
 	}
 
 	if kserveState == "managed" {
-		inferenceGraphCrdAvailable, igCrdErr := utils.IsCrdAvailable(
-			mgr.GetConfig(),
-			v1alpha1.SchemeGroupVersion.String(),
-			"InferenceGraph")
-		if igCrdErr != nil {
-			setupLog.Error(igCrdErr, "unable to check if InferenceGraph CRD is available", "controller", "InferenceGraph")
-			return igCrdErr
-		} else if inferenceGraphCrdAvailable {
-			if err := setupInferenceGraphReconciler(mgr); err != nil {
-				setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
-				return err
-			}
-		} else {
-			setupLog.Info("crds unavailable, skipping controller", "controller", "InferenceGraph")
+		if err := setupInferenceGraphReconciler(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
+			return err
 		}
 	} else {
 		setupLog.Info("kserve state is not managed, skipping controller", "controller", "InferenceGraph")

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -128,6 +128,39 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.nim-state
+    targets:
+      - select:
+          kind: Deployment
+          name: odh-model-controller
+        fieldPaths:
+          - spec.template.spec.containers.0.env.[name=NIM_STATE].value
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.kserve-state
+    targets:
+      - select:
+          kind: Deployment
+          name: odh-model-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=KSERVE_STATE].value
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.modelmeshserving-state
+    targets:
+      - select:
+          kind: Deployment
+          name: odh-model-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=MODELMESH_STATE].value
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: metadata.namespace
     targets:
       - select:

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -134,7 +134,7 @@ replacements:
           kind: Deployment
           name: odh-model-controller
         fieldPaths:
-          - spec.template.spec.containers.0.env.[name=NIM_STATE].value
+          - spec.template.spec.containers.[name=manager].env.[name=NIM_STATE].value
   - source:
       kind: ConfigMap
       version: v1

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -5,3 +5,5 @@ tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2024.5-release
 vllm-image=quay.io/opendatahub/vllm:fast
 nim-state=managed
+kserve-state=managed
+modelmeshserving-state=managed

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -101,11 +101,11 @@ spec:
                 key: MESH_NAMESPACE
                 optional: true
           - name: NIM_STATE
-            valueFrom:
-              configMapKeyRef:
-                name: odh-model-controller-parameters
-                key: nim-state
-                optional: false
+            value: $(nim-state)
+          - name: KSERVE_STATE
+            value: $(kserve-state)
+          - name: MODELMESH_STATE
+            value: $(modelmeshserving-state)
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -101,11 +101,11 @@ spec:
                 key: MESH_NAMESPACE
                 optional: true
           - name: NIM_STATE
-            value: $(nim-state)
+            value: replace
           - name: KSERVE_STATE
-            value: $(kserve-state)
+            value: replace
           - name: MODELMESH_STATE
-            value: $(modelmeshserving-state)
+            value: replace
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes: [RHOAIENG-18974](https://issues.redhat.com/browse/RHOAIENG-18974)
- add `kserve-state` and `modelmesh-state` in odh-model-controller-parameters 
- pass `kserve-state` and `modelmesh-state` values as env variables in the odh-model-controller deployment
- use `kserve-state` value to determine whether to start InferenceGraph controller

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run `kustomize build config/base > temp.txt`
- change `kserve-state` and `modelmeshserving-state` in `config/base/params.env` from `managed` to `unmanaged` in any combination. 
- For each combination run `kustomize build config/base > temp1.txt` etc 
- Compare the kustomize build outputs for each case
- each resulting deployment yaml should differ (thus leading to a new deployment on a cluster) 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
