### PR TITLE
Write the HF Detector pod name into an env var for the container

### DIFF
--- a/config/runtimes/hf-detector-template.yaml
+++ b/config/runtimes/hf-detector-template.yaml
@@ -49,6 +49,10 @@ objects:
               value: /mnt/models
             - name: HF_HOME
               value: /tmp/hf_home
+            - name: DETECTOR_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Creates an env var in the container that stores the pod name of the deployed ISVC. This allows for user-selected names to be reflected in responses and metrics from the HF detector runtime.


## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated detector runtime configuration to include automatic detector identification via environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->