### PR TITLE
chore(image): corrects builder image syntax

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
When running docker build, following error is reported:

```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized capitalization in the multi-stage build instruction within the Containerfile, switching to uppercase “AS” for consistency with common conventions.
  - Improves readability and aligns with style expectations in build configurations.
  - No impact on features, performance, build behavior, or deployment processes.
  - Users should experience no functional changes; this is a cosmetic adjustment to maintain consistency across the build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->