### PR TITLE
RHOAIENG-25111: Add KEDA reconciler for raw deployment mode

### DIFF
--- a/config/crd/external/keda.sh_triggerauthentications.yaml
+++ b/config/crd/external/keda.sh_triggerauthentications.yaml
@@ -1,0 +1,578 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: triggerauthentications.keda.sh
+spec:
+  group: keda.sh
+  names:
+    kind: TriggerAuthentication
+    listKind: TriggerAuthenticationList
+    plural: triggerauthentications
+    shortNames:
+    - ta
+    - triggerauth
+    singular: triggerauthentication
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.podIdentity.provider
+      name: PodIdentity
+      type: string
+    - jsonPath: .spec.secretTargetRef[*].name
+      name: Secret
+      type: string
+    - jsonPath: .spec.env[*].name
+      name: Env
+      type: string
+    - jsonPath: .spec.hashiCorpVault.address
+      name: VaultAddress
+      type: string
+    - jsonPath: .status.scaledobjects
+      name: ScaledObjects
+      priority: 1
+      type: string
+    - jsonPath: .status.scaledjobs
+      name: ScaledJobs
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TriggerAuthentication defines how a trigger can authenticate
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TriggerAuthenticationSpec defines the various ways to authenticate
+            properties:
+              awsSecretManager:
+                description: AwsSecretManager is used to authenticate using AwsSecretManager
+                properties:
+                  credentials:
+                    properties:
+                      accessKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessSecretKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessToken:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - accessKey
+                    - accessSecretKey
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  region:
+                    type: string
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        secretKey:
+                          type: string
+                        versionId:
+                          type: string
+                        versionStage:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              azureKeyVault:
+                description: AzureKeyVault is used to authenticate using Azure Key
+                  Vault
+                properties:
+                  cloud:
+                    properties:
+                      activeDirectoryEndpoint:
+                        type: string
+                      keyVaultResourceURL:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  credentials:
+                    properties:
+                      clientId:
+                        type: string
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      tenantId:
+                        type: string
+                    required:
+                    - clientId
+                    - clientSecret
+                    - tenantId
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    type: array
+                  vaultUri:
+                    type: string
+                required:
+                - secrets
+                - vaultUri
+                type: object
+              boundServiceAccountToken:
+                items:
+                  properties:
+                    parameter:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                  required:
+                  - parameter
+                  - serviceAccountName
+                  type: object
+                type: array
+              configMapTargetRef:
+                items:
+                  description: AuthConfigMapTargetRef is used to authenticate using
+                    a reference to a config map
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              env:
+                items:
+                  description: |-
+                    AuthEnvironment is used to authenticate using environment variables
+                    in the destination ScaleTarget spec
+                  properties:
+                    containerName:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - name
+                  - parameter
+                  type: object
+                type: array
+              gcpSecretManager:
+                properties:
+                  credentials:
+                    properties:
+                      clientSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - clientSecret
+                    type: object
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                        parameter:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - id
+                      - parameter
+                      type: object
+                    type: array
+                required:
+                - secrets
+                type: object
+              hashiCorpVault:
+                description: HashiCorpVault is used to authenticate using Hashicorp
+                  Vault
+                properties:
+                  address:
+                    type: string
+                  authentication:
+                    description: VaultAuthentication contains the list of Hashicorp
+                      Vault authentication methods
+                    type: string
+                  credential:
+                    description: Credential defines the Hashicorp Vault credentials
+                      depending on the authentication method
+                    properties:
+                      serviceAccount:
+                        type: string
+                      token:
+                        type: string
+                    type: object
+                  mount:
+                    type: string
+                  namespace:
+                    type: string
+                  role:
+                    type: string
+                  secrets:
+                    items:
+                      description: VaultSecret defines the mapping between the path
+                        of the secret in Vault to the parameter
+                      properties:
+                        key:
+                          type: string
+                        parameter:
+                          type: string
+                        path:
+                          type: string
+                        pkiData:
+                          properties:
+                            altNames:
+                              type: string
+                            commonName:
+                              type: string
+                            format:
+                              type: string
+                            ipSans:
+                              type: string
+                            otherSans:
+                              type: string
+                            ttl:
+                              type: string
+                            uriSans:
+                              type: string
+                          type: object
+                        type:
+                          description: VaultSecretType defines the type of vault secret
+                          type: string
+                      required:
+                      - key
+                      - parameter
+                      - path
+                      type: object
+                    type: array
+                required:
+                - address
+                - authentication
+                - secrets
+                type: object
+              podIdentity:
+                description: |-
+                  AuthPodIdentity allows users to select the platform native identity
+                  mechanism
+                properties:
+                  identityAuthorityHost:
+                    description: Set identityAuthorityHost to override the default
+                      Azure authority host. If this is set, then the IdentityTenantID
+                      must also be set
+                    type: string
+                  identityId:
+                    type: string
+                  identityOwner:
+                    description: IdentityOwner configures which identity has to be
+                      used during auto discovery, keda or the scaled workload. Mutually
+                      exclusive with roleArn
+                    enum:
+                    - keda
+                    - workload
+                    type: string
+                  identityTenantId:
+                    description: Set identityTenantId to override the default Azure
+                      tenant id. If this is set, then the IdentityID must also be
+                      set
+                    type: string
+                  provider:
+                    description: PodIdentityProvider contains the list of providers
+                    enum:
+                    - azure-workload
+                    - gcp
+                    - aws
+                    - aws-eks
+                    - none
+                    type: string
+                  roleArn:
+                    description: RoleArn sets the AWS RoleArn to be used. Mutually
+                      exclusive with IdentityOwner
+                    type: string
+                required:
+                - provider
+                type: object
+              secretTargetRef:
+                items:
+                  description: AuthSecretTargetRef is used to authenticate using a
+                    reference to a secret
+                  properties:
+                    key:
+                      type: string
+                    name:
+                      type: string
+                    parameter:
+                      type: string
+                  required:
+                  - key
+                  - name
+                  - parameter
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TriggerAuthenticationStatus defines the observed state of
+              TriggerAuthentication
+            properties:
+              scaledjobs:
+                type: string
+              scaledobjects:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - keda.sh
+  resources:
+  - triggerauthentications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - maistra.io
   resources:
   - servicemeshcontrolplanes
@@ -105,6 +117,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - monitoring.coreos.com
@@ -183,8 +204,8 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - roles
   - rolebindings
+  - roles
   verbs:
   - create
   - delete
@@ -301,24 +322,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-    - keda.sh
-  resources:
-    - triggerauthentications
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - metrics.k8s.io
-  resources:
-    - pods
-    - nodes
-  verbs:
-    - get
-    - list
-    - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -183,6 +183,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  - roles
   - rolebindings
   verbs:
   - create
@@ -300,3 +301,24 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+    - keda.sh
+  resources:
+    - triggerauthentications
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - metrics.k8s.io
+  resources:
+    - pods
+    - nodes
+  verbs:
+    - get
+    - list
+    - watch

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/kedacore/keda/v2 v2.16.1
 	github.com/kserve/kserve v0.15.0
 	github.com/kuadrant/authorino v0.20.0
 	github.com/kubeflow/model-registry v0.2.14
