### PR TITLE
[Cherry-pick] Add volume to servingRuntime template (#416)

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -426,6 +426,10 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 								MountPath: "/mnt/models/cache",
 								Name:      "nim-pvc",
 							},
+							{
+								MountPath: "/opt/nim/workspace",
+								Name:      "nim-workspace",
+							},
 						},
 					},
 				},
@@ -441,6 +445,12 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 								ClaimName: "nim-pvc",
 							},
+						},
+					},
+					{
+						Name: "nim-workspace",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
 				},


### PR DESCRIPTION
###  Summary
Cherry pick from incubating

Cherry-picks: https://github.com/opendatahub-io/odh-model-controller/pull/416

This PR adds a writable volume mount at `/opt/nim/workspace` to the `ServingRuntime` template to address model compatibility issues in NIM deployments.

### Motivation

Certain NVIDIA NIM models require `/opt/nim/workspace` to be a writable directory. Without this, the model initialization fails due to permission errors. This change introduces an `emptyDir` volume to meet that requirement.

### Jira

- Resolves [NVPE-205](https://issues.redhat.com/browse/NVPE-205)

### ✅ Changes

- Added `emptyDir` volume named `nim-workspace`
- Mounted the volume to `/opt/nim/workspace` in the container spec

### Notes

- This change ensures compatibility across NIM models expecting a writable workspace path.
- Tested with known failing model configurations to validate resolution.