### PR TITLE
fix: Change NIM validation refresh rate from 24h to 1h to align with NGC API key constraints

### DIFF
--- a/api/nim/v1/account_types.go
+++ b/api/nim/v1/account_types.go
@@ -13,9 +13,9 @@ type AccountSpec struct {
 	APIKeySecret corev1.ObjectReference `json:"apiKeySecret"`
 	// A reference to the ConfigMap containing the list of NIM models that are allowed to be deployed.
 	ModelListConfig *corev1.ObjectReference `json:"modelListConfig,omitempty"`
-	// Refresh Rate for validation, defaults to 24h
+	// Refresh Rate for validation, defaults to 1h
 	// +kubebuilder:validation:Format="duration"
-	// +kubebuilder:default:="24h"
+	// +kubebuilder:default:="1h"
 	// +kubebuilder:validation:Optional
 	ValidationRefreshRate string `json:"validationRefreshRate"`
 	// Refresh rate for models data, defaults to 24h

--- a/config/crd/bases/nim.opendatahub.io_accounts.yaml
+++ b/config/crd/bases/nim.opendatahub.io_accounts.yaml
@@ -157,8 +157,8 @@ spec:
                 format: duration
                 type: string
               validationRefreshRate:
-                default: 24h
-                description: Refresh Rate for validation, defaults to 24h
+                default: 1h
+                description: Refresh Rate for validation, defaults to 1h
                 format: duration
                 type: string
             required:

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -124,7 +124,7 @@ const (
 // NIM
 const (
 	NimApplyConfigFieldManager   = "nim-account-controller"
-	NimValidationRefreshRate     = time.Hour * 24
+	NimValidationRefreshRate     = time.Hour * 1
 	NimConfigRefreshRate         = time.Hour * 24
 	NimCleanupFinalizer          = "runtimes.opendatahub.io/nim-cleanup-finalizer"
 	NimForceValidationAnnotation = "runtimes.opendatahub.io/nim-force-validation"


### PR DESCRIPTION
This PR fixes the NGC API key validation refresh rate issue where expired API keys showed as healthy for up to 23 hours.

## Problem
The NIM controller was only validating NGC API keys once every 24 hours, but NGC API keys have a minimum expiration time of 1 hour. This created a 23-hour window where API keys appeared healthy but deployments failed.

## Solution
Changed the validation refresh rate from 24 hours to 1 hour to align with NGC's minimum API key expiration time.

## Changes Made
- Changed NimValidationRefreshRate constant from 24 hours to 1 hour in `internal/controller/constants/constants.go`
- Updated kubebuilder default annotation from '24h' to '1h' in `api/nim/v1/account_types.go`
- Updated comment to reflect new default
- Regenerated CRDs to reflect new 1h default in `config/crd/bases/nim.opendatahub.io_accounts.yaml`

## Related Issues
- Fixes: [NVPE-350](https://issues.redhat.com//browse/NVPE-350)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Default validation refresh interval changed from 24 hours to 1 hour. Unspecified configs will now use the hourly default, causing validation to run more frequently and provide faster detection of changes and up-to-date status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->