### PR TITLE
Restore code removed by mistake

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -43,7 +44,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/go-logr/logr"
 	corecontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/core"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/nim"
 	servingcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving"
@@ -370,7 +370,7 @@ func setupInferenceServiceReconciler(mgr ctrl.Manager, kubeClient kubernetes.Int
 		enableMRInferenceServiceReconcile,
 		getEnvAsBool("MR_SKIP_TLS_VERIFY", false),
 		cfg.BearerToken,
-	)).SetupWithManager(mgr)
+	)).SetupWithManager(mgr, setupLog)
 }
 
 func setupSecretReconciler(mgr ctrl.Manager) error {

--- a/internal/controller/serving/suite_test.go
+++ b/internal/controller/serving/suite_test.go
@@ -168,7 +168,7 @@ var _ = BeforeSuite(func() {
 		true,
 		false,
 		"",
-	).SetupWithManager(mgr)
+	).SetupWithManager(mgr, ctrl.Log.WithName("setup"))
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&ServingRuntimeReconciler{


### PR DESCRIPTION
## Description
The restored code lets InferenceService controller to watch for any changes in AuthConfig resources and do any healing, if needed.

Fixes: https://issues.redhat.com/browse/RHOAIENG-20356

## How Has This Been Tested?
Having KServe setup with Service Mesh and Authorino:
* Deploy a model. It doesn't matter if the model is protected with auth or not.
  * Notice that an `AuthConfig` resource is created.
* Manually delete the `AuthConfig` resource
* Check that the `AuthConfig` resource is re-created.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
