### PR TITLE
feat: add BaseRefs support for LLMInferenceService gateway resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -164,6 +164,7 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/external-dns v0.14.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/lws v0.6.2 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d h
 contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d/go.mod h1:IshRmMJBhDfFj5Y67nVhMYTTIze91RUeT73ipWKs/GY=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
+dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0 h1:f2Qw/Ehhimh5uO1fayV0QIW7DShEQqhtUfhYc+cBPlw=
@@ -196,6 +198,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -239,6 +243,8 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/martinlindhe/base36 v1.1.1 h1:1F1MZ5MGghBXDZ2KJ3QfxmiydlWOGB8HCEtkap5NkVg=
 github.com/martinlindhe/base36 v1.1.1/go.mod h1:vMS8PaZ5e/jV9LwFKlm0YLnXl/hpOihiBxKkIoc3g08=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -254,6 +260,8 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/open-telemetry/opentelemetry-operator v0.113.0 h1:EoN3SLwF9dP5Ou7gFcfYligdwzedsEQBewQdagk5E3U=
+github.com/open-telemetry/opentelemetry-operator v0.113.0/go.mod h1:eQ8W+MxP+q5Tewf5Cx1vNXvRynjP9JNgrBbUO7TqjXQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opendatahub-io/kserve v0.0.0-20250929192938-907f0f3addeb h1:K4BOk2FnCqc1XAnab9T4xmZHgrcGBB2JNgaETvDXTi0=
@@ -335,6 +343,8 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/collector/featuregate v1.24.0 h1:DEqDsuJgxjZ3E5JNC9hXCd4sWGFiF7h9kaziODuqwFY=
+go.opentelemetry.io/collector/featuregate v1.24.0/go.mod h1:3GaXqflNDVwWndNGBJ1+XJFy3Fv/XrFgjMN60N3z7yg=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0 h1:JRxssobiPg23otYU5SbWtQC//snGVIM3Tx6QRzlQBao=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 h1:rgMkmiGfix9vFJDcDi1PK8WEQP4FLQwLDfhp5ZLpFeE=
@@ -347,6 +357,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 h1:Vh5HayB/0HHfOQA7Ctx
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0/go.mod h1:cpgtDBaqD/6ok/UG0jT15/uKjAY8mRA53diogHBg3UI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 h1:5pojmb1U1AogINhN3SurB+zm/nIcusopeBNp42f45QM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0/go.mod h1:57gTHJSE5S1tqg+EKsLPlTWhpHMsWlVmer+LA926XiA=
+go.opentelemetry.io/otel/exporters/prometheus v0.56.0 h1:GnCIi0QyG0yy2MrJLzVrIM7laaJstj//flf1zEJCG+E=
+go.opentelemetry.io/otel/exporters/prometheus v0.56.0/go.mod h1:JQcVZtbIIPM+7SWBB+T6FK+xunlyidwLp++fN0sUaOk=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0 h1:WDdP9acbMYjbKIyJUhTvtzj601sVJOqgWdUxSdR/Ysc=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/siN90M=
@@ -578,6 +590,8 @@ sigs.k8s.io/gateway-api-inference-extension v0.3.0 h1:jLFNxWfG8GeosTa4KWOMr4eTIL
 sigs.k8s.io/gateway-api-inference-extension v0.3.0/go.mod h1:x6g5FKSs4MsivsIAZJigVEjrvDAtgxNNynoWyid4v28=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
+sigs.k8s.io/lws v0.6.2 h1:5ulPJDaLBI9zk6ayGO2Lfg9P/FBL3C1LsmHmJVqvHvo=
+sigs.k8s.io/lws v0.6.2/go.mod h1:7nbwcpHwdDticuWPTDe6Va5OpjasS0MoVeVD61N5Y0c=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/internal/controller/resources/authpolicy.go
+++ b/internal/controller/resources/authpolicy.go
@@ -21,11 +21,13 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"text/template"
 
 	"github.com/go-logr/logr"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,11 +232,35 @@ func (k *kserveAuthPolicyTemplateLoader) getHTTPRouteInfo(llmisvc *kservev1alpha
 }
 
 // getGatewayInfo returns gateway list with fallback logic, filtering out gateways with opendatahub.io/managed: false
