### PR TITLE
[RHOAIENG-25522] Route that is not managed by the InferenceService gets deleted

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_route_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_route_reconciler.go
@@ -80,9 +80,8 @@ func (r *KserveRouteReconciler) Reconcile(ctx context.Context, log logr.Logger, 
 }
 
 func (r *KserveRouteReconciler) Delete(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	log.V(1).Info("Deleting Kserve inference service generic route")
-	_, meshNamespace := utils2.GetIstioControlPlaneName(ctx, r.client)
-	return r.routeHandler.DeleteRoute(ctx, types.NamespacedName{Name: getKServeRouteName(isvc), Namespace: meshNamespace})
+	// handled by owner references
+	return nil
 }
 
 func (r *KserveRouteReconciler) Cleanup(_ context.Context, _ logr.Logger, _ string) error {


### PR DESCRIPTION

While the reported issue was not reproducible in the current code base, I've made an improvement in the serverless mode route deletion, it was deleting the route based on the isvc name, whereas it should be deleting based on the owner reference, similar to how raw route handling is done.

Plus, a unit test was added to verify that the route is still deployed upon Inference Service deletion.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work