### PR TITLE
fix: model selection should update the account status for failurs

### DIFF
--- a/internal/controller/nim/handlers/configmap_handler.go
+++ b/internal/controller/nim/handlers/configmap_handler.go
@@ -55,9 +55,9 @@ func (c *ConfigMapHandler) Handle(ctx context.Context, account *v1.Account) Hand
 	}
 
 	// fetch available runtimes
-	availableRuntimes, runtimesErr := utils.GetAvailableNimRuntimes(logger)
+	availableRuntimes, runtimesErr := getRuntimes(ctx, c.Client, account)
 	if runtimesErr != nil {
-		msg := "failed to fetch NIM available custom runtimes"
+		msg := "failed to fetch NIM runtimes"
 
 		failedStatus := account.Status
 		failedStatus.LastAccountCheck = &metav1.Time{Time: time.Now()}
@@ -70,14 +70,7 @@ func (c *ConfigMapHandler) Handle(ctx context.Context, account *v1.Account) Hand
 		}
 		return HandleResponse{Error: runtimesErr}
 	}
-
-	// check the selected models
-	if selectedModelList, err := utils.GetSelectedModelList(ctx, account.Spec.ModelListConfig, account.Namespace, c.Client, logger); err != nil {
-		logger.V(1).Error(err, "failed to get the selected model list")
-		return HandleResponse{Error: err}
-	} else {
-		availableRuntimes = utils.FilterAvailableNimRuntimes(availableRuntimes, selectedModelList, logger)
-	}
+	logger.V(1).Info("got NIM runtimes")
 
 	var applyCfg *ssacorev1.ConfigMapApplyConfiguration
 	var ref *corev1.ObjectReference

--- a/internal/controller/nim/handlers/handlers.go
+++ b/internal/controller/nim/handlers/handlers.go
@@ -18,14 +18,22 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ssametav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
@@ -103,4 +111,93 @@ func mergeStringMaps(baseMap, existing map[string]string) (bool, map[string]stri
 // shouldUpdateReference will true if an update to the object reference is required
 func shouldUpdateReference(origRef, newRef *corev1.ObjectReference) bool {
 	return origRef == nil || newRef == nil || !utils.NimEqualities.DeepEqual(origRef.UID, newRef.UID)
+}
+
+// getRuntimes will fetch the available runtimes from NVIDIA, the list of selected models from the cluster, and return a
+// filtered list of runtimes.
+func getRuntimes(ctx context.Context, clt client.Client, account *v1.Account) ([]utils.NimRuntime, error) {
+	logger := log.FromContext(ctx)
+	availableRuntimes, runtimesErr := utils.GetAvailableNimRuntimes(logger)
+	if runtimesErr != nil {
+		return nil, runtimesErr
+	}
+
+	selectedList, selectedErr := getSelectedModelList(ctx, clt, account)
+	if selectedErr != nil {
+		return nil, selectedErr
+	}
+
+	return filterAvailableNimRuntimes(availableRuntimes, selectedList, logger), nil
+}
+
+// getSelectedModelList returns a list of Ids of the selected models
+func getSelectedModelList(ctx context.Context, clt client.Client, account *v1.Account) ([]string, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("getting selected model list")
+
+	// if selected model list is not set
+	if account.Spec.ModelListConfig == nil || len(account.Spec.ModelListConfig.Name) == 0 {
+		return []string{}, nil
+	}
+
+	// get the config map that contains the selected model list
+	cmNs := account.Spec.ModelListConfig.Namespace
+	if cmNs == "" {
+		cmNs = account.Namespace
+	}
+	modelListCm := &corev1.ConfigMap{}
+	modelListCmSubject := types.NamespacedName{Name: account.Spec.ModelListConfig.Name, Namespace: cmNs}
+	if err := clt.Get(ctx, modelListCmSubject, modelListCm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Error(err, "failed to fetch the config map for getting the selected model list",
+				"config map", modelListCmSubject)
+			return []string{}, nil
+		}
+		return nil, err
+	}
+
+	// convert the selected model list to a string array
+	if modelListCm.Data != nil {
+		if models, ok := modelListCm.Data["models"]; ok {
+			var selectedModelIds []string
+			if err := json.Unmarshal([]byte(models), &selectedModelIds); err != nil {
+				logger.Error(err, "failed to unmarshal the selected mode list",
+					"model list", models)
+				return []string{}, nil
+			}
+			return selectedModelIds, nil
+		}
+	}
+
+	logger.Error(nil, "failed to get the selected model list from the data of the config map",
+		"config map", modelListCmSubject)
+	return []string{}, nil
+}
+
+// filterAvailableNimRuntimes is used for filtering a list of available NIM custom runtimes by a list of model Ids
+func filterAvailableNimRuntimes(availableRuntimes []utils.NimRuntime, selectedModelList []string, logger logr.Logger) []utils.NimRuntime {
+	// log the available model Ids
+	var size = len(availableRuntimes)
+	modelIds := make([]string, size)
+	for i := 0; i < size; i++ {
+		modelIds[i] = availableRuntimes[i].Name
+	}
+	logger.V(1).Info("fetched the available NIM models",
+		"model Ids", json.RawMessage(`["`+strings.Join(modelIds, `", "`)+`"]`))
+
+	// check the selected models
+	if len(selectedModelList) > 0 {
+		logger.V(1).Info("got the selected NIM model list",
+			"model Ids", json.RawMessage(`["`+strings.Join(selectedModelList, `", "`)+`"]`))
+		// filter the available runtimes
+		var selectedRuntimes []utils.NimRuntime
+		for _, r := range availableRuntimes {
+			if slices.Contains(selectedModelList, r.Name) {
+				selectedRuntimes = append(selectedRuntimes, r)
+			}
+		}
+		return selectedRuntimes
+	}
+
+	return availableRuntimes
 }

