### PR TITLE
[RHOAIENG-16147] with kserve 0.15 bump, updated multi node checker with WorkerSpec

### DIFF
--- a/internal/controller/serving/servingruntime_controller.go
+++ b/internal/controller/serving/servingruntime_controller.go
@@ -323,7 +323,7 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 			return err
 		}
 		for _, sr := range servingRuntimeList.Items {
-			if isMultiNodeServingRuntime(sr.Name) {
+			if isMultiNodeServingRuntime(sr) {
 				rayDefaultSecret.SetNamespace(sr.Namespace)
 				if err := r.Client.Update(ctx, rayDefaultSecret); err != nil {
 					if apierrs.IsNotFound(err) {
@@ -397,18 +397,17 @@ func getDesiredRayDefaultSecret(namespace string, caSecret *corev1.Secret) *core
 }
 
 func existMultiNodeServingRuntimeInNs(srList servingv1alpha1.ServingRuntimeList) bool {
-	existMultiNodeServingRuntime := false
 	for _, sr := range srList.Items {
-		existMultiNodeServingRuntime = isMultiNodeServingRuntime(sr.Name)
+		if isMultiNodeServingRuntime(sr) {
+			return true
+		}
 	}
-	return existMultiNodeServingRuntime
+	return false
 }
 
 // Determine if ServingRuntime matches specific conditions
-// TO-DO upstream Kserve 0.15 will have a new API WorkerSpec
-// So for now, it will check servingRuntime name, but after we move to 0.15, it needs to check workerSpec is specified or not.(RHOAIENG-16147)
-func isMultiNodeServingRuntime(srName string) bool {
-	return srName == "vllm-multinode-runtime"
+func isMultiNodeServingRuntime(sr servingv1alpha1.ServingRuntime) bool {
+	return sr.Spec.WorkerSpec != nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[RHOAIENG-16147](https://issues.redhat.com/browse/RHOAIENG-16147)

With kserve version bump, now we can use the latest CRD `workerSpec`. So we can use it to check if there is a servingruntime that is for mult-node case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The existing test can cover this. so unit test ci will cover this.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection of multi-node ServingRuntime resources, ensuring more accurate handling based on configuration rather than relying on specific names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->