### PR TITLE
chore: pins go version using go.mod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - incubating
       - main
+      - stable-*
     tags:
       - 'latest'
       - 'odh-v*'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |


### PR DESCRIPTION
Instead of using explicit version in github action we can rely on what is defined in `go.mod` file. This way we will have jobs up-to-date using single place to define toolchain version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI build pipeline now also runs for branches matching stable-*, ensuring release branch builds are automatically validated.
  * Lint and end-to-end test pipelines now derive the Go toolchain version from the project configuration, improving consistency and reducing manual version maintenance.
  * Overall CI reliability improved by aligning workflows to the declared project version and expanding branch coverage. No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->