@@ -25,6 +26,7 @@ require (
 	istio.io/client-go v1.24.2
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
+	k8s.io/apiserver v0.32.3
 	k8s.io/client-go v0.32.3
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	knative.dev/pkg v0.0.0-20250117084104-c43477f0052b
@@ -47,7 +49,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go v1.55.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -60,6 +62,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/expr-lang/expr v1.16.9 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -120,7 +123,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
@@ -145,7 +148,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.3 // indirect
-	k8s.io/apiserver v0.32.3 // indirect
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250304201544-e5f78fe3ede9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.1/go.mod h1:viRWSEhtMZqz1rhwmOVKkWl6SwmVowfL9O2YR5gI2PE=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
-github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -88,6 +88,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
+github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
+github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -206,6 +208,8 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/kedacore/keda/v2 v2.16.1 h1:LfYsxfSX8DjetLW8q9qnriImH936POrQJvE+caRoScI=
+github.com/kedacore/keda/v2 v2.16.1/go.mod h1:pO2ksUCwSOQ2u3OWqj+jh9Hgf0+26MZug6dF7WWgcAk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -332,8 +336,8 @@ go.opentelemetry.io/otel/sdk/metric v1.35.0 h1:1RriWBmCKgkeHEhM7a2uMjMUfP7MsOF5J
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
-go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
-go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
+go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1jgeg=
+go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -106,7 +106,7 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 // +kubebuilder:rbac:groups=maistra.io,resources=servicemeshcontrolplanes,verbs=get;list;watch;use
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=get;list;watch;create;update;patch;watch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;watch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
@@ -116,6 +116,8 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 // +kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=keda.sh,resources=triggerauthentications,verbs=get;list;watch;create;update;patch;watch;delete
+// +kubebuilder:rbac:groups=metrics.k8s.io,resources=pods;nodes,verbs=get;list;watch
 
 // Reconcile performs the reconciling of the Openshift objects for a Kubeflow
 // InferenceService.

--- a/internal/controller/serving/inferenceservice_controller_test.go
+++ b/internal/controller/serving/inferenceservice_controller_test.go
@@ -41,7 +41,6 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,7 +48,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	maistrav1 "maistra.io/api/core/v1"
@@ -58,6 +56,7 @@ import (
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/comparators"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	. "github.com/opendatahub-io/odh-model-controller/test/matchers"
 	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
@@ -1299,209 +1298,7 @@ var _ = Describe("InferenceService Controller", func() {
 		var (
 			testNs         string
 			kedaReconciler *reconcilers.KserveKEDAReconciler
-			ctx            context.Context
 		)
-
-		// makeKedaTestISVC creates an InferenceService for KEDA tests.
-		makeKedaTestISVC := func(namespace, name string, enableKedaMetrics bool) *kservev1beta1.InferenceService {
-			isvc := &kservev1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						"serving.kserve.io/deploymentMode": "RawDeployment",
-					},
-				},
-				Spec: kservev1beta1.InferenceServiceSpec{
-					Predictor: kservev1beta1.PredictorSpec{
-						// Model field is required for KServe, even if not directly used by KEDA logic
-						Model: &kservev1beta1.ModelSpec{
-							ModelFormat: kservev1beta1.ModelFormat{Name: "onnx"},
-							Runtime:     ptr.To("kserve-ovms"),
-							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
-								StorageURI: ptr.To("s3://modelmesh-example-models/onnx/mnist-8"),
-							},
-						},
-					},
-				},
-			}
-			if enableKedaMetrics {
-				isvc.Spec.Predictor.MinReplicas = ptr.To[int32](1)
-				isvc.Spec.Predictor.MaxReplicas = 5
-				isvc.Spec.Predictor.AutoScaling = &kservev1beta1.AutoScalingSpec{
-					Metrics: []kservev1beta1.MetricsSpec{
-						{
-							Type: kservev1beta1.ExternalMetricSourceType,
-							External: &kservev1beta1.ExternalMetricSource{
-								Metric: kservev1beta1.ExternalMetrics{
-									Backend:       kservev1beta1.PrometheusBackend,
-									ServerAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9092",
-									Query:         `sum(rate(http_requests_total{namespace="kserve-keda-prometheus", service="sample-app-service"}[1m]))`,
-								},
-								Target: kservev1beta1.MetricTarget{
-									Type:  kservev1beta1.AverageValueMetricType,
-									Value: ptr.To(resource.MustParse("2")),
-								},
-							},
-						},
-					},
-				}
-			} else {
-				// To disable KEDA metrics, we can remove AutoScaling
-				// This makes hasPrometheusExternalAutoscalingMetric return false
-				isvc.Spec.Predictor.AutoScaling = nil
-			}
-			return isvc
-		}
-
-		// createTestKedaSA creates a ServiceAccount for KEDA tests.
-		createTestKedaSA := func(currentCtx context.Context, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *corev1.ServiceAccount {
-			sa := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      reconcilers.KEDAPrometheusAuthResourceName,
-					Namespace: namespace,
-				},
-			}
-			if isvcOwner != nil {
-				sa.OwnerReferences = append(sa.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
-			}
-			if otherOwner != nil {
-				sa.OwnerReferences = append(sa.OwnerReferences, *otherOwner)
-			}
-			Expect(k8sClient.Create(currentCtx, sa)).Should(Succeed())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sa), sa)).Should(Succeed())
-			return sa
-		}
-
-		// createTestKedaSecret creates a Secret for KEDA tests.
-		createTestKedaSecret := func(currentCtx context.Context, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *corev1.Secret {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      reconcilers.KEDAPrometheusAuthTriggerSecretName,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						corev1.ServiceAccountNameKey: reconcilers.KEDAPrometheusAuthResourceName,
-					},
-				},
-				Type: corev1.SecretTypeServiceAccountToken,
-			}
-			if isvcOwner != nil {
-				secret.OwnerReferences = append(secret.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
-			}
-			if otherOwner != nil {
-				secret.OwnerReferences = append(secret.OwnerReferences, *otherOwner)
-			}
-			Expect(k8sClient.Create(currentCtx, secret)).Should(Succeed())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).Should(Succeed())
-			return secret
-		}
-
-		// createTestKedaRole creates a Role for KEDA tests.
-		createTestKedaRole := func(currentCtx context.Context, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *rbacv1.Role {
-			role := &rbacv1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      reconcilers.KEDAPrometheusAuthMetricsReaderRoleName,
-					Namespace: namespace,
-				},
-				Rules: []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}}, // Simplified rule
-			}
-			if isvcOwner != nil {
-				role.OwnerReferences = append(role.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
-			}
-			if otherOwner != nil {
-				role.OwnerReferences = append(role.OwnerReferences, *otherOwner)
-			}
-			Expect(k8sClient.Create(currentCtx, role)).Should(Succeed())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role), role)).Should(Succeed())
-			return role
-		}
-
-		// createTestKedaRoleBinding creates a RoleBinding for KEDA tests.
-		createTestKedaRoleBinding := func(currentCtx context.Context, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *rbacv1.RoleBinding {
-			rb := &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      reconcilers.KEDAPrometheusAuthMetricsReaderRoleBindingName,
-					Namespace: namespace,
-				},
-				Subjects: []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: reconcilers.KEDAPrometheusAuthResourceName, Namespace: namespace}},
-				RoleRef:  rbacv1.RoleRef{Kind: "Role", Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, APIGroup: rbacv1.GroupName},
-			}
-			if isvcOwner != nil {
-				rb.OwnerReferences = append(rb.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
-			}
-			if otherOwner != nil {
-				rb.OwnerReferences = append(rb.OwnerReferences, *otherOwner)
-			}
-			Expect(k8sClient.Create(currentCtx, rb)).Should(Succeed())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb), rb)).Should(Succeed())
-			return rb
-		}
-
-		// createTestKedaTA creates a TriggerAuthentication for KEDA tests.
-		createTestKedaTA := func(currentCtx context.Context, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *kedaapi.TriggerAuthentication {
-			ta := &kedaapi.TriggerAuthentication{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      reconcilers.KEDAPrometheusAuthTriggerAuthName,
-					Namespace: namespace,
-				},
-				Spec: kedaapi.TriggerAuthenticationSpec{
-					SecretTargetRef: []kedaapi.AuthSecretTargetRef{
-						{Parameter: "bearerToken", Name: reconcilers.KEDAPrometheusAuthTriggerSecretName, Key: "token"},
-					},
-				},
-			}
-			if isvcOwner != nil {
-				ta.OwnerReferences = append(ta.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
-			}
-			if otherOwner != nil {
-				ta.OwnerReferences = append(ta.OwnerReferences, *otherOwner)
-			}
-			Expect(k8sClient.Create(currentCtx, ta)).Should(Succeed())
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ta), ta)).Should(Succeed())
-			return ta
-		}
-
-		// hasOwnerReferenceByUID checks if an object has an owner reference with the given UID.
-		hasOwnerReferenceByUID := func(obj client.Object, ownerUID types.UID) bool {
-			if ownerUID == "" {
-				panic("Expected ownerUID to be non-empty")
-			}
-			if obj == nil {
-				panic("Expected non-nil obj, got nil")
-			}
-			for _, ref := range obj.GetOwnerReferences() {
-				if ref.UID == ownerUID {
-					return true
-				}
-			}
-			return false
-		}
-
-		// getAllKedaTestResources fetches all KEDA resources by their known names.
-		getAllKedaTestResources := func(currentCtx context.Context, namespace string) map[string]client.Object {
-			resources := make(map[string]client.Object)
-			sa := &corev1.ServiceAccount{}
-			if err := k8sClient.Get(currentCtx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthServiceAccountName, Namespace: namespace}, sa); err == nil {
-				resources["ServiceAccount"] = sa
-			}
-			secret := &corev1.Secret{}
-			if err := k8sClient.Get(currentCtx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerSecretName, Namespace: namespace}, secret); err == nil {
-				resources["Secret"] = secret
-			}
-			role := &rbacv1.Role{}
-			if err := k8sClient.Get(currentCtx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, Namespace: namespace}, role); err == nil {
-				resources["Role"] = role
-			}
-			rb := &rbacv1.RoleBinding{}
-			if err := k8sClient.Get(currentCtx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleBindingName, Namespace: namespace}, rb); err == nil {
-				resources["RoleBinding"] = rb
-			}
-			ta := &kedaapi.TriggerAuthentication{}
-			if err := k8sClient.Get(currentCtx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerAuthName, Namespace: namespace}, ta); err == nil {
-				resources["TriggerAuthentication"] = ta
-			}
-			return resources
-		}
 
 		BeforeEach(func() {
 			ctx = context.Background()
@@ -1534,25 +1331,15 @@ var _ = Describe("InferenceService Controller", func() {
 				Expect(isvc.ObjectMeta.UID).ToNot(BeEmpty())
 				Expect(isvc2.ObjectMeta.UID).ToNot(BeEmpty())
 
-				err := kedaReconciler.Reconcile(ctx, GinkgoLogr, isvc)
-				Expect(err).NotTo(HaveOccurred())
-				err = kedaReconciler.Reconcile(ctx, GinkgoLogr, isvc2)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(kedaReconciler.Reconcile(ctx, GinkgoLogr, isvc)).NotTo(HaveOccurred())
+				Expect(kedaReconciler.Reconcile(ctx, GinkgoLogr, isvc2)).NotTo(HaveOccurred())
 			})
 
 			It("Must have owner reference to InferenceService", func() {
-				for kind, obj := range getAllKedaTestResources(ctx, testNs) {
+				for _, obj := range getAllKedaTestResources(ctx, k8sClient, testNs) {
 					Expect(obj).To(Not(BeNil()), fmt.Sprintf("Obj: %#v", obj))
-					Expect(hasOwnerReferenceByUID(obj, isvc.UID)).To(BeTrue(), fmt.Sprintf(`
-%s should be owned by ISVC
-obj: %#v
-isvc: %#v
-`, kind, obj, isvc))
-					Expect(hasOwnerReferenceByUID(obj, isvc2.UID)).To(BeTrue(), fmt.Sprintf(`
-%s should be owned by ISVC
-obj: %#v
-isvc: %#v
-`, kind, obj, isvc2))
+					Expect(obj).To(HaveOwnerReferenceByUID(isvc.UID))
+					Expect(obj).To(HaveOwnerReferenceByUID(isvc2.UID))
 				}
 			})
 
@@ -1560,18 +1347,10 @@ isvc: %#v
 				Expect(k8sClient.Delete(ctx, isvc2)).Should(Succeed())
 				Expect(kedaReconciler.Delete(ctx, GinkgoLogr, isvc2)).To(Succeed())
 
-				for kind, obj := range getAllKedaTestResources(ctx, testNs) {
+				for _, obj := range getAllKedaTestResources(ctx, k8sClient, testNs) {
 					Expect(obj).To(Not(BeNil()), fmt.Sprintf("Obj: %#v", obj))
-					Expect(hasOwnerReferenceByUID(obj, isvc.UID)).To(BeTrue(), fmt.Sprintf(`
-%s should be owned by ISVC
-obj: %#v
-isvc: %#v
-`, kind, obj, isvc))
-					Expect(hasOwnerReferenceByUID(obj, isvc2.UID)).To(BeFalse(), fmt.Sprintf(`
-%s should not be owned by ISVC
-obj: %#v
-isvc: %#v
-`, kind, obj, isvc2))
+					Expect(obj).To(HaveOwnerReferenceByUID(isvc.UID))
+					Expect(obj).ToNot(HaveOwnerReferenceByUID(isvc2.UID))
 				}
 			})
 
@@ -1648,7 +1427,7 @@ isvc: %#v
 				Expect(kedaReconciler.Delete(ctx, GinkgoLogr, isvc)).To(Succeed())
 				Expect(kedaReconciler.Cleanup(ctx, GinkgoLogr, testNs)).To(Succeed())
 
-				Expect(getAllKedaTestResources(ctx, testNs)).To(BeEmpty())
+				Expect(getAllKedaTestResources(ctx, k8sClient, testNs)).To(BeEmpty())
 			})
 		})
 
