### PR TITLE
feat: add authPolicy comparator

### DIFF
--- a/internal/controller/comparators/authpolicy_comparator.go
+++ b/internal/controller/comparators/authpolicy_comparator.go
@@ -1,0 +1,65 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparators
+
+import (
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetAuthPolicyComparator() ResourceComparator {
+	return func(deployed client.Object, requested client.Object) bool {
+		deployedAP, dok := deployed.(*unstructured.Unstructured)
+		requestedAP, rok := requested.(*unstructured.Unstructured)
+		if !dok || !rok || deployedAP == nil || requestedAP == nil {
+			return false
+		}
+
+		// Compare spec and labels
+		deployedSpec, f1, err1 := unstructured.NestedMap(deployedAP.Object, "spec")
+		requestedSpec, f2, err2 := unstructured.NestedMap(requestedAP.Object, "spec")
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		if !f1 {
+			deployedSpec = map[string]interface{}{}
+		}
+		if !f2 {
+			requestedSpec = map[string]interface{}{}
+		}
+
+		return reflect.DeepEqual(deployedSpec, requestedSpec) &&
+			reflect.DeepEqual(filterLabels(deployedAP.GetLabels()), filterLabels(requestedAP.GetLabels()))
+	}
+}
+
+func filterLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		if k == "kubectl.kubernetes.io/last-applied-configuration" ||
+			strings.HasPrefix(k, "app.kubernetes.io/managed-by") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/internal/controller/comparators/authpolicy_comparator.go
+++ b/internal/controller/comparators/authpolicy_comparator.go
@@ -22,11 +22,12 @@ import (
 )
 
 func GetAuthPolicyComparator() ResourceComparator {
-	return func(deployed client.Object, requested client.Object) bool {
-		deployedAP := deployed.(*unstructured.Unstructured)
-		requestedAP := requested.(*unstructured.Unstructured)
+	return func(current client.Object, desired client.Object) bool {
+		currentAP := current.(*unstructured.Unstructured)
+		desiredAP := desired.(*unstructured.Unstructured)
 
-		return equality.Semantic.DeepDerivative(deployedAP.Object["spec"], requestedAP.Object["spec"]) &&
-			equality.Semantic.DeepDerivative(deployedAP.GetLabels(), requestedAP.GetLabels())
+		return equality.Semantic.DeepDerivative(desiredAP.Object["spec"], currentAP.Object["spec"]) &&
+			equality.Semantic.DeepDerivative(desiredAP.GetLabels(), currentAP.GetLabels()) &&
+			equality.Semantic.DeepDerivative(desiredAP.GetAnnotations(), currentAP.GetAnnotations())
 	}
 }

--- a/internal/controller/comparators/authpolicy_comparator_test.go
+++ b/internal/controller/comparators/authpolicy_comparator_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func createAuthPolicy(appLabel, strategy string) *unstructured.Unstructured {
+func createAuthPolicy(appLabel string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "kuadrant.io/v1",
@@ -36,14 +36,37 @@ func createAuthPolicy(appLabel, strategy string) *unstructured.Unstructured {
 			},
 			"spec": map[string]interface{}{
 				"defaults": map[string]interface{}{
-					"strategy": strategy,
+					"strategy": "atomic",
 				},
 			},
 		},
 	}
 }
 
-func createAuthPolicyWithoutLabels(strategy string) *unstructured.Unstructured {
+func createAuthPolicyWithExtraLabels(appLabel string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kuadrant.io/v1",
+			"kind":       "AuthPolicy",
+			"metadata": map[string]interface{}{
+				"name":      "test-authn",
+				"namespace": "test-ns",
+				"labels": map[string]interface{}{
+					"app": appLabel,
+					"kubectl.kubernetes.io/last-applied-configuration": "...",
+					"app.kubernetes.io/managed-by":                     "controller",
+				},
+			},
+			"spec": map[string]interface{}{
+				"defaults": map[string]interface{}{
+					"strategy": "atomic",
+				},
+			},
+		},
+	}
+}
+
+func createAuthPolicyWithoutLabels() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "kuadrant.io/v1",
@@ -54,7 +77,76 @@ func createAuthPolicyWithoutLabels(strategy string) *unstructured.Unstructured {
 			},
 			"spec": map[string]interface{}{
 				"defaults": map[string]interface{}{
-					"strategy": strategy,
+					"strategy": "atomic",
+				},
+			},
+		},
+	}
+}
+
+func createComplexAuthPolicy(gatewayName, authType string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kuadrant.io/v1",
+			"kind":       "AuthPolicy",
+			"metadata": map[string]interface{}{
+				"name":      "llm-gateway-authn",
+				"namespace": "openshift-ingress",
+				"labels": map[string]interface{}{
+					"app": "test",
+				},
+			},
+			"spec": map[string]interface{}{
+				"targetRef": map[string]interface{}{
+					"group": "gateway.networking.k8s.io",
+					"kind":  "Gateway",
+					"name":  gatewayName,
+				},
+				"defaults": map[string]interface{}{
+					"rules": map[string]interface{}{
+						"authentication": map[string]interface{}{
+							"kubernetes-user": map[string]interface{}{
+								"credentials": map[string]interface{}{
+									"authorizationHeader": map[string]interface{}{},
+								},
+								"kubernetesTokenReview": map[string]interface{}{
+									"audiences": []interface{}{
+										"https://rh-oidc.s3.us-east-1.amazonaws.com/27bd6cg0vs7nn08mue83fbof94dj4m9a",
+									},
+								},
+							},
+						},
+						"authorization": map[string]interface{}{
+							authType: map[string]interface{}{
+								"kubernetesSubjectAccessReview": map[string]interface{}{
+									"user": map[string]interface{}{
+										"expression": "auth.identity.user.username",
+									},
+									"authorizationGroups": map[string]interface{}{
+										"expression": "auth.identity.user.groups",
+									},
+									"resourceAttributes": map[string]interface{}{
+										"group": map[string]interface{}{
+											"value": "serving.kserve.io",
+										},
+										"resource": map[string]interface{}{
+											"value": "llminferenceservices",
+										},
+										"namespace": map[string]interface{}{
+											"expression": "request.path.split(\"/\")[1]",
+										},
+										"name": map[string]interface{}{
+											"expression": "request.path.split(\"/\")[2]",
+										},
+										"verb": map[string]interface{}{
+											"value": "get",
+										},
+									},
+								},
+								"priority": 1,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -65,40 +157,64 @@ func TestAuthPolicyComparator(t *testing.T) {
 	comparator := comparators.GetAuthPolicyComparator()
 
 	tests := []struct {
-		name     string
-		policy1  *unstructured.Unstructured
-		policy2  *unstructured.Unstructured
-		expected bool
+		name      string
+		deployed  *unstructured.Unstructured
+		requested *unstructured.Unstructured
+		expected  bool
 	}{
 		{
-			name:     "identical AuthPolicies should return true",
-			policy1:  createAuthPolicy("test", "atomic"),
-			policy2:  createAuthPolicy("test", "atomic"),
-			expected: true,
+			name:      "identical AuthPolicies should return true",
+			deployed:  createAuthPolicy("test"),
+			requested: createAuthPolicy("test"),
+			expected:  true,
 		},
 		{
-			name:     "different specs should return false",
-			policy1:  createAuthPolicy("test", "atomic"),
-			policy2:  createAuthPolicy("test", "merge"),
-			expected: false,
+			name:      "different labels should return false",
+			deployed:  createAuthPolicy("test"),
+			requested: createAuthPolicy("different"),
+			expected:  false,
 		},
 		{
-			name:     "different labels should return false",
-			policy1:  createAuthPolicy("test", "atomic"),
-			policy2:  createAuthPolicy("different", "atomic"),
-			expected: false,
+			name:      "policies without labels should return true when specs match",
+			deployed:  createAuthPolicyWithoutLabels(),
+			requested: createAuthPolicyWithoutLabels(),
+			expected:  true,
 		},
 		{
-			name:     "policies without labels should return true when specs match",
-			policy1:  createAuthPolicyWithoutLabels("atomic"),
-			policy2:  createAuthPolicyWithoutLabels("atomic"),
-			expected: true,
+			name:      "deployed with extra labels - DeepDerivative checks if requested is subset of deployed",
+			deployed:  createAuthPolicyWithExtraLabels("test"),
+			requested: createAuthPolicy("test"),
+			expected:  false,
+		},
+		{
+			name:      "requested with extra labels - deployed cannot contain all requested fields",
+			deployed:  createAuthPolicy("test"),
+			requested: createAuthPolicyWithExtraLabels("test"),
+			expected:  true,
+		},
+		{
+			name:      "complex AuthPolicy with different authorization types should return false",
+			deployed:  createComplexAuthPolicy("openshift-ai-inference", "tier-access"),
+			requested: createComplexAuthPolicy("openshift-ai-inference", "admin-access"),
+			expected:  false,
+		},
+		{
+			name:      "complex AuthPolicy with identical structure should return true",
+			deployed:  createComplexAuthPolicy("openshift-ai-inference", "tier-access"),
+			requested: createComplexAuthPolicy("openshift-ai-inference", "tier-access"),
+			expected:  true,
+		},
+		{
+			name:      "complex AuthPolicy with different gateway names should return false",
+			deployed:  createComplexAuthPolicy("gateway-1", "tier-access"),
+			requested: createComplexAuthPolicy("gateway-2", "tier-access"),
+			expected:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := comparator(tt.policy1, tt.policy2)
+			result := comparator(tt.deployed, tt.requested)
 			if result != tt.expected {
 				t.Errorf("comparator() = %v, expected %v", result, tt.expected)
 			}

--- a/internal/controller/comparators/authpolicy_comparator_test.go
+++ b/internal/controller/comparators/authpolicy_comparator_test.go
@@ -1,0 +1,107 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package comparators_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/comparators"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func createAuthPolicy(appLabel, strategy string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kuadrant.io/v1",
+			"kind":       "AuthPolicy",
+			"metadata": map[string]interface{}{
+				"name":      "test-authn",
+				"namespace": "test-ns",
+				"labels": map[string]interface{}{
+					"app": appLabel,
+				},
+			},
+			"spec": map[string]interface{}{
+				"defaults": map[string]interface{}{
+					"strategy": strategy,
+				},
+			},
+		},
+	}
+}
+
+func createAuthPolicyWithoutLabels(strategy string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "kuadrant.io/v1",
+			"kind":       "AuthPolicy",
+			"metadata": map[string]interface{}{
+				"name":      "test-authn",
+				"namespace": "test-ns",
+			},
+			"spec": map[string]interface{}{
+				"defaults": map[string]interface{}{
+					"strategy": strategy,
+				},
+			},
+		},
+	}
+}
+
+func TestAuthPolicyComparator(t *testing.T) {
+	comparator := comparators.GetAuthPolicyComparator()
+
+	tests := []struct {
+		name     string
+		policy1  *unstructured.Unstructured
+		policy2  *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name:     "identical AuthPolicies should return true",
+			policy1:  createAuthPolicy("test", "atomic"),
+			policy2:  createAuthPolicy("test", "atomic"),
+			expected: true,
+		},
+		{
+			name:     "different specs should return false",
+			policy1:  createAuthPolicy("test", "atomic"),
+			policy2:  createAuthPolicy("test", "merge"),
+			expected: false,
+		},
+		{
+			name:     "different labels should return false",
+			policy1:  createAuthPolicy("test", "atomic"),
+			policy2:  createAuthPolicy("different", "atomic"),
+			expected: false,
+		},
+		{
+			name:     "policies without labels should return true when specs match",
+			policy1:  createAuthPolicyWithoutLabels("atomic"),
+			policy2:  createAuthPolicyWithoutLabels("atomic"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := comparator(tt.policy1, tt.policy2)
+			if result != tt.expected {
+				t.Errorf("comparator() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/comparators/authpolicy_comparator_test.go
+++ b/internal/controller/comparators/authpolicy_comparator_test.go
@@ -84,7 +84,7 @@ func createAuthPolicyWithoutLabels() *unstructured.Unstructured {
 	}
 }
 
-func createAuthPolicyWithAnnotations(appLabel string, annotations map[string]string) *unstructured.Unstructured {
+func createAuthPolicyWithAnnotations(annotations map[string]string) *unstructured.Unstructured {
 	annotationsInterface := make(map[string]interface{})
 	for k, v := range annotations {
 		annotationsInterface[k] = v
@@ -95,10 +95,10 @@ func createAuthPolicyWithAnnotations(appLabel string, annotations map[string]str
 			"apiVersion": "kuadrant.io/v1",
 			"kind":       "AuthPolicy",
 			"metadata": map[string]interface{}{
-				"name":        "test-authn",
-				"namespace":   "test-ns",
+				"name":      "test-authn",
+				"namespace": "test-ns",
 				"labels": map[string]interface{}{
-					"app": appLabel,
+					"app": "test",
 				},
 				"annotations": annotationsInterface,
 			},
@@ -239,11 +239,11 @@ func TestAuthPolicyComparator(t *testing.T) {
 		},
 		{
 			name: "policies with identical annotations should return true",
-			deployed: createAuthPolicyWithAnnotations("test", map[string]string{
+			deployed: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value1",
 				"test.io/config":         "enabled",
 			}),
-			requested: createAuthPolicyWithAnnotations("test", map[string]string{
+			requested: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value1",
 				"test.io/config":         "enabled",
 			}),
@@ -251,31 +251,31 @@ func TestAuthPolicyComparator(t *testing.T) {
 		},
 		{
 			name: "policies with different annotation values should return false",
-			deployed: createAuthPolicyWithAnnotations("test", map[string]string{
+			deployed: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value1",
 			}),
-			requested: createAuthPolicyWithAnnotations("test", map[string]string{
+			requested: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value2",
 			}),
 			expected: false,
 		},
 		{
 			name: "deployed with extra annotations - DeepDerivative checks if requested is subset of deployed",
-			deployed: createAuthPolicyWithAnnotations("test", map[string]string{
+			deployed: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation":             "value1",
 				"kubectl.kubernetes.io/last-applied": "...",
 			}),
-			requested: createAuthPolicyWithAnnotations("test", map[string]string{
+			requested: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value1",
 			}),
 			expected: true,
 		},
 		{
 			name: "requested with extra annotations - deployed cannot contain all requested fields",
-			deployed: createAuthPolicyWithAnnotations("test", map[string]string{
+			deployed: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation": "value1",
 			}),
-			requested: createAuthPolicyWithAnnotations("test", map[string]string{
+			requested: createAuthPolicyWithAnnotations(map[string]string{
 				"example.com/annotation":             "value1",
 				"kubectl.kubernetes.io/last-applied": "...",
 			}),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add AuthPolicy comparator for resource comparison and management
- Implement comprehensive comparison logic for AuthPolicy resources
- Include thorough test coverage with 107 test lines for comparator functionality
- Extend controller comparator framework to support AuthPolicy resource operations

This is a sliced pr from https://github.com/opendatahub-io/odh-model-controller/pull/512

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] JIRA(s) are linked in the PR description
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AuthPolicy synchronization by comparing spec, labels, and annotations with subset-aware matching so only meaningful differences trigger updates, reducing unnecessary reconciliations.

* **Tests**
  * Added comprehensive unit tests validating identical policies, spec mismatches, unlabeled policies, extra/missing labels and annotations, and complex nested policy scenarios to ensure comparator behavior across varied cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->