### PR TITLE
change the authorinzation key name to avoid conflict with maas

### DIFF
--- a/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
@@ -16,7 +16,7 @@ spec:
         kubernetesTokenReview:
           audiences: {{.AudiencesJSON}}
     authorization:
-      tier-access:
+      inference-access:
         kubernetesSubjectAccessReview:
           user:
             expression: auth.identity.user.username


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
per title

https://issues.redhat.com/browse/RHOAIENG-34711

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed authorization policy field from "tier-access" to "inference-access". Update any configs, templates, and deployment manifests referencing the old name to avoid validation failures or misapplied access rules. This is not backward compatible; no other behavioral changes to authorization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->