### PR TITLE
fix(make): ensures tools are always in the correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,12 +215,19 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
-# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
-# $1 - target path with name of binary
-# $2 - package url which can be installed
-# $3 - specific version of package
+# Macro `go-install-tool` installs a specific version of a Go package and ensures that
+# invoking the binary at the given path uses that version.
+#
+# Usage:
+#   $(call go-install-tool,<binary-path>,<pkg-url>,<version>)
+#
+# Arguments:
+#   $1 — binary-path: full path (including binary name) where the tool will be placed
+#   $2 — pkg-url: Go binary path (e.g. github.com/user/tool/cmd/binary)
+#   $3 — version: exact module version (e.g. v1.2.3)
 define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
+@rm -f $(1); \
+[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\


### PR DESCRIPTION
## Description

Previously, once a tool (like `kustomize` or `controller-gen`) was downloaded, even if the version defined in `Makefile` changed, the old tool would be used if present in `LOCALBIN`.

If the outdated tool modifies code incorrectly, this could lead to unnecessary noise (and even bugs or errors) in PRs.

### Steps to reproduce

1. `rm -rf ./bin`
1. `git checkout 5db4925` (that's from when my `LOCALBIN` was ;))
1. `make`
1. `git checkout -`
1. `make`

<details>
<summary>Errors when having outdated tooling</summary>

```sh
✦ ❯ make
# Any customization needed, apply to a patch in the kustomize.yaml file on webhooks
/home/bartek/code/rhods/model-serving/odh-model-controller/bin/controller-gen rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/bartek/.gvm/pkgsets/go1.22/global/pkg/mod/k8s.io/api@v0.31.1/core/v1/doc.go:21:1: missing argument "" (at <input>)
/home/bartek/.gvm/pkgsets/go1.22/global/pkg/mod/k8s.io/api@v0.31.1/core/v1/doc.go:21:1: missing argument "" (at <input>)
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
k8s.io/api/core/v1:-: unknown type "k8s.io/api/core/v1".ObjectReference
github.com/opendatahub-io/odh-model-controller/api/nim/v1:-: unable to locate schema for type "k8s.io/api/core/v1".ObjectReference
github.com/opendatahub-io/odh-model-controller/api/nim/v1:-: unable to locate schema for type "k8s.io/api/core/v1".ObjectReference
github.com/opendatahub-io/odh-model-controller/api/nim/v1:-: unable to locate schema for type "k8s.io/api/core/v1".ObjectReference
github.com/opendatahub-io/odh-model-controller/api/nim/v1:-: unable to locate schema for type "k8s.io/api/core/v1".ObjectReference
github.com/opendatahub-io/odh-model-controller/api/nim/v1:-: unable to locate schema for type "k8s.io/api/core/v1".ObjectReference
Error: not all generators ran successfully
run `controller-gen rbac:roleName=odh-model-controller-role,headerFile=hack/manifests_boilerplate.yaml.txt crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen rbac:roleName=odh-model-controller-role,headerFile=hack/manifests_boilerplate.yaml.txt crd webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [Makefile:50: manifests] Error 1
```

</details>

With this PR, we always remove the symlink first to recreate it at the end. Therefore, it is always pointing to the desired version, regardless of whether the actual `go install` needs to be invoked.

## How Has This Been Tested?

See "Steps to reproduce" in the section above

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
