### PR TITLE
fix issue with with startup probe when --served-model-name is set

### DIFF
--- a/config/runtimes/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm-multinode-template.yaml
@@ -279,11 +279,11 @@ objects:
                     # Double check to make sure Model is ready to serve.
                     for i in 1 2; do
                       # Check model health
-                      model_health_check=$(curl -s ${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:8080/v1/models|grep -o ${ISVC_NAME})
-                      if [[ ${model_health_check} != "${ISVC_NAME}" ]]; then
+                      model_health_check=$(curl -s ${HEAD_SVC}.${POD_NAMESPACE}.svc.cluster.local:8080/v1/models | grep -q '"object":"model"' && echo true || echo false)
+                      if [[ "${model_health_check}" == "false" ]]; then
                         echo "Unhealthy - vLLM Runtime Health Check failed."
                         exit 1
-                      fi                     
+                      fi
                       sleep 10
                     done
         volumes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://issues.redhat.com/browse/RHOAIENG-32105

When setting a model name with `--served-model-name` the worker never goes to a fully running state.

This update changes the health check to simply validate that a model is being served, and not that the name matches the InferenceService object.

## How Has This Been Tested?
Deployed and tested a ServingRuntime using this check.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work