@@ -1665,13 +1444,9 @@ isvc: %#v
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify initial ownership
-				for kind, obj := range getAllKedaTestResources(ctx, testNs) {
+				for _, obj := range getAllKedaTestResources(ctx, k8sClient, testNs) {
 					Expect(obj).To(Not(BeNil()), fmt.Sprintf("Obj: %#v", obj))
-					Expect(hasOwnerReferenceByUID(obj, isvc.UID)).To(BeTrue(), fmt.Sprintf(`
-%s should initially be owned by ISVC
-obj: %#v
-isvc: %#v
-`, kind, obj, isvc))
+					Expect(obj).To(HaveOwnerReferenceByUID(isvc.UID))
 				}
 
 				// Update ISVC to no longer require KEDA
@@ -1690,11 +1465,11 @@ isvc: %#v
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify owner reference is removed
-				for kind, obj := range getAllKedaTestResources(ctx, testNs) {
+				for _, obj := range getAllKedaTestResources(ctx, k8sClient, testNs) {
 					// Refetch the object to get its latest state
 					currentObj := obj.DeepCopyObject().(client.Object)
 					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(currentObj), currentObj)).Should(Succeed())
-					Expect(hasOwnerReferenceByUID(currentObj, isvc.UID)).To(BeFalse(), fmt.Sprintf("ISVC owner reference should be removed from %s", kind))
+					Expect(obj).ToNot(HaveOwnerReferenceByUID(isvc.UID))
 				}
 			})
 		})
@@ -1720,11 +1495,11 @@ isvc: %#v
 				}
 
 				// Create KEDA resources owned by ISVC1 and otherOwner
-				_ = createTestKedaSA(ctx, testNs, isvc1, otherOwnerRef)
-				_ = createTestKedaSecret(ctx, testNs, isvc1, otherOwnerRef)
-				_ = createTestKedaRole(ctx, testNs, isvc1, otherOwnerRef)
-				_ = createTestKedaRoleBinding(ctx, testNs, isvc1, otherOwnerRef)
-				_ = createTestKedaTA(ctx, testNs, isvc1, otherOwnerRef)
+				_ = createTestKedaSA(ctx, k8sClient, testNs, isvc1, otherOwnerRef)
+				_ = createTestKedaSecret(ctx, k8sClient, testNs, isvc1, otherOwnerRef)
+				_ = createTestKedaRole(ctx, k8sClient, testNs, isvc1, otherOwnerRef)
+				_ = createTestKedaRoleBinding(ctx, k8sClient, testNs, isvc1, otherOwnerRef)
+				_ = createTestKedaTA(ctx, k8sClient, testNs, isvc1, otherOwnerRef)
 
 				// Update ISVC1 to no longer require KEDA
 				latestIsvc1 := &kservev1beta1.InferenceService{}
@@ -1741,28 +1516,28 @@ isvc: %#v
 
 				sa := &corev1.ServiceAccount{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthResourceName, Namespace: testNs}, sa)).Should(Succeed())
-				Expect(hasOwnerReferenceByUID(sa, isvc1.UID)).To(BeFalse(), "ISVC1 owner ref should be removed from SA")
-				Expect(hasOwnerReferenceByUID(sa, otherOwnerRef.UID)).To(BeTrue(), "Other owner ref should be preserved on SA")
+				Expect(sa).ToNot(HaveOwnerReferenceByUID(isvc1.UID))
+				Expect(sa).To(HaveOwnerReferenceByUID(otherOwnerRef.UID))
 
 				secret := &corev1.Secret{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerSecretName, Namespace: testNs}, secret)).Should(Succeed())
-				Expect(hasOwnerReferenceByUID(secret, isvc1.UID)).To(BeFalse(), "ISVC1 owner ref should be removed from Secret")
-				Expect(hasOwnerReferenceByUID(secret, otherOwnerRef.UID)).To(BeTrue(), "Other owner ref should be preserved on Secret")
+				Expect(secret).ToNot(HaveOwnerReferenceByUID(isvc1.UID))
+				Expect(secret).To(HaveOwnerReferenceByUID(otherOwnerRef.UID))
 
 				ta := &kedaapi.TriggerAuthentication{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerAuthName, Namespace: testNs}, ta)).Should(Succeed())
