### PR TITLE
ci(manifests): validates kustomize manifest

### DIFF
--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -1,0 +1,29 @@
+name: Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-manifests:
+    name: Validate Kustomize manifests
+    timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-validate-manifests
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Install kustomize
+      run: |
+        set -euo pipefail
+        curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.7.1
+        sudo mv kustomize /usr/local/bin/
+
+    - name: Validate Kustomize manifests
+      run: |
+        set -euo pipefail
+        ./hack/validate-manifests.sh

--- a/hack/validate-manifests.sh
+++ b/hack/validate-manifests.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bold='\033[1m'
+normal='\033[0m'
+underline='\033[4m'
+
+validate_kustomization() {
+    local kustomization_file="$1"
+    local project_root="${2:-$(git rev-parse --show-toplevel)}"
+    
+    local dir
+    dir=$(dirname "$kustomization_file")
+    local relative_path=${kustomization_file#"$project_root/"}
+    local message="${bold}Validating${normal} ${underline}$relative_path${normal}"
+
+    echo -n -e "⏳ ${message}"
+    if output=$(kustomize build --load-restrictor LoadRestrictionsNone --stack-trace "$dir" 2>&1); then
+        echo -e "\r✅ ${message}"
+        return 0
+    else
+        echo -e "\r❌ ${message}"
+        echo "$output"
+        return 1
+    fi
+}
+
+validate_all() {
+    local project_root="$1"; shift
+    local ignore_paths=("$@")
+    local exit_code=0
+
+    while IFS= read -r -d '' kustomization_file; do
+        local skip=false
+        for ignore in "${ignore_paths[@]}"; do
+            if [[ "$kustomization_file" == "$project_root/$ignore"* ]]; then
+                skip=true
+                break
+            fi
+        done
+
+        if [[ $skip == true ]]; then
+            continue
+        fi
+
+        if ! validate_kustomization "$kustomization_file" "$project_root"; then
+            exit_code=1
+        fi
+    done < <(find "$project_root" -name "kustomization.yaml" -type f -print0)
+
+    return $exit_code
+}
+
+# When script is not sourced, but directly invoked
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+    ignore_paths=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --ignore)
+                shift
+                [[ $# -gt 0 ]] || { echo "Error: --ignore requires a path"; exit 1; }
+                ignore_paths+=("$1")
+                ;;
+            *)
+                echo "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    validate_all "$PROJECT_ROOT" "${ignore_paths[@]}"
+    exit $?
+fi


### PR DESCRIPTION
To ensure that our kustomize manifests are always valid, this PR brings a validation script and gh action to ensure that.

> [!IMPORTANT]
> This only checks if kustomize can process YAMLs, it does not mean it
can be successfully applied to the cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated validation workflow for configuration manifests that runs on pushes and pull requests.
  * Ensures required tooling is installed and validates all manifests consistently.
  * Provides clear, aggregated results with success/failure indicators and detailed error output for easier troubleshooting.
  * Supports excluding specified paths from validation when needed.
  * Fails the check if any manifest is invalid, improving reliability before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->