--- a/internal/controller/nim/handlers/validation_handler.go
+++ b/internal/controller/nim/handlers/validation_handler.go
@@ -79,9 +79,9 @@ func (v *ValidationHandler) Handle(ctx context.Context, account *v1.Account) Han
 		}
 
 		// fetch available runtimes
-		availableRuntimes, runtimesErr := utils.GetAvailableNimRuntimes(logger)
+		availableRuntimes, runtimesErr := getRuntimes(ctx, v.Client, account)
 		if runtimesErr != nil {
-			msg := "failed to fetch NIM available runtimes"
+			msg := "failed to fetch NIM runtimes"
 
 			failedStatus := account.Status
 			failedStatus.LastAccountCheck = &metav1.Time{Time: time.Now()}
@@ -94,16 +94,7 @@ func (v *ValidationHandler) Handle(ctx context.Context, account *v1.Account) Han
 			}
 			return HandleResponse{Error: runtimesErr}
 		}
-
-		logger.V(1).Info("got available runtimes")
-
-		// check the selected models
-		if selectedModelList, err := utils.GetSelectedModelList(ctx, account.Spec.ModelListConfig, account.Namespace, v.Client, logger); err != nil {
-			logger.V(1).Error(err, "failed to get the selected model list")
-			return HandleResponse{Error: err}
-		} else {
-			availableRuntimes = utils.FilterAvailableNimRuntimes(availableRuntimes, selectedModelList, logger)
-		}
+		logger.V(1).Info("got NIM runtimes")
 
 		apiKeyStr, kmSErr := v.KeyManager.GetAPIKey(ctx, account)
 		if kmSErr != nil {

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
@@ -591,78 +590,4 @@ func (r *NIMCleanupRunner) Start(ctx context.Context) error {
 // ObjectKeyFromReference returns the ObjectKey given a ObjectReference
 func ObjectKeyFromReference(ref *corev1.ObjectReference) client.ObjectKey {
 	return types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}
-}
-
-// FilterAvailableNimRuntimes is used for filtering a list of available NIM custom runtimes by a list of model Ids
-func FilterAvailableNimRuntimes(availableRuntimes []NimRuntime, selectedModelList []string,
-	logger logr.Logger) []NimRuntime {
-	// log the available model Ids
-	var size = len(availableRuntimes)
-	modelIds := make([]string, size)
-	for i := 0; i < size; i++ {
-		modelIds[i] = availableRuntimes[i].Name
-	}
-	logger.V(1).Info("fetched the available NIM models",
-		"model Ids", json.RawMessage(`["`+strings.Join(modelIds, `", "`)+`"]`))
-
-	// check the selected models
-	if len(selectedModelList) > 0 {
-		logger.V(1).Info("got the selected NIM model list",
-			"model Ids", json.RawMessage(`["`+strings.Join(selectedModelList, `", "`)+`"]`))
-		// filter the available runtimes
-		var selectedRuntimes []NimRuntime
-		for _, r := range availableRuntimes {
-			if slices.Contains(selectedModelList, r.Name) {
-				selectedRuntimes = append(selectedRuntimes, r)
-			}
-		}
-		return selectedRuntimes
-	}
-
-	return availableRuntimes
-}
-
-// GetSelectedModelList returns a list of Ids of the selected models
-func GetSelectedModelList(
-	ctx context.Context, cmRef *corev1.ObjectReference,
-	namespace string, kubeClient client.Client, logger logr.Logger) ([]string, error) {
-	logger.V(1).Info("getting selected model list")
-
-	// if selected model list is not set
-	if cmRef == nil || len(cmRef.Name) == 0 {
-		return []string{}, nil
-	}
-
-	// get the config map that contains the selected model list
-	cmNs := cmRef.Namespace
-	if cmNs == "" {
-		cmNs = namespace
-	}
-	modelListCm := &corev1.ConfigMap{}
-	modelListCmSubject := types.NamespacedName{Name: cmRef.Name, Namespace: cmNs}
-	if err := kubeClient.Get(ctx, modelListCmSubject, modelListCm); err != nil {
-		if k8serrors.IsNotFound(err) {
-			logger.Error(err, "failed to fetch the config map for getting the selected model list",
-				"config map", modelListCmSubject)
-			return []string{}, nil
-		}
-		return nil, err
-	}
-
-	// convert the selected model list to a string array
-	if modelListCm.Data != nil {
-		if models, ok := modelListCm.Data["models"]; ok {
-			var selectedModelIds []string
-			if err := json.Unmarshal([]byte(models), &selectedModelIds); err != nil {
-				logger.Error(err, "failed to unmarshal the selected mode list",
-					"model list", models)
-				return []string{}, nil
-			}
-			return selectedModelIds, nil
-		}
-	}
-
-	logger.Error(nil, "failed to get the selected model list from the data of the config map",
-		"config map", modelListCmSubject)
-	return []string{}, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When fetching the available runtimes from NVIDIA, a failure is indicated in the Account's status. Filtering the selected models however, is not updating the Account's status. This PR addresses this.

Jira: [NVPE-282](https://issues.redhat.com/browse/NVPE-282).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a live cluster:
1. Enabled the integration succesfully.
2. Created a selection ConfigMap.
3. Update the Account with the referncing the ConfigMap.
4. Update the Account to spec ConfigMap refresh rate to 1 minute.
5. Added a force/skip validation annotation to the the API key Secret.
6. Verified the enabled modeld list was trimmed based on the seclected list.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
