### PR TITLE
fix: update or delete MaaS RBAC only when managed

### DIFF
--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -584,3 +584,21 @@ func GetMaaSRoleName(llmisvc *kservev1alpha1.LLMInferenceService) string {
 func GetMaaSRoleBindingName(llmisvc *kservev1alpha1.LLMInferenceService) string {
 	return kmeta.ChildName(llmisvc.Name, "-model-post-access-tier-binding")
 }
+
+func IsManagedResource(owner client.Object, resource client.Object) bool {
+	if resource.GetLabels()["app.kubernetes.io/managed-by"] != "odh-model-controller" {
+		return false
+	}
+
+	for _, ownerRef := range resource.GetOwnerReferences() {
+		if ownerRef.APIVersion == owner.GetObjectKind().GroupVersionKind().GroupVersion().String() &&
+			ownerRef.Kind == owner.GetObjectKind().GroupVersionKind().Kind &&
+			ownerRef.Name == owner.GetName() &&
+			ownerRef.UID == owner.GetUID() &&
+			ownerRef.Controller != nil && *ownerRef.Controller {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
These changes are for taking into account the possibility of user-owned Roles and RoleBindings related to MaaS RBAC: the resources are updated or deleted only when managed by the controller. The management state is determined when the resources have both a managed annotation, and when the owner reference is properly set.

Follow-up of: https://github.com/opendatahub-io/odh-model-controller/pull/534#discussion_r2403508702
Related to https://issues.redhat.com/browse/RHOAIENG-34707

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operator now ignores unmanaged Roles/RoleBindings and avoids modifying resources it doesn't own.
  * Roles/RoleBindings are no longer created when the required tier annotation is absent.
  * Managed Roles/RoleBindings are automatically removed when the tier annotation is deleted.

* **Tests**
  * Expanded coverage for multiple services, ownership checks, and annotation-removal cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->