### PR TITLE
Update golangci-lint to be compatible with go 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= v1.64.8
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[RHOAIENG-32595](https://issues.redhat.com/browse/RHOAIENG-32595)
Followup from https://github.com/opendatahub-io/odh-model-controller/pull/498/files - I missed changing the lint version in the Make file in order for `make lint` to run successfully locally 

## How Has This Been Tested?
`make lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated the linting tool used in development and CI to golangci-lint v1.64.8 to keep static analysis current and compatible with recent Go versions.
  - Aligns local and CI linting for more consistent results; no changes to build logic or runtime behavior.
  - No user-facing functionality affected; maintenance only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->