### PR TITLE
Aggregate code coverage for `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" POD_NAMESPACE=default \
-		MESH_NAMESPACE=istio-system CONTROL_PLANE_NAME=istio-system go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+		MESH_NAMESPACE=istio-system CONTROL_PLANE_NAME=istio-system go test $$(go list ./... | grep -v /e2e) \
+		-coverprofile cover.out -coverpkg=./...
 
 # TODO(user): To use a different cluster than Kind for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Current tests in `internal/controller/serving` will not produce any coverage data for the package `internal/controller/serving/reconcilers` without aggreagation flag: `-coverpkg=./...`.

## How Has This Been Tested?
CI

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description: N/A
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work