### PR TITLE
Add LLMInferenceServiceConfig read access

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -300,6 +300,7 @@ rules:
   - serving.kserve.io
   resources:
   - inferencegraphs
+  - llminferenceserviceconfigs
   verbs:
   - get
   - list

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -121,6 +121,7 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch;update;patch;post
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
```
E1017 04:43:24.022271       1 reflector.go:200] "Failed to watch" err="failed to list *v1alpha1.LLMInferenceServiceConfig: llminferenceserviceconfigs.serving.kserve.io is forbidden: User \"system:serviceaccount:opendatahub:odh-model-controller\" cannot list resource \"llminferenceserviceconfigs\" in API group \"serving.kserve.io\" at the cluster scope" logger="UnhandledError" reflector="go/pkg/mod/k8s.io/client-go@v0.33.1/tools/cache/reflector.go:285" type="*v1alpha1.LLMInferenceServiceConfig"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled system permissions for accessing and monitoring LLM inference service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->