### PR TITLE
fix: legally blocked content should not break NIM integration

### DIFF
--- a/hack/verify_nvidia_nim_api.go
+++ b/hack/verify_nvidia_nim_api.go
@@ -67,7 +67,7 @@ func main() {
 		}
 	}
 
-	if vErr := utils.ValidateApiKey(logger, apiKey, runtimes[0]); vErr != nil {
+	if vErr := utils.ValidateApiKey(logger, apiKey, runtimes); vErr != nil {
 		panic(vErr)
 	}
 	fmt.Println("API Key validated successfully")

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -217,7 +217,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, runtimesOk))
 
 	// validate api key
-	if err := utils.ValidateApiKey(logger, apiKeyStr, availableRuntimes[0]); err != nil {
+	if err := utils.ValidateApiKey(logger, apiKeyStr, availableRuntimes); err != nil {
 		msg := "api key failed validation"
 		logger.Error(err, msg)
 		meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, msg))

--- a/internal/controller/nim/account_controller_test.go
+++ b/internal/controller/nim/account_controller_test.go
@@ -80,7 +80,7 @@ var _ = Describe("NIM Account Controller Test Cases", func() {
 		Expect(pullSecretSubject.Name).To(HavePrefix(account.Name + "-"))
 		Expect(pullSecret.OwnerReferences[0]).To(Equal(expectedOwner))
 
-		By("Verify models info")
+		By("Verify only two models (the nemotron model fetch is not stubbed)")
 		Expect(dataCmap.Data).To(HaveLen(2))
 
 		By("Cleanups")

--- a/internal/controller/nim/testdata/ngc_catalog_response_page_0.json
+++ b/internal/controller/nim/testdata/ngc_catalog_response_page_0.json
@@ -1,5 +1,5 @@
 {
-  "resultTotal": 2,
+  "resultTotal": 3,
   "resultPageTotal": 2,
   "params": {
     "orderBy": [
@@ -17,7 +17,7 @@
       "description"
     ],
     "scoredSize": 1,
-    "pageSize": 1,
+    "pageSize": 2,
     "fields": [
       "weight_popular",
       "ace_name",
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "totalCount": 2,
+      "totalCount": 3,
       "groupValue": "CONTAINER",
       "resources": [
         {
@@ -229,6 +229,88 @@
             {
               "key": "logo",
               "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        },
+        {
+          "orgName": "nim",
+          "resourceId": "nim/nvidia/nemotron-4-340b-instruct",
+          "labels": [
+            {
+              "values": [
+                "NVIDIA AI Enterprise Supported",
+                "NIM",
+                "NSPECT-0BKP-31SV",
+                "Nemotron-4-340B-Instruct",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nim-dev",
+                "nv-ai-enterprise"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/nvidia"
+          ],
+          "teamName": "nvidia",
+          "msgTimestamp": 1724956384091,
+          "dateModified": "2024-08-29T18:33:02.979Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU accelerated Nemotron-4-340B-Instruct inference through OpenAI compatible APIs",
+          "accessType": "LISTED",
+          "dateCreated": "2024-08-28T22:50:58.702Z",
+          "weightPopular": 3275.6,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "nemotron-4-340b-instruct",
+          "name": "nemotron-4-340b-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.1.2"
+            },
+            {
+              "key": "size",
+              "value": "6729257602"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-08-29T18:32:52.864Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/nemotron-4-340b-instruct.jpg"
             }
           ]
         }

--- a/internal/controller/nim/testdata/ngc_catalog_response_page_1.json
+++ b/internal/controller/nim/testdata/ngc_catalog_response_page_1.json
@@ -1,5 +1,5 @@
 {
-  "resultTotal": 2,
+  "resultTotal": 3,
   "resultPageTotal": 2,
   "params": {
     "orderBy": [

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -119,18 +119,27 @@ func GetAvailableNimRuntimes(logger logr.Logger) ([]NimRuntime, error) {
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime
-func ValidateApiKey(logger logr.Logger, apiKey string, runtime NimRuntime) error {
-	tokenResp, tokenErr := getRuntimeRegistryToken(logger, apiKey, runtime.Resource)
-	if tokenErr != nil {
-		return tokenErr
-	}
+func ValidateApiKey(logger logr.Logger, apiKey string, runtimes []NimRuntime) error {
+	for _, runtime := range runtimes {
+		tokenResp, tokenErr := getRuntimeRegistryToken(logger, apiKey, runtime.Resource)
+		if tokenErr != nil {
+			return tokenErr
+		}
 
-	manifestErr := attemptToPullManifest(logger, runtime, tokenResp)
-	if manifestErr != nil {
-		return manifestErr
-	}
+		manifestResp, manifestErr := attemptToPullManifest(logger, runtime, tokenResp)
+		if manifestErr != nil {
+			return manifestErr
+		}
 
-	return nil
+		switch manifestResp.StatusCode {
+		case http.StatusUnavailableForLegalReasons:
+			continue
+		case http.StatusOK:
+			return nil
+		}
+		break
+	}
+	return fmt.Errorf("failed to validate api key")
 }
 
 // GetNimModelData is used for fetching the model info for the given runtimes, returns configmap data
@@ -141,20 +150,15 @@ func GetNimModelData(logger logr.Logger, apiKey string, runtimes []NimRuntime) (
 		return data, tokenErr
 	}
 
-	var modelErr error
 	for _, runtime := range runtimes {
-		model, unmarshaled, err := getModelData(logger, runtime, tokenResp)
-		if err != nil {
-			modelErr = err
-			break
+		if model, unmarshaled, err := getModelData(logger, runtime, tokenResp); err == nil {
+			data[model.Name] = unmarshaled
 		}
-		data[model.Name] = unmarshaled
 	}
 
-	if modelErr != nil {
-		return nil, modelErr
+	if len(data) < 1 {
+		return nil, fmt.Errorf("no models found")
 	}
-
 	return data, nil
 }
 
@@ -172,11 +176,10 @@ func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize in
 
 	req.URL.RawQuery = query.Encode()
 
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return runtimes, respErr
 	}
-	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -194,22 +197,6 @@ func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize in
 	}
 
 	return runtimes, nil
-}
-
-func logApiResponse(logger logr.Logger, req *http.Request, resp *http.Response) {
-	logger.V(1).Info(fmt.Sprintf("sending api request %s", req.URL))
-
-	logger.V(1).Info(fmt.Sprintf("got api response %s", resp.Status))
-	if resp.StatusCode != http.StatusOK {
-		if resp.ContentLength > 0 {
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				logger.V(1).Error(err, "failed to parse body")
-			} else {
-				logger.V(1).Info(fmt.Sprintf("got body %s", string(body)))
-			}
-		}
-	}
 }
 
 // mapNimCatalogResponseToRuntimeList is used for parsing the ngc catalog response to a list of available runtimes
@@ -265,11 +252,10 @@ func getNgcToken(logger logr.Logger, apiKey string) (*NimTokenResponse, error) {
 
 // requestToken is used for sending a token requests and parse the response
 func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, error) {
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return nil, respErr
 	}
-	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -285,54 +271,78 @@ func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, err
 }
 
 // attemptToPullManifest is used for pulling a runtime for verifying access
-func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) error {
+func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*http.Response, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetRuntimeManifestFmt, runtime.Resource, runtime.Version), nil)
 	if reqErr != nil {
-		return reqErr
+		logger.Error(reqErr, "failed to construct request")
+		return nil, reqErr
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
 	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
-	resp, respErr := NimHttpClient.Do(req)
-	if respErr != nil {
-		return respErr
-	}
-	logApiResponse(logger, req, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to pull manifest")
-	}
-
-	return nil
+	return handleRequest(logger, req)
 }
 
 // getModelData is used for fetching NIM model data for the given runtime
 func getModelData(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, string, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetNgcModelDataFmt, runtime.Org, runtime.Team, runtime.Image), nil)
 	if reqErr != nil {
+		logger.Error(reqErr, "failed to construct request")
 		return nil, "", reqErr
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
 
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return nil, "", respErr
 	}
-	logApiResponse(logger, req, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		sErr := fmt.Errorf("got response %s", resp.Status)
+		if resp.StatusCode == http.StatusUnavailableForLegalReasons {
+			logger.Info("content not available for legal reasons")
+		} else {
+			logger.Error(sErr, "unexpected response status code")
+		}
+		return nil, "", sErr
+	}
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
+		logger.Error(bodyErr, "failed to read response body")
 		return nil, "", bodyErr
 	}
 
 	model := &NimModel{}
 	if err := json.Unmarshal(body, model); err != nil {
+		logger.Error(err, "failed to deserialize body")
 		return nil, "", err
 	}
-
 	return model, string(body), nil
+}
+
+func handleRequest(logger logr.Logger, req *http.Request) (*http.Response, error) {
+	logger.V(1).Info(fmt.Sprintf("sending api request %s", req.URL))
+
+	resp, doErr := NimHttpClient.Do(req)
+	if doErr != nil {
+		logger.Error(doErr, "failed to send request")
+		return nil, doErr
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.ContentLength > 0 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.V(1).Error(err, "failed to parse body")
+			} else {
+				logger.V(1).Info(fmt.Sprintf("got body %s", string(body)))
+			}
+		}
+	}
+	return resp, nil
 }
 
 // GetNimServingRuntimeTemplate returns the Template used by ODH for creating serving runtimes

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -274,7 +274,6 @@ func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, err
 func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*http.Response, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetRuntimeManifestFmt, runtime.Resource, runtime.Version), nil)
 	if reqErr != nil {
-		logger.Error(reqErr, "failed to construct request")
 		return nil, reqErr
 	}
 

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -331,6 +331,7 @@ func handleRequest(logger logr.Logger, req *http.Request) (*http.Response, error
 		return nil, doErr
 	}
 
+	logger.V(1).Info(fmt.Sprintf("got api response %s", resp.Status))
 	if resp.StatusCode != http.StatusOK {
 		if resp.ContentLength > 0 {
 			body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In clusters deployed in the EU, we noticed some models are considered blocked content and will return a 451 response code.
In this PR, we:
- Modified the API validation process to try with another image when hit with 451.
- Modified the metadata scraping process to exclude failing models instead of breaking the process.

Jira: https://issues.redhat.com/browse/NVPE-193

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a third model to the stub for runtime images. Tests assert that only two models exist without failing.
- Created an intermediate image and tested it in an EU cluster, `quay.io/tomerfi/odh-model-controller:fix-eu`. After deploying, verify the integration is enabled successfully by examining the Account status. This image was tested simultaneously in an EU and US cluster, making sure it works.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
