### PR TITLE
Add Konflux ODH tag bump automation to our existing release workflow.

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -3,9 +3,19 @@ name: Create Tag and Release with Changelog
 on:
   workflow_dispatch:
     inputs:
-      tag_name:
-        description: 'Tag name for the new release'
+      tag_name: # The new release tag to be created and used as the search value.
+        description: 'New release tag (e.g., odh-v2.35)'
         required: true
+        type: string
+      next_odh_tag: # The next ODH tag to replace the current one in the Konflux files.
+        description: 'Next development cycle tag: (e.g., odh-v2.36)'
+        required: true
+        type: string
+    #
+    # Note: This workflow assumes the release tag and image tags are in sync.
+    #       'tag_name' is used to create the release and as the value to find in konflux files.
+    #       'next_odh_tag' provides the new value to set.
+    #
 
 permissions:
   contents: write
@@ -101,3 +111,43 @@ jobs:
           files: bin/*
           generate_release_notes: true
           name: ${{ github.event.inputs.tag_name }}
+  
+  # This job updates the ODH tag in the specified file and commits the change
+  bump-odh-tag: 
+    name: Bump ODH Tag for Next Release
+    runs-on: ubuntu-latest
+    needs: [fetch-tag, update-params-env, changelog]
+    permissions:
+      contents: write # Re-adding to ensure write permission.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }} # This will resolve the detached HEAD issue that code rabbit brought up.
+      
+      - name: Update odh-model-controller-push.yaml with next ODH tag
+        run: |
+          CURRENT_TAG="${{ github.event.inputs.tag_name }}"
+          NEXT_TAG="${{ github.event.inputs.next_odh_tag }}"
+          
+          echo "Updating ODH tag from $CURRENT_TAG to $NEXT_TAG..."
+          
+          # Using sed to replace the current ODH tag with the next one,
+          # anchored to the image name to prevent over-matching.
+          sed -i "s|odh-model-controller:${CURRENT_TAG}|odh-model-controller:${NEXT_TAG}|g" .tekton/odh-model-controller-push.yaml
+
+          echo "Update complete."
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .tekton/odh-model-controller-push.yaml
+          
+          # Check if there are any changes to commit
+          if [[ -z "$(git status --porcelain)" ]]; then 
+            echo "No changes to commit. Exiting."
+          else
+            git commit -m "chore(konflux): Bump ODH release tag to ${{ github.event.inputs.next_odh_tag }}"
+            git push
+          fi


### PR DESCRIPTION
## Description
This PR, as per [RHOAIENG-31952](https://issues.redhat.com/browse/RHOAIENG-31952), adds a new job to our existing `create-release.yaml` workflow to automate the process of updating the ODH release tag in the Konflux build files. This automation will run at the end of the ODH release workflow, preparing the repository for the next development cycle. It uses two manual inputs (`tag_name` and `next_odh_tag`) to align with the team's approach of keeping release tags and image tags in sync. The Konflux tag is updated from `tag_name` to `next_odh_tag` in the `.tekton/odh-model-controller-push.yaml` file, and the changes are committed directly to the branch.

The following improvements were also made based on code review:
- The checkout step now explicitly checks out the correct branch to avoid a detached HEAD.
- The `sed` command is now anchored to prevent unintended over-matching.
- A conditional check was added to prevent the workflow from failing if there are no file changes to commit.

## How Has This Been Tested?
This change was tested in a dedicated test environment on a separate branch, `rhoaieng-31952-test`, to prevent any impact on the main codebase.

- **Testing Environment:** A dedicated GitHub branch was created on the main repository (`rhoaieng-31952-test`). The workflow was run on this branch.
- **Test Ran:** The workflow was manually triggered using the `workflow_dispatch` event with the following inputs:
  - `tag_name:` `odh-v2.35`
  - `next_odh_tag:` `odh-v2.36`

- **Verification:** After the workflow completed, the `.tekton/odh-model-controller-push.yaml` file was manually checked. The value field was successfully updated from `quay.io/opendatahub/odh-model-controller:odh-v2.35` to `quay.io/opendatahub/odh-model-controller:odh-v2.36` and a release named `odh-v2.35` was made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added a required typed "next ODH tag" release input and clarified its relationship with the release tag.
  * Expanded workflow permissions to allow package publishing and creating pull requests.
  * Added a public post-release job that updates the development ODH tag for the next cycle, commits and pushes the change, and runs after tag fetch and changelog steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->