### PR TITLE
rename spyre accelerator identifier

### DIFF
--- a/config/runtimes/vllm-spyre-template.yaml
+++ b/config/runtimes/vllm-spyre-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-spyre-runtime
       annotations:
         openshift.io/display-name: vLLM Spyre AI Accelerator ServingRuntime for KServe
-        opendatahub.io/recommended-accelerators: '["ibm.com/aiu_pf"]'
+        opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
         opendatahub.io/runtime-version: 'v0.10.1.1'
       labels:
         opendatahub.io/dashboard: 'true'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Update template for Spyre accelerator identifier rename to spyre_pf in the latest Spyre Operator.
<!--- Describe your changes in detail -->
The latest Spyre Operator renames spyre accelerator identifier to ``ibm.com/spyre_pf``
Jira: https://issues.redhat.com/browse/RHOAIENG-27963
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the latest [Spyre operator](https://catalog.redhat.com/en/software/container-stacks/detail/683da25176619df6976559d0) on Openshift cluster
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vLLM Spyre ServingRuntime template to recommend the "ibm.com/spyre_pf" accelerator by default. This adjusts the suggested hardware profile during deployment to better match supported accelerators. No other runtime behavior, configuration, or documentation was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->