### PR TITLE
feat: prioritize Authentication.spec.serviceAccountIssuer for ROSA support

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,6 +53,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - authentications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - datasciencecluster.opendatahub.io
   resources:
   - datascienceclusters

--- a/internal/controller/resources/authpolicy.go
+++ b/internal/controller/resources/authpolicy.go
@@ -111,7 +111,7 @@ func (k *kserveAuthPolicyTemplateLoader) loadUserDefinedTemplates(ctx context.Co
 	authPolicies := make([]*kuadrantv1.AuthPolicy, 0, len(gateways))
 
 	for _, gateway := range gateways {
-		authPolicy, err := k.renderUserDefinedTemplate(gateway.Namespace, gateway.Name)
+		authPolicy, err := k.renderUserDefinedTemplate(ctx, gateway.Namespace, gateway.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render AuthPolicy for gateway %s/%s: %w", gateway.Namespace, gateway.Name, err)
 		}
@@ -121,13 +121,13 @@ func (k *kserveAuthPolicyTemplateLoader) loadUserDefinedTemplates(ctx context.Co
 	return authPolicies, nil
 }
 
-func (k *kserveAuthPolicyTemplateLoader) renderUserDefinedTemplate(gatewayNamespace, gatewayName string) (*kuadrantv1.AuthPolicy, error) {
+func (k *kserveAuthPolicyTemplateLoader) renderUserDefinedTemplate(ctx context.Context, gatewayNamespace, gatewayName string) (*kuadrantv1.AuthPolicy, error) {
 	tmpl, err := template.New("authpolicy").Parse(string(authPolicyTemplateUserDefined))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse AuthPolicy template: %w", err)
 	}
 
-	audiences := controllerutils.GetAuthAudience(constants.KubernetesAudience)
+	audiences := controllerutils.GetAuthAudience(ctx, k.client, constants.KubernetesAudience)
 	audiencesJSON, err := json.Marshal(audiences)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal audiences %v to JSON: %w", audiences, err)

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -129,6 +129,7 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
 
 func (r *LLMInferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Logger) error {
 	b := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/utils/init.go
+++ b/internal/controller/utils/init.go
@@ -6,6 +6,7 @@ import (
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	ocpconfigv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -49,6 +50,7 @@ func RegisterSchemes(s *runtime.Scheme) {
 	utilruntime.Must(kedaapi.AddToScheme(s))
 	utilruntime.Must(gatewayapiv1.Install(s))
 	utilruntime.Must(istioclientv1alpha3.AddToScheme(s))
+	utilruntime.Must(ocpconfigv1.AddToScheme(s))
 
 	// The following are related to Service Mesh, uncomment this and other
 	// similar blocks to use with Service Mesh


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, the Gateway AuthPolicy (Global) uses the default audience https://kubernetes.default.svc/. However, for ROSA clusters, a custom audience is required.

https://issues.redhat.com/browse/RHOAIENG-36131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Auth policies now resolve token-review audiences from the cluster ServiceAccount issuer on OpenShift, falling back to the configured environment value.
  - Template rendering is context-aware, ensuring audience resolution uses runtime context.

- **Tests**
  - Added tests for OpenShift Authentication issuer detection and the environment-based fallback.

- **Chores**
  - Added RBAC to allow reading OpenShift Authentication resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->