### PR TITLE
correct tgis deprecation changes

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -18,6 +18,17 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.tgis-image
+    targets:
+      - select:
+          kind: Template
+          name: caikit-tgis-serving-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.caikit-tgis-image
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,6 +1,7 @@
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
 caikit-tgis-image=quay.io/opendatahub/caikit-tgis-serving:fast
 caikit-standalone-image=quay.io/opendatahub/caikit-nlp:fast
+tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2024.5-release
 vllm-cuda-image=quay.io/opendatahub/vllm:fast
 ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Correction to TGIS deprecation
## Description
<!--- Describe your changes in detail -->
Initially we removed TGIS templates and references to it (see [PR](https://github.com/opendatahub-io/odh-model-controller/pull/399)). However, we accidentally removed references to TGIS image. TGIS image still gets referenced in Caikit-TGIS image, which we still support.
Additionally the TGIS reference replacements in Caikit-TGIS template were removed by mistake as well ([PR](https://github.com/opendatahub-io/odh-model-controller/pull/401)).
So this PR addresses both and resolves the TGIS deprecation in ODH. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
