### PR TITLE
chore: Removing service mesh related checks from the inferenceservice webhook

### DIFF
--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook_test.go
@@ -18,21 +18,17 @@ package v1beta1
 
 import (
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
-const InferenceServiceConfigPath1 = "../../../controller/serving/testdata/configmaps/inferenceservice-config.yaml"
-
 var _ = Describe("InferenceService validator Webhook", func() {
-	var meshNamespace, appsNamespace string
+	var appsNamespace string
 
 	createInferenceService := func(namespace, name string) *kservev1beta1.InferenceService {
 		inferenceService := &kservev1beta1.InferenceService{}
@@ -46,7 +42,6 @@ var _ = Describe("InferenceService validator Webhook", func() {
 	}
 
 	BeforeEach(func() {
-		_, meshNamespace = utils.GetIstioControlPlaneName(ctx, k8sClient)
 		appsNamespace, _ = utils.GetApplicationNamespace(ctx, k8sClient)
 	})
 
@@ -71,106 +66,10 @@ var _ = Describe("InferenceService validator Webhook", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("Should not allow the Inference Service in the ServiceMesh namespace", func() {
-			isvc := createInferenceService(meshNamespace, "test-isvc")
-			_, err := validator.ValidateCreate(ctx, isvc)
-			Expect(err).To(HaveOccurred())
-		})
-
 		It("Should not allow the Inference Service in the ApplicationsNamespace namespace", func() {
 			isvc := createInferenceService(appsNamespace, "test-isvc")
 			_, err := validator.ValidateCreate(ctx, isvc)
 			Expect(err).To(HaveOccurred())
-		})
-
-		It("Should not allow the Inference Service in the knative-serving namespace", func() {
-			testNs := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "knative-serving",
-					Namespace: "knative-serving",
-				},
-			}
-			Expect(k8sClient.Create(ctx, testNs)).Should(Succeed())
-			isvc := createInferenceService(testNs.Name, "test-isvc")
-			_, err := validator.ValidateCreate(ctx, isvc)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("When creating InferenceService under Defaulting Webhook", func() {
-		var defaulter InferenceServiceCustomDefaulter
-
-		BeforeEach(func() {
-			defaulter = InferenceServiceCustomDefaulter{client: k8sClient}
-
-			inferenceServiceConfig := &corev1.ConfigMap{}
-			Expect(testutils.ConvertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
-			if err := k8sClient.Create(ctx, inferenceServiceConfig); err != nil && !k8sErrors.IsAlreadyExists(err) {
-				Fail(err.Error())
-			}
-		})
-
-		It("Should apply default annotations for Serverless mode", func() {
-			isvc := kservev1beta1.InferenceService{}
-			Expect(defaulter.Default(ctx, &isvc)).To(Succeed())
-
-			annotations := isvc.GetAnnotations()
-			Expect(annotations).To(HaveKeyWithValue("serving.knative.openshift.io/enablePassthrough", "true"))
-			Expect(annotations).To(HaveKeyWithValue("sidecar.istio.io/inject", "true"))
-			Expect(annotations).To(HaveKeyWithValue("sidecar.istio.io/rewriteAppHTTPProbers", "true"))
-		})
-
-		It("Should keep user-specified annotations for Serverless mode", func() {
-			isvc := kservev1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-isvc",
-					Namespace: "test-isvc",
-					Annotations: map[string]string{
-						"serving.knative.openshift.io/enablePassthrough": "false",
-						"sidecar.istio.io/rewriteAppHTTPProbers":         "false",
-						"sidecar.istio.io/inject":                        "false",
-					},
-				},
-			}
-			Expect(defaulter.Default(ctx, &isvc)).To(Succeed())
-
-			annotations := isvc.GetAnnotations()
-			Expect(annotations).To(HaveKeyWithValue("serving.knative.openshift.io/enablePassthrough", "false"))
-			Expect(annotations).To(HaveKeyWithValue("sidecar.istio.io/inject", "false"))
-			Expect(annotations).To(HaveKeyWithValue("sidecar.istio.io/rewriteAppHTTPProbers", "false"))
-		})
-
-		It("Should not apply default annotations for Raw mode specified in annotation", func() {
-			isvc := kservev1beta1.InferenceService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-isvc",
-					Namespace: "test-isvc",
-					Annotations: map[string]string{
-						constants.DeploymentMode: string(constants.RawDeployment),
-					},
-				},
-			}
-			Expect(defaulter.Default(ctx, &isvc)).To(Succeed())
-
-			annotations := isvc.GetAnnotations()
-			Expect(annotations).ToNot(HaveKey("serving.knative.openshift.io/enablePassthrough"))
-			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/inject"))
-			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/rewriteAppHTTPProbers"))
-		})
-
-		It("Should not apply default annotations for Raw mode specified in default configuration", func() {
-			inferenceServiceConfig := &corev1.ConfigMap{}
-			Expect(testutils.ConvertToStructuredResource(InferenceServiceConfigPath1, inferenceServiceConfig)).To(Succeed())
-			inferenceServiceConfig.Data["deploy"] = "{\"defaultDeploymentMode\": \"RawDeployment\"}"
-			Expect(k8sClient.Update(ctx, inferenceServiceConfig)).To(Succeed())
-
-			isvc := kservev1beta1.InferenceService{}
-			Expect(defaulter.Default(ctx, &isvc)).To(Succeed())
-
-			annotations := isvc.GetAnnotations()
-			Expect(annotations).ToNot(HaveKey("serving.knative.openshift.io/enablePassthrough"))
-			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/inject"))
-			Expect(annotations).ToNot(HaveKey("sidecar.istio.io/rewriteAppHTTPProbers"))
 		})
 	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is to unlock the ODH ServiceMesh/Serverless/Authorin removal PR https://github.com/opendatahub-io/opendatahub-operator/pull/2560

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified namespace protection: only the application namespace is treated as protected; creating or updating services there continues to be rejected.
  - Removed automatic defaulting of serverless-related annotations; behavior now depends solely on user-provided configuration.
  - Streamlined logging when verifying protected namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->