### PR TITLE
fix: add missing RBAC for querying Gateways

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/finalizers
+  verbs:
+  - update
+- apiGroups:
   - keda.sh
   resources:
   - triggerauthentications

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -114,6 +114,8 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 // +kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/finalizers,verbs=update
 
 func (r *LLMInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	b := ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
The `KserveAuthPolicyReconciler` (in `kserve_authpolicy_reconciler.go`), related to the authentication feature for LLMIsvc requires fetching Gateway resources (Gw API) to properly set OwnerReferences to the Kuadrant AuthPolicies. However, the needed privileges are missing, leading to reconcile errors.

This is adding the missing privileges.

## How Has This Been Tested?
Manual testing: Creating an LLMIsvc is enough to see the errors in the logs. Kuadrant must be installed to hit the issue.

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Controller can now interact with Kubernetes Gateway API resources (Gateways and their finalizers) by listing, watching, and updating as needed.
- Chores
  - Expanded RBAC permissions to include Gateway resources, adding list/watch for Gateways and update for finalizers.
  - Aligned controller setup with the new permissions; no changes to reconciliation logic or user-facing behavior.
  - Existing permissions remain unchanged; only additive adjustments to support Gateway resource operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->