### PR TITLE
fix: nim integration tries to deserialize empty bodies

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -181,6 +182,10 @@ func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize in
 		return runtimes, respErr
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return runtimes, errors.New(resp.Status)
+	}
+
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
 		return runtimes, bodyErr
@@ -255,6 +260,10 @@ func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, err
 	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return nil, respErr
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(resp.Status)
 	}
 
 	body, bodyErr := io.ReadAll(resp.Body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

NIM Integration is trying to deserialize bodies of failed requests, usually empty bodies. This casues a json error to hide the actual error. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