-				Expect(hasOwnerReferenceByUID(ta, isvc1.UID)).To(BeFalse(), "ISVC1 owner ref should be removed from TriggerAuthentication")
-				Expect(hasOwnerReferenceByUID(ta, otherOwnerRef.UID)).To(BeTrue(), "Other owner ref should be preserved on TriggerAuthentication")
+				Expect(ta).ToNot(HaveOwnerReferenceByUID(isvc1.UID))
+				Expect(ta).To(HaveOwnerReferenceByUID(otherOwnerRef.UID))
 
 				role := &rbacv1.Role{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, Namespace: testNs}, role)).Should(Succeed())
-				Expect(hasOwnerReferenceByUID(ta, isvc1.UID)).To(BeFalse(), "ISVC1 owner ref should be removed from Role")
-				Expect(hasOwnerReferenceByUID(ta, otherOwnerRef.UID)).To(BeTrue(), "Other owner ref should be preserved on Role")
+				Expect(role).ToNot(HaveOwnerReferenceByUID(isvc1.UID))
+				Expect(role).To(HaveOwnerReferenceByUID(otherOwnerRef.UID))
 
 				roleBinding := &rbacv1.RoleBinding{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleBindingName, Namespace: testNs}, roleBinding)).Should(Succeed())
-				Expect(hasOwnerReferenceByUID(ta, isvc1.UID)).To(BeFalse(), "ISVC1 owner ref should be removed from RoleBinding")
-				Expect(hasOwnerReferenceByUID(ta, otherOwnerRef.UID)).To(BeTrue(), "Other owner ref should be preserved on RoleBinding")
+				Expect(roleBinding).ToNot(HaveOwnerReferenceByUID(isvc1.UID))
+				Expect(roleBinding).To(HaveOwnerReferenceByUID(otherOwnerRef.UID))
 			})
 		})
 
@@ -1818,7 +1593,7 @@ isvc: %#v
 				Expect(k8sClient.Create(ctx, isvc2)).Should(Succeed())
 
 				// Create SA but not owned by this ISVC
-				sa = createTestKedaSA(ctx, testNs, nil, nil) // No owners
+				sa = createTestKedaSA(ctx, k8sClient, testNs, nil, nil) // No owners
 			})
 
 			It("should complete without error and not modify the resource's owners", func() {
@@ -1841,7 +1616,7 @@ isvc: %#v
 				Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
 
 				// Create SA
-				sa = createTestKedaSA(ctx, testNs, nil, nil) // No owners
+				sa = createTestKedaSA(ctx, k8sClient, testNs, nil, nil) // No owners
 			})
 
 			It("should cleanup resources", func() {

--- a/internal/controller/serving/inferenceservice_controller_test.go
+++ b/internal/controller/serving/inferenceservice_controller_test.go
@@ -1301,12 +1301,7 @@ var _ = Describe("InferenceService Controller", func() {
 		)
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			testNamespace := testutils.Namespaces.Create(ctx, k8sClient)
-			testNs = testNamespace.Name
-			// Note: Add KEDA API to scheme if not already done in main test setup for the suite
-			// For example, in `suite_test.go`:
-			// Expect(kedaapi.AddToScheme(scheme.Scheme)).To(Succeed())
+			testNs = testutils.Namespaces.Create(ctx, k8sClient).Name
 			kedaReconciler = reconcilers.NewKServeKEDAReconciler(k8sClient)
 		})
 

--- a/internal/controller/serving/keda_fixtures_test.go
+++ b/internal/controller/serving/keda_fixtures_test.go
@@ -102,7 +102,7 @@ func createTestKedaSA(ctx context.Context, k8sClient client.Client, namespace st
 		},
 	}
 	if isvcOwner != nil {
-		sa.OwnerReferences = append(sa.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+		sa.OwnerReferences = append(sa.OwnerReferences, reconcilers.AsIsvcOwnerRef(isvcOwner))
 	}
 	if otherOwner != nil {
 		sa.OwnerReferences = append(sa.OwnerReferences, *otherOwner)
@@ -124,7 +124,7 @@ func createTestKedaSecret(ctx context.Context, k8sClient client.Client, namespac
 		Type: corev1.SecretTypeServiceAccountToken,
 	}
 	if isvcOwner != nil {
-		secret.OwnerReferences = append(secret.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+		secret.OwnerReferences = append(secret.OwnerReferences, reconcilers.AsIsvcOwnerRef(isvcOwner))
 	}
 	if otherOwner != nil {
 		secret.OwnerReferences = append(secret.OwnerReferences, *otherOwner)
@@ -143,7 +143,7 @@ func createTestKedaRole(ctx context.Context, k8sClient client.Client, namespace 
 		Rules: []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}}, // Simplified rule
 	}
 	if isvcOwner != nil {
-		role.OwnerReferences = append(role.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+		role.OwnerReferences = append(role.OwnerReferences, reconcilers.AsIsvcOwnerRef(isvcOwner))
 	}
 	if otherOwner != nil {
 		role.OwnerReferences = append(role.OwnerReferences, *otherOwner)
@@ -163,7 +163,7 @@ func createTestKedaRoleBinding(ctx context.Context, k8sClient client.Client, nam
 		RoleRef:  rbacv1.RoleRef{Kind: "Role", Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, APIGroup: rbacv1.GroupName},
 	}
 	if isvcOwner != nil {
-		rb.OwnerReferences = append(rb.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+		rb.OwnerReferences = append(rb.OwnerReferences, reconcilers.AsIsvcOwnerRef(isvcOwner))
 	}
 	if otherOwner != nil {
 		rb.OwnerReferences = append(rb.OwnerReferences, *otherOwner)
@@ -186,7 +186,7 @@ func createTestKedaTA(ctx context.Context, k8sClient client.Client, namespace st
 		},
 	}
 	if isvcOwner != nil {
-		ta.OwnerReferences = append(ta.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+		ta.OwnerReferences = append(ta.OwnerReferences, reconcilers.AsIsvcOwnerRef(isvcOwner))
 	}
 	if otherOwner != nil {
 		ta.OwnerReferences = append(ta.OwnerReferences, *otherOwner)

--- a/internal/controller/serving/keda_fixtures_test.go
+++ b/internal/controller/serving/keda_fixtures_test.go
@@ -1,0 +1,197 @@
+package serving
+
+import (
+	"context"
+
+	kedaapi "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/serving/reconcilers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func makeKedaTestISVC(namespace, name string, enableKedaMetrics bool) *kservev1beta1.InferenceService {
+	isvc := &kservev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"serving.kserve.io/deploymentMode": "RawDeployment",
+			},
+		},
+		Spec: kservev1beta1.InferenceServiceSpec{
+			Predictor: kservev1beta1.PredictorSpec{
+				// Model field is required for KServe, even if not directly used by KEDA logic
+				Model: &kservev1beta1.ModelSpec{
+					ModelFormat: kservev1beta1.ModelFormat{Name: "onnx"},
+					Runtime:     ptr.To("kserve-ovms"),
+					PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+						StorageURI: ptr.To("s3://modelmesh-example-models/onnx/mnist-8"),
+					},
+				},
+			},
+		},
+	}
+	if enableKedaMetrics {
+		isvc.Spec.Predictor.MinReplicas = ptr.To[int32](1)
+		isvc.Spec.Predictor.MaxReplicas = 5
+		isvc.Spec.Predictor.AutoScaling = &kservev1beta1.AutoScalingSpec{
+			Metrics: []kservev1beta1.MetricsSpec{
+				{
+					Type: kservev1beta1.ExternalMetricSourceType,
+					External: &kservev1beta1.ExternalMetricSource{
+						Metric: kservev1beta1.ExternalMetrics{
+							Backend:       kservev1beta1.PrometheusBackend,
+							ServerAddress: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9092",
+							Query:         `sum(rate(http_requests_total{namespace="kserve-keda-prometheus", service="sample-app-service"}[1m]))`,
+						},
+						Target: kservev1beta1.MetricTarget{
+							Type:  kservev1beta1.AverageValueMetricType,
+							Value: ptr.To(resource.MustParse("2")),
+						},
+					},
+				},
+			},
+		}
+	} else {
+		// To disable KEDA metrics, we can remove AutoScaling
+		// This makes hasPrometheusExternalAutoscalingMetric return false
+		isvc.Spec.Predictor.AutoScaling = nil
+	}
+	return isvc
+}
+
+// getAllKedaTestResources fetches all KEDA resources by their known names.
+func getAllKedaTestResources(ctx context.Context, k8sClient client.Client, namespace string) map[string]client.Object {
+	resources := make(map[string]client.Object)
+	sa := &corev1.ServiceAccount{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthServiceAccountName, Namespace: namespace}, sa); err == nil {
+		resources["ServiceAccount"] = sa
+	}
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerSecretName, Namespace: namespace}, secret); err == nil {
+		resources["Secret"] = secret
+	}
+	role := &rbacv1.Role{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, Namespace: namespace}, role); err == nil {
+		resources["Role"] = role
+	}
+	rb := &rbacv1.RoleBinding{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleBindingName, Namespace: namespace}, rb); err == nil {
+		resources["RoleBinding"] = rb
+	}
+	ta := &kedaapi.TriggerAuthentication{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: reconcilers.KEDAPrometheusAuthTriggerAuthName, Namespace: namespace}, ta); err == nil {
+		resources["TriggerAuthentication"] = ta
+	}
+	return resources
+}
+
+func createTestKedaSA(ctx context.Context, k8sClient client.Client, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *corev1.ServiceAccount {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reconcilers.KEDAPrometheusAuthResourceName,
+			Namespace: namespace,
+		},
+	}
+	if isvcOwner != nil {
+		sa.OwnerReferences = append(sa.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+	}
+	if otherOwner != nil {
+		sa.OwnerReferences = append(sa.OwnerReferences, *otherOwner)
+	}
+	Expect(k8sClient.Create(ctx, sa)).Should(Succeed())
+	Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sa), sa)).Should(Succeed())
+	return sa
+}
+
+func createTestKedaSecret(ctx context.Context, k8sClient client.Client, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reconcilers.KEDAPrometheusAuthTriggerSecretName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: reconcilers.KEDAPrometheusAuthResourceName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	if isvcOwner != nil {
+		secret.OwnerReferences = append(secret.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+	}
+	if otherOwner != nil {
+		secret.OwnerReferences = append(secret.OwnerReferences, *otherOwner)
+	}
+	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+	Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).Should(Succeed())
+	return secret
+}
+
+func createTestKedaRole(ctx context.Context, k8sClient client.Client, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *rbacv1.Role {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reconcilers.KEDAPrometheusAuthMetricsReaderRoleName,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}}, // Simplified rule
+	}
+	if isvcOwner != nil {
+		role.OwnerReferences = append(role.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+	}
+	if otherOwner != nil {
+		role.OwnerReferences = append(role.OwnerReferences, *otherOwner)
+	}
+	Expect(k8sClient.Create(ctx, role)).Should(Succeed())
+	Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role), role)).Should(Succeed())
+	return role
+}
+
+func createTestKedaRoleBinding(ctx context.Context, k8sClient client.Client, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *rbacv1.RoleBinding {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reconcilers.KEDAPrometheusAuthMetricsReaderRoleBindingName,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: reconcilers.KEDAPrometheusAuthResourceName, Namespace: namespace}},
+		RoleRef:  rbacv1.RoleRef{Kind: "Role", Name: reconcilers.KEDAPrometheusAuthMetricsReaderRoleName, APIGroup: rbacv1.GroupName},
+	}
+	if isvcOwner != nil {
+		rb.OwnerReferences = append(rb.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+	}
+	if otherOwner != nil {
+		rb.OwnerReferences = append(rb.OwnerReferences, *otherOwner)
+	}
+	Expect(k8sClient.Create(ctx, rb)).Should(Succeed())
+	Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb), rb)).Should(Succeed())
+	return rb
+}
+
+func createTestKedaTA(ctx context.Context, k8sClient client.Client, namespace string, isvcOwner *kservev1beta1.InferenceService, otherOwner *metav1.OwnerReference) *kedaapi.TriggerAuthentication {
+	ta := &kedaapi.TriggerAuthentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reconcilers.KEDAPrometheusAuthTriggerAuthName,
+			Namespace: namespace,
+		},
+		Spec: kedaapi.TriggerAuthenticationSpec{
+			SecretTargetRef: []kedaapi.AuthSecretTargetRef{
+				{Parameter: "bearerToken", Name: reconcilers.KEDAPrometheusAuthTriggerSecretName, Key: "token"},
+			},
+		},
+	}
+	if isvcOwner != nil {
+		ta.OwnerReferences = append(ta.OwnerReferences, reconcilers.AsOwnerRef(isvcOwner))
+	}
+	if otherOwner != nil {
+		ta.OwnerReferences = append(ta.OwnerReferences, *otherOwner)
+	}
+	Expect(k8sClient.Create(ctx, ta)).Should(Succeed())
+	Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ta), ta)).Should(Succeed())
+	return ta
+}

