### PR TITLE
refactor: use constants for AuthType

### DIFF
--- a/internal/controller/resources/authconfig_test.go
+++ b/internal/controller/resources/authconfig_test.go
@@ -13,6 +13,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/resources"
 )
 
@@ -88,7 +89,7 @@ var _ = When("InferenceService is ready", func() {
 		It("should resolve UserDefined template for InferenceService", func() {
 			ac, err := resources.NewStaticTemplateLoader().Load(
 				context.Background(),
-				resources.UserDefined,
+				constants.UserDefined,
 				&dummyIsvc)
 
 			Expect(err).To(Succeed())
@@ -98,7 +99,7 @@ var _ = When("InferenceService is ready", func() {
 		It("should default to kubernetes.default.svc Audience", func() {
 			ac, err := resources.NewStaticTemplateLoader().Load(
 				context.Background(),
-				resources.UserDefined,
+				constants.UserDefined,
 				&dummyIsvc)
 
 			Expect(err).To(Succeed())
@@ -113,7 +114,7 @@ var _ = When("InferenceService is ready", func() {
 
 			ac, err := resources.NewStaticTemplateLoader().Load(
 				context.Background(),
-				resources.UserDefined,
+				constants.UserDefined,
 				&dummyIsvc)
 
 			Expect(err).To(Succeed())
@@ -123,7 +124,7 @@ var _ = When("InferenceService is ready", func() {
 		It("should default to opendatahub.io.. AuthorinoLabel", func() {
 			ac, err := resources.NewStaticTemplateLoader().Load(
 				context.Background(),
-				resources.UserDefined,
+				constants.UserDefined,
 				&dummyIsvc)
 
 			Expect(err).To(Succeed())
@@ -138,7 +139,7 @@ var _ = When("InferenceService is ready", func() {
 
 			ac, err := resources.NewStaticTemplateLoader().Load(
 				context.Background(),
-				resources.UserDefined,
+				constants.UserDefined,
 				&dummyIsvc)
 
 			Expect(err).To(Succeed())

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -99,7 +99,7 @@ func (r *InferenceGraphReconciler) reconcileAuthConfig(ctx context.Context, logg
 		logger.V(1).Info("Skipping AuthConfig reconciliation, authorization is not enabled")
 
 		authType := r.detector.Detect(ctx, ig.GetAnnotations())
-		if authType == resources.UserDefined {
+		if authType == constants.UserDefined {
 			// Raise an event that the IG wants auth enabled, but the auth stack is missing
 			r.Recorder.Eventf(ig, v1.EventTypeWarning, constants.AuthUnavailable, "InferenceGraph %s is requiring auth, but the auth stack is not available", ig.GetName())
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
simple refactor to use contants for AuthType for existing code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized authentication type constants across the app for consistent handling and easier maintenance.
  - Preserved existing behavior for auth template selection and related events; no user-facing changes expected.

- Tests
  - Updated tests to use the new centralized authentication constants; test outcomes remain the same.

- Chores
  - Cleaned up redundant local constants and aligned imports with the centralized approach.

No functional changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->