### PR TITLE
feat: add authPolicy resource

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -15,7 +15,11 @@ limitations under the License.
 
 package constants
 
-import "time"
+import (
+	"time"
+
+	"knative.dev/pkg/kmeta"
+)
 
 type KServeDeploymentMode string
 
@@ -154,22 +158,28 @@ const (
 )
 
 const (
-	AuthAudience         = "AUTH_AUDIENCE"
-	AuthorinoLabel       = "AUTHORINO_LABEL"
-	AuthPolicyNameSuffix = "-authn"
-	AuthPolicyGroup      = "kuadrant.io"
-	AuthPolicyVersion    = "v1"
-	AuthPolicyKind       = "AuthPolicy"
-	HTTPRouteNameSuffix  = "-kserve-route"
-	KubernetesAudience   = "https://kubernetes.default.svc"
+	AuthAudience            = "AUTH_AUDIENCE"
+	AuthorinoLabel          = "AUTHORINO_LABEL"
+	AuthPolicyNameSuffix    = "-authn"
+	AuthPolicyGroup         = "kuadrant.io"
+	AuthPolicyVersion       = "v1"
+	AuthPolicyKind          = "AuthPolicy"
+	HTTPRouteNameSuffix     = "-kserve-route"
+	KubernetesAudience      = "https://kubernetes.default.svc"
+	DefaultGatewayName      = "openshift-ai-inference"
+	DefaultGatewayNamespace = "openshift-ingress"
 )
 
 func GetAuthPolicyName(llmisvcName string) string {
-	return llmisvcName + AuthPolicyNameSuffix
+	return kmeta.ChildName(llmisvcName, AuthPolicyNameSuffix)
+}
+
+func GetGatewayAuthPolicyName(gatewayName string) string {
+	return kmeta.ChildName(gatewayName, AuthPolicyNameSuffix)
 }
 
 func GetHTTPRouteName(llmisvcName string) string {
-	return llmisvcName + HTTPRouteNameSuffix
+	return kmeta.ChildName(llmisvcName, HTTPRouteNameSuffix)
 }
 
 func GetAuthPolicyGroupVersion() string {

--- a/internal/controller/resources/template/authpolicy_anonymous.yaml
+++ b/internal/controller/resources/template/authpolicy_anonymous.yaml
@@ -8,14 +8,10 @@ spec:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
     name: {{.HTTPRouteName}}
-  defaults:
-    strategy: merge
-    rules:
-      authentication:
-        anonymous:
-          metrics: false
-          priority: 0
-      authorization:
-        allow:
-          metrics: false
-          priority: 0
+  rules:
+    authentication:
+      public:
+        anonymous: {}
+        metrics: false
+        priority: 0
+

--- a/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
@@ -2,42 +2,33 @@ apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: {{.Name}}
-  namespace: {{.Namespace}}
+  namespace: {{.GatewayNamespace}}
 spec:
   targetRef:
-    group: "gateway.networking.k8s.io"
-    kind: "HTTPRoute"
-    name: {{.HTTPRouteName}}
-  defaults:
-    strategy: merge
-    rules:
-      authentication:
-        kubernetes-user:
-          credentials:
-            authorizationHeader: {}
-          kubernetesTokenReview:
-            audiences: {{.AudiencesJSON}}
-          metrics: false
-          priority: 0
-      authorization:
-        kubernetes-rbac:
-          kubernetesSubjectAccessReview:
-            resourceAttributes:
-              group:
-                value: "serving.kserve.io"
-              version:
-                value: "v1alpha1"
-              name:
-                value: {{.LLMInferenceServiceName}}
-              namespace:
-                value: {{.Namespace}}
-              resource:
-                value: llminferenceservices
-              subresource:
-                value: ""
-              verb:
-                value: get
-            user:
-              selector: auth.identity.user.username
-          metrics: false
-          priority: 0
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{.GatewayName}}
+  rules:
+    authentication:
+      kubernetes-user:
+        kubernetesTokenReview:
+          audiences: {{.AudiencesJSON}}
+    authorization:
+      tier-access:
+        kubernetesSubjectAccessReview:
+          user:
+            expression: auth.identity.user.username
+          authorizationGroups:
+            expression: auth.identity.user.groups
+          resourceAttributes:
+            group:
+              value: serving.kserve.io
+            resource:
+              value: llminferenceservices
+            namespace:
+              expression: request.path.split("/")[1]
+            name:
+              expression: request.path.split("/")[2]
+            verb:
+              value: get
+        priority: 1

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -61,14 +61,9 @@ func GetDeploymentModeForKServeResource(ctx context.Context, cli client.Client, 
 		}
 	} else {
 		// There is no explicit deployment mode using an annotation, determine the default from configmap
-		controllerNs := os.Getenv("POD_NAMESPACE")
-		inferenceServiceConfigMap := &corev1.ConfigMap{}
-		err := cli.Get(ctx, client.ObjectKey{
-			Namespace: controllerNs,
-			Name:      KserveConfigMapName,
-		}, inferenceServiceConfigMap)
+		inferenceServiceConfigMap, err := GetInferenceServiceConfigMap(ctx, cli)
 		if err != nil {
-			return "", fmt.Errorf("error getting configmap 'inferenceservice-config'. %w", err)
+			return "", err
 		}
 		var deployData map[string]interface{}
 		if err = json.Unmarshal([]byte(inferenceServiceConfigMap.Data["deploy"]), &deployData); err != nil {
@@ -495,4 +490,39 @@ func GetAuthAudience(defaultAudience string) []string {
 		audiences[i] = strings.TrimSpace(audiences[i])
 	}
 	return audiences
+}
+
+// GetInferenceServiceConfigMap retrieves the KServe inference service configuration ConfigMap
+func GetInferenceServiceConfigMap(ctx context.Context, cli client.Client) (*corev1.ConfigMap, error) {
+	controllerNs := os.Getenv("POD_NAMESPACE")
+	inferenceServiceConfigMap := &corev1.ConfigMap{}
+	err := cli.Get(ctx, client.ObjectKey{
+		Namespace: controllerNs,
+		Name:      KserveConfigMapName,
+	}, inferenceServiceConfigMap)
+	if err != nil {
+		return nil, fmt.Errorf("error getting configmap 'inferenceservice-config'. %w", err)
+	}
+	return inferenceServiceConfigMap, nil
+}
+
+// GetGatewayInfoFromConfigMap parses the gateway namespace and name from the inference service ConfigMap
+func GetGatewayInfoFromConfigMap(ctx context.Context, cli client.Client) (namespace, name string, err error) {
+	configMap, err := GetInferenceServiceConfigMap(ctx, cli)
+	if err != nil {
+		return "", "", err
+	}
+
+	if ingressData := configMap.Data["ingress"]; ingressData != "" {
+		var config map[string]any
+		if json.Unmarshal([]byte(ingressData), &config) == nil {
+			if gateway, ok := config["kserveIngressGateway"].(string); ok {
+				if parts := strings.Split(gateway, "/"); len(parts) == 2 {
+					return parts[0], parts[1], nil
+				}
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("failed to parse gateway info from configmap")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add AuthPolicy resource support for model serving authentication
- Implement AuthPolicy controller with anonymous and user-defined authentication modes
- Include comprehensive test coverage and YAML templates for different auth scenarios
- Extend utility functions and constants to support AuthPolicy resource management

This is a sliced pr from https://github.com/opendatahub-io/odh-model-controller/pull/512

Following PR will include
- refactoring authConfig/inferenceGraph to use constants.go and utils.go.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds authentication policy management for inference services with user-defined and anonymous modes.
  - Per-service toggle to enable/disable anonymous access.
  - Generates auth policies per gateway for user-defined mode or a single anonymous policy per service.
  - Configurable token audiences via AUTH_AUDIENCE (comma-separated) with sensible gateway/name defaults.

- Chores
  - Reads gateway configuration from cluster config to determine policy placement.

- Tests
  - Expanded coverage for detection, template rendering, error handling, and audience propagation.

- Notes
  - No breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->