--- a/internal/controller/serving/reconcilers/kserve_keda_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_keda_reconciler.go
@@ -1,0 +1,629 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-multierror"
+	"github.com/kuadrant/authorino/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kedaapi "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+)
+
+const (
+	KEDAResourcesPrefix                            = "inference-"
+	KEDAPrometheusPrefix                           = KEDAResourcesPrefix + "prometheus-"
+	KEDAPrometheusAuthResourceName                 = KEDAPrometheusPrefix + "auth"
+	KEDAPrometheusAuthServiceAccountName           = KEDAPrometheusAuthResourceName
+	KEDAPrometheusAuthTriggerSecretName            = KEDAPrometheusAuthResourceName
+	KEDAPrometheusAuthMetricsReaderRoleName        = KEDAPrometheusAuthResourceName
+	KEDAPrometheusAuthMetricsReaderRoleBindingName = KEDAPrometheusAuthResourceName
+	KEDAPrometheusAuthTriggerAuthName              = KEDAPrometheusAuthResourceName
+
+	KEDAResourcesLabelKey   = "odh-model-controller"
+	KEDAResourcesLabelValue = "keda-reconciler"
+)
+
+var (
+	KedaLabelPredicate predicate.Predicate
+)
+
+func init() {
+	p, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			KEDAResourcesLabelKey: KEDAResourcesLabelValue,
+		},
+	})
+	if err != nil {
+		panic("failed to create label selector predicate: " + err.Error())
+	}
+	KedaLabelPredicate = p
+}
+
+var _ SubResourceReconciler = (*KserveKEDAReconciler)(nil)
+
+// KserveKEDAReconciler allows ISVCs to autoscale on custom Prometheus metrics via KEDA, with secure OpenShift Monitoring
+// access. The reconciler automates KEDA/RBAC resource lifecycle.
+//
+// KServeKEDAReconciler manages KEDA-specific resources (ServiceAccount, Secret, Role, RoleBinding, TriggerAuthentication)
+// for Prometheus-based autoscaling.
+// - Creates resources if InferenceService uses KEDA Prometheus external metric.
+// - Adds each InferenceService in a given namespace as non-controlling owner to shared namespaced resources.
+// - Removes InferenceService owner reference if KEDA Prometheus autoscaling is unused or InferenceService deleted.
+// - Cleans up KEDA resources from namespace if no InferenceServices use KEDA Prometheus autoscaling.
+type KserveKEDAReconciler struct {
+	client client.Client
+}
+
+func NewKServeKEDAReconciler(client client.Client) *KserveKEDAReconciler {
+	return &KserveKEDAReconciler{
+		client: client,
+	}
+}
+
+func (k *KserveKEDAReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+
+	log = log.WithName("KserveKEDAReconciler")
+	log.V(2).Info("Reconciling InferenceService", "InferenceService", isvc)
+
+	if !hasPrometheusExternalAutoscalingMetric(isvc) {
+		log.V(1).Info("No Prometheus external autoscaling metric found, KEDA resources not required by this InferenceService. Ensuring InferenceService is removed from owner references.")
+
+		// When Prometheus autoscaling is not used, we remove the InferenceService as owner reference from
+		// all KEDA-related resources.
+		if err := k.removeOwnerReference(ctx, log, isvc); err != nil {
+			return fmt.Errorf("failed to remove owner reference from KEDA resources: %w", err)
+		}
+		return k.maybeCleanupNamespace(ctx, log, isvc.GetNamespace())
+	}
+
+	log.Info("Reconciling resources")
+
+	if err := retryOnConflicts(func() error { return k.reconcileServiceAccount(ctx, log, isvc) }); err != nil {
+		return fmt.Errorf("failed to reconcile service account: %w", err)
+	}
+	if err := retryOnConflicts(func() error { return k.reconcileSecret(ctx, log, isvc) }); err != nil {
+		return fmt.Errorf("failed to reconcile secret: %w", err)
+	}
+	if err := retryOnConflicts(func() error { return k.reconcileRole(ctx, log, isvc) }); err != nil {
+		return fmt.Errorf("failed to reconcile role: %w", err)
+	}
+	if err := retryOnConflicts(func() error { return k.reconcileRoleBinding(ctx, log, isvc) }); err != nil {
+		return fmt.Errorf("failed to reconcile role binding: %w", err)
+	}
+	if err := retryOnConflicts(func() error { return k.reconcileTriggerAuthentication(ctx, log, isvc) }); err != nil && !meta.IsNoMatchError(err) {
+		return fmt.Errorf("failed to reconcile trigger authentication: %w", err)
+	}
+	log.Info("Successfully reconciled KEDA resources")
+	return nil
+}
+
+func (k *KserveKEDAReconciler) Delete(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+
+	log = log.WithName("KserveKEDAReconciler")
+	log.V(2).Info("KserveKEDAReconciler.Delete called, removing owner reference.")
+
+	if err := k.removeOwnerReference(ctx, log, isvc); err != nil {
+		return fmt.Errorf("failed to remove owner reference from KEDA resources: %w", err)
+	}
+	return k.maybeCleanupNamespace(ctx, log, isvc.GetNamespace())
+}
+
+func (k *KserveKEDAReconciler) Cleanup(ctx context.Context, log logr.Logger, isvcNs string) error {
+	return k.cleanupNamespace(ctx, log, isvcNs)
+}
+
+func (k *KserveKEDAReconciler) maybeCleanupNamespace(ctx context.Context, log logr.Logger, namespace string) error {
+	inferenceServiceList := &kservev1beta1.InferenceServiceList{}
+	if err := k.client.List(ctx, inferenceServiceList, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+	for _, isvc := range inferenceServiceList.Items {
+		if hasPrometheusExternalAutoscalingMetric(&isvc) {
+			// There are still InferenceServices with Prometheus autoscaling configured, nothing to remove.
+			return nil
+		}
+	}
+	return k.cleanupNamespace(ctx, log, namespace)
+}
+
+func (k *KserveKEDAReconciler) cleanupNamespace(ctx context.Context, log logr.Logger, namespace string) error {
+	log = log.WithName("KserveKEDAReconciler")
+	log.V(2).Info("KserveKEDAReconciler.Cleanup called.", "Namespace", namespace)
+
+	var encounteredErrors []error
+	for _, r := range k.resourcesToCleanup() {
+		r.SetNamespace(namespace)
+		if err := k.client.Delete(ctx, r); err != nil && !errors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+			encounteredErrors = append(encounteredErrors, err)
+		}
+	}
+	if len(encounteredErrors) > 0 {
+		return multierror.Append(nil, encounteredErrors...)
+	}
+	return nil
+}
+
+// --- TriggerAuthentication ---
+func (k *KserveKEDAReconciler) reconcileTriggerAuthentication(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	expected := k.expectedTriggerAuthentication(isvc)
+	curr := &kedaapi.TriggerAuthentication{}
+	key := client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}
+
+	err := k.client.Get(ctx, key, curr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating TriggerAuthentication")
+			return k.createTriggerAuthentication(ctx, isvc)
+		}
+		return fmt.Errorf("failed to get TriggerAuthentication %s: %w", key.String(), err)
+	}
+
+	expected.OwnerReferences = upsertOwnerReference(AsOwnerRef(isvc), curr)
+	expected.ResourceVersion = curr.ResourceVersion
+
+	if equality.Semantic.DeepDerivative(expected.Spec, curr.Spec) &&
+		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations) &&
+		equality.Semantic.DeepDerivative(expected.OwnerReferences, curr.OwnerReferences) {
+		log.V(1).Info("TriggerAuthentication is up-to-date")
+		return nil
+	}
+
+	log.Info("Updating TriggerAuthentication")
+	if err := k.client.Update(ctx, expected); err != nil {
+		return fmt.Errorf("failed to update TriggerAuthentication %s: %w", key.String(), err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) createTriggerAuthentication(ctx context.Context, isvc *kservev1beta1.InferenceService) error {
+	ta := k.expectedTriggerAuthentication(isvc)
+	if err := k.client.Create(ctx, ta); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create TriggerAuthentication %s/%s: %w", ta.Namespace, ta.Name, err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) expectedTriggerAuthentication(isvc *kservev1beta1.InferenceService) *kedaapi.TriggerAuthentication {
+	return &kedaapi.TriggerAuthentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            KEDAPrometheusAuthTriggerAuthName,
+			Namespace:       isvc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{AsOwnerRef(isvc)},
+			Labels:          getKedaLabels(isvc.Labels),
+			Annotations:     isvc.Annotations,
+		},
+		Spec: kedaapi.TriggerAuthenticationSpec{
+			SecretTargetRef: []kedaapi.AuthSecretTargetRef{
+				{
+					Parameter: "bearerToken",
+					Name:      KEDAPrometheusAuthTriggerSecretName,
+					Key:       "token",
+				},
+				{
+					Parameter: "ca",
+					Name:      KEDAPrometheusAuthTriggerSecretName,
+					Key:       "ca.crt",
+				},
+			},
+		},
+	}
+}
+
+// --- ServiceAccount ---
+func (k *KserveKEDAReconciler) reconcileServiceAccount(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	expected := k.expectedServiceAccount(isvc)
+	curr := &corev1.ServiceAccount{}
+	key := client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}
+
+	err := k.client.Get(ctx, key, curr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating ServiceAccount")
+			return k.createServiceAccount(ctx, isvc)
+		}
+		return fmt.Errorf("failed to get ServiceAccount %s: %w", key.String(), err)
+	}
+
+	expected.OwnerReferences = upsertOwnerReference(AsOwnerRef(isvc), curr)
+	expected.ResourceVersion = curr.ResourceVersion
+
+	if equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations) &&
+		equality.Semantic.DeepDerivative(expected.OwnerReferences, curr.OwnerReferences) {
+		log.V(1).Info("ServiceAccount is up-to-date")
+		return nil
+	}
+
+	log.Info("Updating ServiceAccount")
+	if err := k.client.Update(ctx, expected); err != nil {
+		return fmt.Errorf("failed to update ServiceAccount %s: %w", key.String(), err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) createServiceAccount(ctx context.Context, isvc *kservev1beta1.InferenceService) error {
+	sa := k.expectedServiceAccount(isvc)
+	if err := k.client.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create ServiceAccount %s/%s: %w", sa.Namespace, sa.Name, err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) expectedServiceAccount(isvc *kservev1beta1.InferenceService) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            KEDAPrometheusAuthResourceName,
+			Namespace:       isvc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{AsOwnerRef(isvc)},
+			Labels:          getKedaLabels(isvc.Labels),
+			Annotations:     isvc.Annotations,
+		},
+		// ServiceAccount Spec is mostly empty; Secrets and ImagePullSecrets are managed via sub-resources or user additions.
+	}
+}
+
+// --- Secret ---
+func (k *KserveKEDAReconciler) reconcileSecret(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	expected := k.expectedSecret(isvc)
+	curr := &corev1.Secret{}
+	key := client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}
+
+	err := k.client.Get(ctx, key, curr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating Secret", "namespace", key.Namespace, "name", key.Name)
+			return k.createSecret(ctx, isvc)
+		}
+		return fmt.Errorf("failed to get Secret %s: %w", key.String(), err)
+	}
+
+	expected.OwnerReferences = upsertOwnerReference(AsOwnerRef(isvc), curr)
+	expected.ResourceVersion = curr.ResourceVersion
+
+	if expected.Type == curr.Type &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations) &&
+		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.OwnerReferences, curr.OwnerReferences) {
+		log.V(1).Info("Secret is up-to-date", "namespace", key.Namespace, "name", key.Name)
+		return nil
+	}
+
+	// Preserve data from the current secret as it's managed by Kubernetes for ServiceAccountToken secrets.
+	expected.Data = curr.Data
+
+	log.Info("Updating Secret", "namespace", key.Namespace, "name", key.Name)
+	if err := k.client.Update(ctx, expected); err != nil {
+		return fmt.Errorf("failed to update Secret %s: %w", key.String(), err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) createSecret(ctx context.Context, isvc *kservev1beta1.InferenceService) error {
+	secret := k.expectedSecret(isvc)
+	if err := k.client.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create Secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) expectedSecret(isvc *kservev1beta1.InferenceService) *corev1.Secret {
+	secretAnnotations := make(map[string]string)
+	if isvc.Annotations != nil {
+		for k, v := range isvc.Annotations {
+			secretAnnotations[k] = v
+		}
+	}
+	// This annotation links the secret to the service account, enabling token population.
+	secretAnnotations[corev1.ServiceAccountNameKey] = KEDAPrometheusAuthResourceName
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            KEDAPrometheusAuthTriggerSecretName,
+			Namespace:       isvc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{AsOwnerRef(isvc)},
+			Labels:          getKedaLabels(isvc.Labels),
+			Annotations:     secretAnnotations,
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		// Data field is populated by the Kubernetes controller for service account tokens.
+	}
+}
+
+// --- Role ---
+func (k *KserveKEDAReconciler) reconcileRole(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	expected := k.expectedRole(isvc)
+	curr := &rbacv1.Role{}
+	key := client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}
+
+	err := k.client.Get(ctx, key, curr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating Role", "namespace", key.Namespace, "name", key.Name)
+			return k.createRole(ctx, isvc)
+		}
+		return fmt.Errorf("failed to get Role %s: %w", key.String(), err)
+	}
+
+	expected.OwnerReferences = upsertOwnerReference(AsOwnerRef(isvc), curr)
+	expected.ResourceVersion = curr.ResourceVersion
+
+	if equality.Semantic.DeepDerivative(expected.Rules, curr.Rules) &&
+		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations) &&
+		equality.Semantic.DeepDerivative(expected.OwnerReferences, curr.OwnerReferences) {
+		log.V(1).Info("Role is up-to-date", "namespace", key.Namespace, "name", key.Name)
+		return nil
+	}
+
+	log.Info("Updating Role", "namespace", key.Namespace, "name", key.Name)
+	if err := k.client.Update(ctx, expected); err != nil {
+		return fmt.Errorf("failed to update Role %s: %w", key.String(), err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) createRole(ctx context.Context, isvc *kservev1beta1.InferenceService) error {
+	role := k.expectedRole(isvc)
+	if err := k.client.Create(ctx, role); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create Role %s/%s: %w", role.Namespace, role.Name, err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) expectedRole(isvc *kservev1beta1.InferenceService) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            KEDAPrometheusAuthMetricsReaderRoleName,
+			Namespace:       isvc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{AsOwnerRef(isvc)},
+			Labels:          getKedaLabels(isvc.Labels),
+			Annotations:     isvc.Annotations,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{"metrics.k8s.io"},
+				Resources: []string{"pods", "nodes"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+}
+
+// --- RoleBinding ---
+func (k *KserveKEDAReconciler) reconcileRoleBinding(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	expected := k.expectedRoleBinding(isvc)
+	curr := &rbacv1.RoleBinding{}
+	key := client.ObjectKey{Namespace: expected.Namespace, Name: expected.Name}
+
+	err := k.client.Get(ctx, key, curr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Creating RoleBinding", "namespace", key.Namespace, "name", key.Name)
+			return k.createRoleBinding(ctx, isvc)
+		}
+		return fmt.Errorf("failed to get RoleBinding %s: %w", key.String(), err)
+	}
+
+	expected.OwnerReferences = upsertOwnerReference(AsOwnerRef(isvc), curr)
+	expected.ResourceVersion = curr.ResourceVersion
+
+	if equality.Semantic.DeepDerivative(expected.Subjects, curr.Subjects) &&
+		equality.Semantic.DeepDerivative(expected.RoleRef, curr.RoleRef) &&
+		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations) &&
+		equality.Semantic.DeepDerivative(expected.OwnerReferences, curr.OwnerReferences) {
+		log.V(1).Info("RoleBinding is up-to-date")
+		return nil
+	}
+
+	log.Info("Updating RoleBinding")
+	if err := k.client.Update(ctx, expected); err != nil {
+		return fmt.Errorf("failed to update RoleBinding %s: %w", key.String(), err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) createRoleBinding(ctx context.Context, isvc *kservev1beta1.InferenceService) error {
+	rb := k.expectedRoleBinding(isvc)
+	if err := k.client.Create(ctx, rb); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
+	}
+	return nil
+}
+
+func (k *KserveKEDAReconciler) expectedRoleBinding(isvc *kservev1beta1.InferenceService) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            KEDAPrometheusAuthMetricsReaderRoleBindingName,
+			Namespace:       isvc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{AsOwnerRef(isvc)},
+			Labels:          getKedaLabels(isvc.Labels),
+			Annotations:     isvc.Annotations,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      KEDAPrometheusAuthResourceName,
+				Namespace: isvc.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     KEDAPrometheusAuthMetricsReaderRoleName,
+		},
+	}
+}
+
+// removeOwnerReference attempts to remove the ISVC's owner reference from all KEDA-related resources.
+// It collects errors and returns a summary error if any occurred.
+func (k *KserveKEDAReconciler) removeOwnerReference(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	ownerRefToRemove := AsOwnerRef(isvc)
+	var encounteredErrors []error
+
+	resourceCleanups := k.resourcesToCleanup()
+
+	for _, rc := range resourceCleanups {
+		if err := retryOnConflicts(func() error { return k.removeOwnerReferenceFromObject(ctx, log, rc, isvc.Namespace, ownerRefToRemove) }); err != nil {
+			err := fmt.Errorf("failed to remove owner reference from %s %s: %w", rc.GetObjectKind(), rc.GetName(), err)
+			encounteredErrors = append(encounteredErrors, err)
+		}
+	}
+
+	if len(encounteredErrors) > 0 {
+		err := multierror.Append(nil, encounteredErrors...)
+		return fmt.Errorf("encountered %d error(s) during owner reference removal: %w", len(encounteredErrors), err)
+	}
+	return nil
+}
+
+// removeOwnerReferenceFromObject fetches a Kubernetes object and removes a specific owner reference.
+// If the object or the owner reference is not found, it's a no-op for that object.
+// obj parameter must be a pointer to an empty struct of the target resource kind (e.g., &corev1.ServiceAccount{}).
+func (k *KserveKEDAReconciler) removeOwnerReferenceFromObject(
+	ctx context.Context,
+	log logr.Logger,
+	obj client.Object,
+	namespace string,
+	ownerRefToRemove metav1.OwnerReference,
+) error {
+	key := client.ObjectKey{Namespace: namespace, Name: obj.GetName()}
+	err := k.client.Get(ctx, key, obj)
+	if err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			log.V(1).Info("Resource not found, skipping owner reference removal", "kind", obj.GetObjectKind(), "namespace", key.Namespace, "name", key.Name)
+			return nil // No-op: resource doesn't exist.
+		}
+		return fmt.Errorf("failed to get %s %s for owner reference removal: %w", obj.GetObjectKind(), key.String(), err)
+	}
+
+	originalOwnerReferences := obj.GetOwnerReferences()
+	if len(originalOwnerReferences) == 0 {
+		log.V(1).Info("Resource has no owner references, skipping removal attempt", "kind", obj.GetObjectKind(), "resourceName", obj.GetName(), "namespace", obj.GetNamespace())
+		return nil // No-op: resource has no owners.
+	}
+
+	newOwnerReferences := make([]metav1.OwnerReference, 0, len(originalOwnerReferences))
+
+	for _, ref := range originalOwnerReferences {
+		// Match by UID, as this is the unique identifier for an owner reference instance.
+		if ref.UID == ownerRefToRemove.UID {
+			log.V(1).Info("Matching ISVC owner reference found, will be removed.",
+				"ownerRefUID", ref.UID, "resourceKind", obj.GetObjectKind(), "resourceName", obj.GetName())
+		} else {
+			newOwnerReferences = append(newOwnerReferences, ref)
+		}
+	}
+
+	if equality.Semantic.DeepEqual(newOwnerReferences, originalOwnerReferences) {
+		return nil
+	}
+
+	obj.SetOwnerReferences(newOwnerReferences)
+	if err := k.client.Update(ctx, obj); err != nil && !errors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+		return fmt.Errorf("failed to update %s %s after removing owner reference: %w", obj.GetObjectKind(), key.String(), err)
+	}
+	log.Info("Successfully removed ISVC owner reference and updated resource",
+		"resourceKind", obj.GetObjectKind(), "resourceName", obj.GetName(), "namespace", obj.GetNamespace())
+
+	return nil
+}
+
+func AsOwnerRef(isvc *kservev1beta1.InferenceService) metav1.OwnerReference {
+	or := *metav1.NewControllerRef(isvc, kservev1beta1.SchemeGroupVersion.WithKind("InferenceService"))
+	// Setting Controller to false makes this a non-controlling owner reference.
+	// The owned object will be garbage collected when the ISVC is deleted,
+	// but the ISVC doesn't "control" its lifecycle in other controller-runtime senses.
+	or.Controller = ptr.To(false)
+	return or
+}
+
+func hasPrometheusExternalAutoscalingMetric(isvc *kservev1beta1.InferenceService) bool {
+
+	log.V(1).Info("hasPrometheusExternalAutoscalingMetric", "autoscaling", isvc.Spec.Predictor.AutoScaling)
+	if isvc.Spec.Predictor.AutoScaling == nil {
+		return false
+	}
+	for _, m := range isvc.Spec.Predictor.AutoScaling.Metrics {
+		if m.External != nil && m.External.Metric.Backend == kservev1beta1.PrometheusBackend {
+			return true
+		}
+	}
+	return false
+}
+
+func upsertOwnerReference(expected metav1.OwnerReference, obj client.Object) []metav1.OwnerReference {
+	references := obj.GetOwnerReferences()
+	newReferences := make([]metav1.OwnerReference, 0, len(references)+1)
+	found := false
+	for _, ref := range references {
+		if ref.APIVersion == expected.APIVersion && ref.Kind == expected.Kind && ref.Name == expected.Name {
+			newReferences = append(newReferences, expected) // Replace with the new reference to update UID etc.
+			found = true
+		} else {
+			newReferences = append(newReferences, ref)
+		}
+	}
+
+	if !found {
+		newReferences = append(newReferences, expected)
+	}
+	return newReferences
+}
+
+func getKedaLabels(isvcLabels map[string]string) map[string]string {
+	labels := make(map[string]string, len(isvcLabels))
+	for k, v := range isvcLabels {
+		labels[k] = v
+	}
+	labels[KEDAResourcesLabelKey] = KEDAResourcesLabelValue
+	return labels
+}
+
+func retryOnConflicts(f func() error) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, f)
+}
+
+func (k *KserveKEDAReconciler) resourcesToCleanup() []client.Object {
+	return []client.Object{
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: KEDAPrometheusAuthServiceAccountName}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: KEDAPrometheusAuthTriggerSecretName}},
+		&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: KEDAPrometheusAuthMetricsReaderRoleName}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: KEDAPrometheusAuthMetricsReaderRoleBindingName}},
+		&kedaapi.TriggerAuthentication{ObjectMeta: metav1.ObjectMeta{Name: KEDAPrometheusAuthTriggerAuthName}},
+	}
+}

