### PR TITLE
Add an image to params.env for init container for ray-tls-generator

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -4,6 +4,7 @@ caikit-standalone-image=quay.io/opendatahub/caikit-nlp:fast
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2024.5-release
 vllm-image=quay.io/opendatahub/vllm:fast
+ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest
 nim-state=managed
 kserve-state=managed
 modelmeshserving-state=managed

--- a/internal/controller/serving/testdata/configmaps/odh-model-controller-parameters.yaml
+++ b/internal/controller/serving/testdata/configmaps/odh-model-controller-parameters.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+data:
+  caikit-standalone-image: quay.io/opendatahub/caikit-nlp:fast
+  caikit-tgis-image: quay.io/opendatahub/caikit-tgis-serving:fast
+  kserve-state: managed
+  modelmeshserving-state: managed
+  nim-state: managed
+  odh-model-controller: quay.io/opendatahub/odh-model-controller:fast
+  ovms-image: quay.io/opendatahub/openvino_model_server:2024.5-release
+  tgis-image: quay.io/opendatahub/text-generation-inference:fast
+  vllm-gaudi-image: quay.io/opendatahub/vllm:fast-gaudi
+  vllm-image: quay.io/opendatahub/vllm:fast
+  vllm-rocm-image: quay.io/opendatahub/vllm:fast-rocm
+  ray-tls-generator-image: registry.redhat.io/ubi8/ubi-minimal:latest
+kind: ConfigMap
+metadata:
+  name: odh-model-controller-parameters
+  namespace: default

--- a/internal/webhook/core/v1/pod_webhook_test.go
+++ b/internal/webhook/core/v1/pod_webhook_test.go
@@ -20,15 +20,18 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
-
+	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+const paramsEnvPath1 = "../../../controller/serving/testdata/configmaps/odh-model-controller-parameters.yaml"
 
 var _ = Describe("Pod Mutator Webhook", func() {
 	var defaulter PodMutatorDefaultor
 	var multinodePod *corev1.Pod
 	BeforeEach(func() {
-		defaulter = PodMutatorDefaultor{}
+		defaulter = PodMutatorDefaultor{client: k8sClient}
 
 		multinodePod = &corev1.Pod{
 			Spec: corev1.PodSpec{
@@ -41,6 +44,12 @@ var _ = Describe("Pod Mutator Webhook", func() {
 					},
 				},
 			},
+		}
+
+		paramsConfigMap := &corev1.ConfigMap{}
+		Expect(testutils.ConvertToStructuredResource(paramsEnvPath1, paramsConfigMap)).To(Succeed())
+		if err := k8sClient.Create(ctx, paramsConfigMap); err != nil && !k8sErrors.IsAlreadyExists(err) {
+			Fail(err.Error())
 		}
 	})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
this fix: [RHOAIENG-19880](https://issues.redhat.com//browse/RHOAIENG-19880)

This is a follow-up PR to [this discussion](https://github.com/opendatahub-io/odh-model-controller/pull/346#discussion_r1949861829). Instead of introducing a new feature, it modifies the existing logic by replacing the hard-coded image with a value from params.env. The mutating webhook, which adds an init-container, now retrieves the image from the params.env ConfigMap. The unit tests have also been updated accordingly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Full test:
- deploy multi-node usecase. it expects no issues

unit test:
- make test

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
