### PR TITLE
Add vllm-spyre-template configurations

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -126,6 +126,17 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.vllm-spyre-image
+    targets:
+      - select:
+          kind: Template
+          name: vllm-spyre-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.odh-model-controller
     targets:
       - select: 

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -12,4 +12,5 @@ vllm-cuda-image=quay.io/opendatahub/vllm:fast
 vllm-cpu-image=quay.io/opendatahub/vllm:fast-cpu
 vllm-gaudi-image=quay.io/opendatahub/vllm:fast-gaudi
 vllm-rocm-image=quay.io/opendatahub/vllm:fast-rocm
+vllm-spyre-image=quay.io/opendatahub/vllm:fast-spyre
 guardrails-detector-huggingface-runtime-image=quay.io/trustyai/guardrails-detector-huggingface-runtime:latest

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -14,5 +14,6 @@ resources:
   - vllm-rocm-template.yaml
   - vllm-gaudi-template.yaml
   - vllm-cpu-template.yaml
+  - vllm-spyre-template.yaml
   - caikit-standalone-template.yaml
   - hf-detector-template.yaml

--- a/config/runtimes/vllm-spyre-template.yaml
+++ b/config/runtimes/vllm-spyre-template.yaml
@@ -1,0 +1,65 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: vLLM ServingRuntime to support IBM Spyre
+    openshift.io/display-name: vLLM Spyre AI Accelerator ServingRuntime for KServe
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM Spyre AI Accelerator ServingRuntime with KServe in Red Hat OpenShift AI
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+    opendatahub.io/model-type: '["generative"]'
+  name: vllm-spyre-runtime-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: vllm-spyre-runtime
+      annotations:
+        openshift.io/display-name: vLLM Spyre AI Accelerator ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["ibm.com/aiu_pf"]'
+        opendatahub.io/runtime-version: 'v0.9.1.0'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '8080'
+      containers:
+        - args:
+            - /mnt/models
+            - '--port=8000'
+            - '--served-model-name={{.Name}}'
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+            - name: FLEX_COMPUTE
+              value: SENTIENT
+            - name: FLEX_DEVICE
+              value: PF
+            - name: TOKENIZERS_PARALLELISM
+              value: 'false'
+            - name: DTLOG_LEVEL
+              value: error
+            - name: TORCH_SENDNN_LOG
+              value: CRITICAL
+            - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+              value: '4'
+            - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+              value: '1024'
+            - name: VLLM_SPYRE_WARMUP_NEW_TOKENS
+              value: '256'
+          image: $(vllm-spyre-image)
+          name: kserve-container
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: vLLM

--- a/config/runtimes/vllm-spyre-template.yaml
+++ b/config/runtimes/vllm-spyre-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre AI Accelerator ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/aiu_pf"]'
-        opendatahub.io/runtime-version: 'v0.9.1.0'
+        opendatahub.io/runtime-version: 'v0.10.1.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Jira: https://issues.redhat.com/browse/RHOAIENG-27963 - Add ServingRuntime template for IBM Spyre in RHOAI
## Description
<!--- Describe your changes in detail -->
This PR adds ServingRuntime template for IBM spyre on x86 in RHOAI. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The template has been successfully validated and deployments are functioning as expected on spyre cluster. Both Serverless and Raw InferenceService have tested against the ServingRuntime template.

```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  annotations:
    openshift.io/display-name: granite-3-1-8b-instruct
    serving.knative.openshift.io/enablePassthrough: 'true'
    serving.kserve.io/deploymentMode: Serverless
    sidecar.istio.io/inject: 'true'
    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
  name: granite-3-1-8b-instruct
  namespace: ibm-spyre-tp
  labels:
    opendatahub.io/dashboard: 'true'
spec:
  predictor:
    imagePullSecrets:
      - name: oci-registry
    maxReplicas: 1
    minReplicas: 1
    model:
      modelFormat:
        name: vLLM
      name: ''
      resources:
        limits:
          ibm.com/aiu_pf: '1'
        requests:
          ibm.com/aiu_pf: '1'
      runtime: vllm-spyre-runtime
      storageUri: 'oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct:1.5'
    schedulerName: aiu-scheduler
    tolerations:
      - effect: NoSchedule
        key: ibm.com/aiu_pf
        operator: Exists
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work