### PR TITLE
fix: when in Raw Mode as no Authorino is available, should not own AuthConfig

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,6 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -337,15 +336,7 @@ func setupReconcilers(mgr ctrl.Manager, setupLog logr.Logger,
 	}
 
 	if kserveState == "managed" {
-		authConfigCrdAvailable, authCrdErr := utils.IsCrdAvailable(
-			mgr.GetConfig(),
-			authorinov1beta2.GroupVersion.String(),
-			"AuthConfig")
-		if authCrdErr != nil {
-			setupLog.Error(authCrdErr, "unable to check if AuthConfig CRD is available", "controller", "InferenceGraph")
-			return authCrdErr
-		}
-		if err := setupInferenceGraphReconciler(mgr, authConfigCrdAvailable); err != nil {
+		if err := setupInferenceGraphReconciler(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "InferenceGraph")
 			return err
 		}
@@ -398,6 +389,6 @@ func setupServingRuntimeReconciler(mgr ctrl.Manager) error {
 	}).SetupWithManager(mgr)
 }
 
-func setupInferenceGraphReconciler(mgr ctrl.Manager, authConfigCrdAvailable bool) error {
-	return servingcontroller.NewInferenceGraphReconciler(mgr).SetupWithManager(mgr, authConfigCrdAvailable)
+func setupInferenceGraphReconciler(mgr ctrl.Manager) error {
+	return servingcontroller.NewInferenceGraphReconciler(mgr).SetupWithManager(mgr)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -395,6 +395,6 @@ func setupServingRuntimeReconciler(mgr ctrl.Manager) error {
 	}).SetupWithManager(mgr)
 }
 
-func setupInferenceGraphReconciler(mgr ctrl.Manager, isServingMode bool) error {
-	return servingcontroller.NewInferenceGraphReconciler(mgr).SetupWithManager(mgr, isServingMode)
+func setupInferenceGraphReconciler(mgr ctrl.Manager, isServerlessMode bool) error {
+	return servingcontroller.NewInferenceGraphReconciler(mgr).SetupWithManager(mgr, isServerlessMode)
 }

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -166,11 +166,11 @@ func (r *InferenceGraphReconciler) getExistingAuthConfig(ctx context.Context, ig
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager, isServingMode bool) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&servingv1alpha1.InferenceGraph{}).
 		Named("serving-inferencegraph")
-	// dynamic add authconfig to watchlist based on serving mode
+	// dynamic add authconfig to watchlist based on serving mode + if authconfig crd is available
 	authConfigCrdAvailable, authCrdErr := utils.IsCrdAvailable(
 		mgr.GetConfig(),
 		authorinov1beta2.GroupVersion.String(),
@@ -178,7 +178,7 @@ func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if authCrdErr != nil {
 		return fmt.Errorf("failed to check if  AuthConfig CRD in the cluster: %w", authCrdErr)
 	}
-	if authConfigCrdAvailable {
+	if authConfigCrdAvailable && isServingMode {
 		builder.Owns(&authorinov1beta2.AuthConfig{})
 	}
 

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -166,11 +166,18 @@ func (r *InferenceGraphReconciler) getExistingAuthConfig(ctx context.Context, ig
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager, authConfigCrdAvailable bool) error {
+func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&servingv1alpha1.InferenceGraph{}).
 		Named("serving-inferencegraph")
 	// dynamic add authconfig to watchlist based on serving mode
+	authConfigCrdAvailable, authCrdErr := utils.IsCrdAvailable(
+		mgr.GetConfig(),
+		authorinov1beta2.GroupVersion.String(),
+		"AuthConfig")
+	if authCrdErr != nil {
+		return fmt.Errorf("failed to check if  AuthConfig CRD in the cluster: %w", authCrdErr)
+	}
 	if authConfigCrdAvailable {
 		builder.Owns(&authorinov1beta2.AuthConfig{})
 	}

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -166,12 +166,16 @@ func (r *InferenceGraphReconciler) getExistingAuthConfig(ctx context.Context, ig
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager, authConfigCrdAvailable bool) error {
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&servingv1alpha1.InferenceGraph{}).
-		Owns(&authorinov1beta2.AuthConfig{}).
-		Named("serving-inferencegraph").
-		Complete(r)
+		Named("serving-inferencegraph")
+	// dynamic add authconfig to watchlist based on serving mode
+	if authConfigCrdAvailable {
+		builder.Owns(&authorinov1beta2.AuthConfig{})
+	}
+
+	return builder.Complete(r)
 }
 
 func (r *InferenceGraphReconciler) processAuthConfigDelta(ctx context.Context, logger logr.Logger, desiredState *authorinov1beta2.AuthConfig, existingState *authorinov1beta2.AuthConfig) error {

--- a/internal/controller/serving/suite_test.go
+++ b/internal/controller/serving/suite_test.go
@@ -177,7 +177,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = NewInferenceGraphReconciler(mgr).SetupWithManager(mgr)
+	err = NewInferenceGraphReconciler(mgr).SetupWithManager(mgr, true)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/internal/controller/serving/suite_test.go
+++ b/internal/controller/serving/suite_test.go
@@ -177,7 +177,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = NewInferenceGraphReconciler(mgr).SetupWithManager(mgr, true)
+	err = NewInferenceGraphReconciler(mgr).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
when introduced PR https://github.com/opendatahub-io/odh-model-controller/pull/345 , an old logic to dynamically add Owns on AuthConfig is removed.
with latest official build, on a cluster without Authorino previously installed, Raw mode wont work , pod keep restart with inferencegraph controller not ready


## Description
<!--- Describe your changes in detail -->
ref: https://issues.redhat.com/browse/RHOAIENG-20304

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build: quay.io/wenzhou/odh-model-controller:20239

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