-func (k *kserveAuthPolicyTemplateLoader) getGatewayInfo(ctx context.Context, log logr.Logger, llmisvc *kservev1alpha1.LLMInferenceService) []struct{ Namespace, Name string } {
+func (k *kserveAuthPolicyTemplateLoader) getGatewayInfo(ctx context.Context, log logr.Logger, llmSvc *kservev1alpha1.LLMInferenceService) []struct{ Namespace, Name string } {
 	var gateways []struct{ Namespace, Name string }
 
-	if llmisvc.Spec.Router != nil && llmisvc.Spec.Router.Gateway != nil && llmisvc.Spec.Router.Gateway.HasRefs() {
-		for _, ref := range llmisvc.Spec.Router.Gateway.Refs {
+	// TODO: Reuse logic in Kserve, currently private and not very reusable.
+	specs := make([]kservev1alpha1.LLMInferenceServiceSpec, 0, 1)
+	for _, ref := range llmSvc.Spec.BaseRefs {
+		cfg, err := k.getConfig(ctx, llmSvc, ref.Name)
+		if err != nil {
+			log.Error(err, "failed to fetch configuration", "ref", ref.Name)
+			continue
+		}
+		if cfg != nil {
+			specs = append(specs, cfg.Spec)
+		}
+	}
+	// Append the service's own spec last so it takes precedence
+	specs = append(specs, llmSvc.Spec)
+
+	spec, err := llmisvc.MergeSpecs(ctx, specs...)
+	if err != nil {
+		log.Error(err, "failed to merge specs")
+		return nil
+	}
+	// Do not override spec
+	llmSvc = llmSvc.DeepCopy()
+	llmSvc.Spec = spec
+
+	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Gateway != nil && llmSvc.Spec.Router.Gateway.HasRefs() {
+		for _, ref := range llmSvc.Spec.Router.Gateway.Refs {
 			// Check if the gateway should be managed
 			if k.isGatewayManaged(ctx, log, string(ref.Namespace), string(ref.Name)) {
 				gateways = append(gateways, struct{ Namespace, Name string }{
@@ -307,6 +333,28 @@ func (k *kserveAuthPolicyTemplateLoader) isGatewayManaged(ctx context.Context, l
 		"namespace", namespace,
 		"name", name)
 	return true
+}
+
+// getConfig retrieves kserveapis.LLMInferenceServiceConfig with the given name from either the kserveapis.LLMInferenceService
+// namespace or from the SystemNamespace (e.g. 'kserve'), prioritizing the former.
+// TODO: Reuse logic in Kserve, currently private and not very reusable.
+func (k *kserveAuthPolicyTemplateLoader) getConfig(ctx context.Context, llmSvc *kservev1alpha1.LLMInferenceService, name string) (*kservev1alpha1.LLMInferenceServiceConfig, error) {
+	cfg := &kservev1alpha1.LLMInferenceServiceConfig{}
+	if err := k.client.Get(ctx, client.ObjectKey{Name: name, Namespace: llmSvc.Namespace}, cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			systemNamespace := os.Getenv("POD_NAMESPACE")
+			if systemNamespace == "" {
+				return nil, nil
+			}
+			cfg = &kservev1alpha1.LLMInferenceServiceConfig{}
+			if err := k.client.Get(ctx, client.ObjectKey{Name: name, Namespace: systemNamespace}, cfg); err != nil {
+				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmSvc.Namespace, systemNamespace, err)
+			}
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %s/%s: %w", llmSvc.Namespace, name, err)
+	}
+	return cfg, nil
 }
 
 type clientAuthPolicyStore struct {

--- a/internal/controller/resources/authpolicy_test.go
+++ b/internal/controller/resources/authpolicy_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ocpconfigv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -697,6 +698,480 @@ var _ = Describe("AuthPolicyMatcher", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(namespacedNames).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("AuthPolicyTemplateLoader - BaseRefs and Spec Merging", func() {
+	var loader resources.AuthPolicyTemplateLoader
+	var fakeClient client.Client
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(kservev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(ocpconfigv1.AddToScheme(scheme)).To(Succeed())
+		Expect(gwapiv1alpha2.Install(scheme)).To(Succeed())
+		Expect(gatewayapiv1.Install(scheme)).To(Succeed())
+	})
+
+	Context("getConfig method", func() {
+		It("should retrieve LLMInferenceServiceConfig from service namespace", func(ctx SpecContext) {
+			config := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "config-gateway",
+									Namespace: "config-gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "config-gateway",
+					Namespace: "config-gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(config, gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "test-config"},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("config-gateway")))
+			Expect(authPolicies[0].Namespace).To(Equal("config-gateway-ns"))
+		})
+
+		It("should retrieve LLMInferenceServiceConfig from system namespace when not found in service namespace", func(ctx SpecContext) {
+			_ = os.Setenv("POD_NAMESPACE", "kserve")
+			defer func() {
+				_ = os.Unsetenv("POD_NAMESPACE")
+			}()
+
+			config := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "system-config",
+					Namespace: "kserve",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "system-gateway",
+									Namespace: "system-gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "system-gateway",
+					Namespace: "system-gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(config, gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "system-config"},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("system-gateway")))
+			Expect(authPolicies[0].Namespace).To(Equal("system-gateway-ns"))
+		})
+
+		It("should prioritize service namespace over system namespace", func(ctx SpecContext) {
+			_ = os.Setenv("POD_NAMESPACE", "kserve")
+			defer func() {
+				_ = os.Unsetenv("POD_NAMESPACE")
+			}()
+
+			// Config in both namespaces with different gateways
+			serviceConfig := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "shared-config",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "service-gateway",
+									Namespace: "service-gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			systemConfig := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "shared-config",
+					Namespace: "kserve",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "system-gateway",
+									Namespace: "system-gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			serviceGateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "service-gateway",
+					Namespace: "service-gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(serviceConfig, systemConfig, serviceGateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "shared-config"},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			// Should use service namespace config, not system namespace
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("service-gateway")))
+			Expect(authPolicies[0].Namespace).To(Equal("service-gateway-ns"))
+		})
+
+		It("should handle config not found in either namespace gracefully", func(ctx SpecContext) {
+			_ = os.Setenv("POD_NAMESPACE", "kserve")
+			defer func() {
+				_ = os.Unsetenv("POD_NAMESPACE")
+			}()
+
+			// Create the default gateway so it's not filtered out
+			defaultGateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      constants.DefaultGatewayName,
+					Namespace: constants.DefaultGatewayNamespace,
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultGateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "missing-config"},
+					},
+				},
+			}
+
+			// The loader should log an error but continue, falling back to default gateway
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			// Should fall back to default gateway
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Namespace).To(Equal(constants.DefaultGatewayNamespace))
+		})
+
+		It("should handle empty system namespace gracefully", func(ctx SpecContext) {
+			// No POD_NAMESPACE env var, so system namespace will be empty
+			// Create the default gateway so it's not filtered out
+			defaultGateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      constants.DefaultGatewayName,
+					Namespace: constants.DefaultGatewayNamespace,
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultGateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "missing-config"},
+					},
+				},
+			}
+
+			// Should fall back to default gateway when config is not found and no system namespace
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Namespace).To(Equal(constants.DefaultGatewayNamespace))
+		})
+	})
+
+	Context("getGatewayInfo with BaseRefs", func() {
+		It("should merge multiple config specs from BaseRefs", func(ctx SpecContext) {
+			config1 := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "config1",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "gateway1",
+									Namespace: "gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			config2 := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "config2",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					// Another config spec - will be merged
+				},
+			}
+
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "gateway1",
+					Namespace: "gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(config1, config2, gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "config1"},
+						{Name: "config2"},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			// Merged spec should use gateway from config1
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("gateway1")))
+		})
+
+		It("should use service spec when no BaseRefs are specified", func(ctx SpecContext) {
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "direct-gateway",
+					Namespace: "direct-gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "direct-gateway",
+									Namespace: "direct-gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("direct-gateway")))
+			Expect(authPolicies[0].Namespace).To(Equal("direct-gateway-ns"))
+		})
+
+		It("should continue processing when one config fetch fails", func(ctx SpecContext) {
+			// Only create config2, config1 will fail to fetch
+			config2 := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "config2",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "gateway2",
+									Namespace: "gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "gateway2",
+					Namespace: "gateway-ns",
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(config2, gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "config1"}, // Will fail
+						{Name: "config2"}, // Will succeed
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			// Should not error, but should still process config2
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicies).To(HaveLen(1))
+			Expect(authPolicies[0].Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName("gateway2")))
+		})
+
+		It("should exclude gateway with managed=false annotation when using BaseRefs", func(ctx SpecContext) {
+			config := &kservev1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "test-ns",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					Router: &kservev1alpha1.RouterSpec{
+						Gateway: &kservev1alpha1.GatewaySpec{
+							Refs: []kservev1alpha1.UntypedObjectReference{
+								{
+									Name:      "unmanaged-gateway",
+									Namespace: "gateway-ns",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			gateway := &gatewayapiv1.Gateway{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "unmanaged-gateway",
+					Namespace: "gateway-ns",
+					Annotations: map[string]string{
+						constants.GatewayManagedAnnotation: "false",
+					},
+				},
+			}
+
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(config, gateway).Build()
+			loader = resources.NewKServeAuthPolicyTemplateLoader(fakeClient)
+
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-llm",
+				},
+				Spec: kservev1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "test-config"},
+					},
+				},
+			}
+
+			authPolicies, err := loader.Load(ctx, constants.UserDefined, llmisvc)
+
+			Expect(err).ToNot(HaveOccurred())
+			// Gateway should be excluded due to managed=false annotation
+			Expect(authPolicies).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
This adds support for LLMInferenceService.Spec.BaseRefs, which allows referencing LLMInferenceServiceConfig objects to inherit gateway configurations. The implementation includes:

- Add getConfig() method to retrieve LLMInferenceServiceConfig from service namespace or system namespace (POD_NAMESPACE env var), prioritizing the service namespace
- Enhance getGatewayInfo() to merge specs from BaseRefs configs before applying the service's own spec
- Add nil check for config retrieval to prevent panics when configs are not found
- Always append service spec to ensure it takes precedence in the merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure dependencies to support enhanced gateway management capabilities.

* **Improvements**
  * Enhanced configuration resolution with improved error handling and fallback mechanisms for gateway discovery across namespaces.
  * Expanded test coverage for configuration-driven gateway management and AuthPolicy generation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->