### PR TITLE
Odh v2.32 release 

### DIFF
--- a/.tekton/odh-model-controller-push.yaml
+++ b/.tekton/odh-model-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-v2.32
+    value: quay.io/opendatahub/odh-model-controller:odh-v2.33
   - name: dockerfile
     value: Containerfile
   - name: path-context


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.33
[RHOAIENG-29332]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image version used in the pipeline to odh-v2.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->