### PR TITLE
fix: TGIS image removal not completely done

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -18,17 +18,6 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
-      fieldPath: data.tgis-image
-    targets:
-      - select:
-          kind: Template
-          name: caikit-tgis-serving-template
-        fieldPaths:
-          - objects.0.spec.containers.0.image
-  - source:
-      kind: ConfigMap
-      version: v1
-      name: odh-model-controller-parameters
       fieldPath: data.caikit-tgis-image
     targets:
       - select:

--- a/internal/controller/serving/testdata/configmaps/odh-model-controller-parameters.yaml
+++ b/internal/controller/serving/testdata/configmaps/odh-model-controller-parameters.yaml
@@ -7,7 +7,6 @@ data:
   nim-state: managed
   odh-model-controller: quay.io/opendatahub/odh-model-controller:fast
   ovms-image: quay.io/opendatahub/openvino_model_server:2024.5-release
-  tgis-image: quay.io/opendatahub/text-generation-inference:fast
   vllm-gaudi-image: quay.io/opendatahub/vllm:fast-gaudi
   vllm-cuda-image: quay.io/opendatahub/vllm:fast
   vllm-rocm-image: quay.io/opendatahub/vllm:fast-rocm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
follow up https://github.com/opendatahub-io/odh-model-controller/pull/399
error seen:
`Error: fieldPath `data.tgis-image` is missing for replacement source ConfigMap.v1.[noGrp]/odh-model-controller-parameters.[noNs]`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
