### PR TITLE
remove cache for authPolicy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+
 	templatev1client "github.com/openshift/client-go/template/clientset/versioned"
 	istiov1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -271,11 +271,6 @@ func createManager(cfg *rest.Config, metricsAddr, probeAddr string,
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Secret{}: {
-					Label: labels.SelectorFromSet(labels.Set{
-						"opendatahub.io/managed": "true",
-					}),
-				},
-				&kuadrantv1.AuthPolicy{}: {
 					Label: labels.SelectorFromSet(labels.Set{
 						"opendatahub.io/managed": "true",
 					}),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If the Authpolicy crd is not installed, odh-model-controller is not running so I remove the Authpolicy cache part. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified controller cache configuration by removing label-based filtering for authentication policies. Authentication policies are now handled uniformly, which may change which policies are observed and reconciled, potentially affecting visibility and updates.

- Chores
  - Cleaned up related unused dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->