### PR TITLE
ci: uses go version from go.mod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.24'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |


### PR DESCRIPTION
Follow-up to #531