### PR TITLE
test(utils): temporarily accept 'Standard' and 'Knative' deploymentMode

### DIFF
--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -56,6 +56,7 @@ func GetDeploymentModeForKServeResource(ctx context.Context, cli client.Client, 
 			return constants.Serverless, nil
 		case string(constants.RawDeployment):
 			return constants.RawDeployment, nil
+		// TODO: Remove temporary alias mapping ("Standard"→RawDeployment, "Knative"→Serverless) post-RHOAI 3.0, with code refactor for new deployment modes.
 		case "Standard":
 			return constants.RawDeployment, nil
 		case "Knative":
@@ -81,6 +82,11 @@ func GetDeploymentModeForKServeResource(ctx context.Context, cli client.Client, 
 			return constants.Serverless, nil
 		case string(constants.RawDeployment):
 			return constants.RawDeployment, nil
+		// TODO: Remove temporary alias mapping ("Standard"→RawDeployment, "Knative"→Serverless) post-RHOAI 3.0, with code refactor for new deployment modes.
+		case "Standard":
+			return constants.RawDeployment, nil
+		case "Knative":
+			return constants.Serverless, nil
 		default:
 			return "", fmt.Errorf("the deployment mode '%s' of the Inference Service is invalid", defaultDeploymentMode)
 		}


### PR DESCRIPTION
Added temporary support in GetDeploymentModeForKServeResource:
- "Standard" → mapped to RawDeployment
- "Knative" → mapped to Serverless

This change is only to ensure KServe e2e RawDeployment tests pass. It is not intended as a permanent feature and should be removed or revised once upstream fixes are in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for “Standard” and “Knative” values in deployment mode annotations/configuration. “Standard” maps to raw deployment and “Knative” maps to serverless, offering clearer, user-friendly aliases. Behavior for defaults and invalid values remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->