### PR TITLE
chore: nim setup should use the setup logger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -167,7 +168,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	signalHandlerCtx := ctrl.SetupSignalHandler()
+	signalHandlerCtx := log.IntoContext(ctrl.SetupSignalHandler(), setupLog)
 	setupNim(mgr, signalHandlerCtx, kubeClient)
 
 	setupLog.Info("starting manager")

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -70,9 +70,7 @@ var (
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;list;watch;create;update;delete
 
 func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
-	// TODO: Copied from original main.go... Should it be FromContext?
-	logger := ctrl.Log.WithName("controllers").WithName("AccountControllerSetup")
-	log.IntoContext(ctx, logger)
+	logger := log.FromContext(ctx, "Setup", "Account Controller")
 
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1.Account{}, apiKeySpecPath, func(obj client.Object) []string {
 		return []string{obj.(*v1.Account).Spec.APIKeySecret.Name}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Account Controller's setup is using its own logger instead of the one created for setting up.
This PR's saves the logger into the context being passed to the Controller's setup function which extracts the logger from the context.

Original discussion:  https://github.com/opendatahub-io/odh-model-controller/pull/383#discussion_r1982209033
Jira: https://issues.redhat.com/browse/NVPE-188

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Executed tests and ran linting.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