--- a/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
@@ -39,6 +39,7 @@ func NewKServeRawInferenceServiceReconciler(client client.Client) *KserveRawInfe
 		NewKServeRawMetricsServiceReconciler(client),
 		NewKServeRawMetricsServiceMonitorReconciler(client),
 		NewKserveMetricsDashboardReconciler(client),
+		NewKServeKEDAReconciler(client),
 	}
 
 	return &KserveRawInferenceServiceReconciler{

--- a/internal/controller/serving/reconcilers/meta.go
+++ b/internal/controller/serving/reconcilers/meta.go
@@ -1,0 +1,38 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+)
+
+// AsOwnerRef returns the non-controlling OwnerReference representation of the given object.
+func AsOwnerRef(obj metav1.Object, gvk schema.GroupVersionKind) metav1.OwnerReference {
+	or := *metav1.NewControllerRef(obj, gvk)
+	// Setting Controller to false makes this a non-controlling owner reference.
+	// The owned object will be garbage collected when the ISVC is deleted,
+	// but the ISVC doesn't "control" its lifecycle in other controller-runtime senses.
+	or.Controller = ptr.To(false)
+	return or
+}
+
+// AsIsvcOwnerRef returns the non-controlling OwnerReference representation of the given isvc.
+func AsIsvcOwnerRef(isvc *kservev1beta1.InferenceService) metav1.OwnerReference {
+	return AsOwnerRef(isvc, kservev1beta1.SchemeGroupVersion.WithKind("InferenceService"))
+}

