### PR TITLE
Fix Prometheus metrics port for HF Detector Runtime

### DIFF
--- a/config/runtimes/hf-detector-template.yaml
+++ b/config/runtimes/hf-detector-template.yaml
@@ -27,7 +27,7 @@ objects:
         opendatahub.io/dashboard: 'true'
     spec:
       annotations:
-        prometheus.io/port: '8080'
+        prometheus.io/port: '8000'
         prometheus.io/path: '/metrics'
       multiModel: false
       supportedModelFormats:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The HF Detector runtime image exposes Prometheus metrics on port 8000, not 8080

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Prometheus metrics endpoint port configuration to align with the runtime's actual port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->