--- a/internal/controller/utils/init.go
+++ b/internal/controller/utils/init.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	kedaapi "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
@@ -41,6 +42,7 @@ func RegisterSchemes(s *runtime.Scheme) {
 	utilruntime.Must(istioclientv1beta1.SchemeBuilder.AddToScheme(s))
 	utilruntime.Must(nimv1.SchemeBuilder.AddToScheme(s))
 	utilruntime.Must(templatev1.AddToScheme(s))
+	utilruntime.Must(kedaapi.AddToScheme(s))
 
 	// The following are related to Service Mesh, uncomment this and other
 	// similar blocks to use with Service Mesh

--- a/test/matchers/gomega_uid_matcher.go
+++ b/test/matchers/gomega_uid_matcher.go
@@ -1,0 +1,52 @@
+package matchers
+
+import (
+	"fmt"
+
+	gomegatypes "github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func HaveOwnerReferenceByUID(expectedUID types.UID) gomegatypes.GomegaMatcher {
+	return &haveOwnerReferenceByUIDMatcher{expectedUID: expectedUID}
+}
+
+type haveOwnerReferenceByUIDMatcher struct {
+	expectedUID types.UID
+}
+
+func (m *haveOwnerReferenceByUIDMatcher) Match(actual any) (bool, error) {
+	if m.expectedUID == "" {
+		return false, fmt.Errorf("HaveOwnerReferenceByUID matcher requires a non-empty UID")
+	}
+
+	obj, ok := actual.(client.Object)
+	if !ok {
+		return false, fmt.Errorf(
+			"HaveOwnerReferenceByUID matcher expects a controller-runtime client.Object; got:\n%#v", actual)
+	}
+
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == m.expectedUID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *haveOwnerReferenceByUIDMatcher) FailureMessage(actual any) string {
+	obj := actual.(client.Object)
+	return fmt.Sprintf(
+		"Expected\n    %#v\nto have OwnerReference with UID %q\nFound OwnerReferences:\n    %#v",
+		obj, string(m.expectedUID), obj.GetOwnerReferences(),
+	)
+}
+
+func (m *haveOwnerReferenceByUIDMatcher) NegatedFailureMessage(actual any) string {
+	obj := actual.(client.Object)
+	return fmt.Sprintf(
+		"Expected\n    %#v\nnot to have OwnerReference with UID %q\nFound OwnerReferences:\n    %#v",
+		obj, string(m.expectedUID), obj.GetOwnerReferences(),
+	)
+}


### PR DESCRIPTION
## Description

Integrate KEDA-based autoscaling for KServe InferenceServices in RawDeployment mode.

This allows ISVCs to autoscale on custom Prometheus metrics via KEDA, with secure OpenShift Monitoring access. The reconciler automates KEDA/RBAC resource lifecycle.

Key changes:
- New KServeKEDAReconciler manages KEDA-specific resources (ServiceAccount, Secret, Role, RoleBinding, TriggerAuthentication) for Prometheus-based autoscaling.
  - Creates resources if ISVC uses Prometheus external metric.
  - Adds ISVC as non-controlling owner to shared resources.
  - Removes ISVC owner reference if KEDA metrics unused or ISVC deleted.
  - Cleans up KEDA resources from namespace if no ISVCs use KEDA.
- InferenceService controller now:
  - Watches KEDA TriggerAuthentication, Role, RoleBinding.
  - Uses MatchEveryOwner for ServiceAccount, Secret for sharing.
  - Conditionally watches TriggerAuthentication if CRD present.
- KEDA API (keda.sh/v1alpha1) registered with scheme.
- A few tests added for KServe KEDA reconciler, covering:
  - Creation/ownership of KEDA resources for multiple ISVCs.
  - Owner reference removal on ISVC deletion/metric config change.
  - Handling updates to managed KEDA resources.
  - Scenarios with shared/unrequired KEDA resources.
  - Namespace cleanup.

## How Has This Been Tested?
`make test`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work