### PR TITLE
[s390x] Update vLLM spyre on Z ServingRuntime template

### DIFF
--- a/config/runtimes/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm-spyre-s390x-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-spyre-s390x-runtime
       annotations:
         openshift.io/display-name: vLLM Spyre s390x ServingRuntime for KServe
-        opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
+        opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
         opendatahub.io/runtime-version: 'v0.10.2.0'
       labels:
         opendatahub.io/dashboard: 'true'
@@ -34,37 +34,39 @@ objects:
         - image: $(vllm-spyre-s390x-image)
           name: kserve-container
           command:
-            - python3
-            - '-m'
-            - vllm_tgis_adapter
+            - /bin/bash
+            - -lc
+            - exec python3 -m vllm.entrypoints.openai.api_server "$@"
+            - --
           args:
-            - /mnt/models
+            - '--model=/mnt/models'
             - '--port=8000'
             - '--served-model-name={{.Name}}'
-            - '--grpc-port=8033'
           env:
             - name: HF_HOME
               value: /tmp/hf_home
             - name: FLEX_COMPUTE
               value: SENTIENT
             - name: FLEX_DEVICE
-              value: PF
+              value: VF
             - name: TOKENIZERS_PARALLELISM
               value: 'false'
             - name: DTLOG_LEVEL
               value: error
             - name: TORCH_SENDNN_LOG
               value: CRITICAL
-            - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
-              value: '4'
-            - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
-              value: '1024'
-            - name: VLLM_SPYRE_WARMUP_NEW_TOKENS
-              value: '256'
           ports:
             - containerPort: 8000
               protocol: TCP
+          volumeMounts:
+            - name: shm
+              mountPath: /dev/shm
       multiModel: false
       supportedModelFormats:
         - autoSelect: true
           name: vLLM
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi

--- a/config/runtimes/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm-spyre-s390x-template.yaml
@@ -35,8 +35,8 @@ objects:
           name: kserve-container
           command:
             - /bin/bash
-            - -lc
-            - exec python3 -m vllm.entrypoints.openai.api_server "$@"
+            - -c
+            - source /etc/profile.d/ibm-aiu-setup.sh && exec python3 -m vllm.entrypoints.openai.api_server "$@"
             - --
           args:
             - '--model=/mnt/models'
@@ -45,8 +45,6 @@ objects:
           env:
             - name: HF_HOME
               value: /tmp/hf_home
-            - name: FLEX_COMPUTE
-              value: SENTIENT
             - name: FLEX_DEVICE
               value: VF
             - name: TOKENIZERS_PARALLELISM
@@ -55,6 +53,12 @@ objects:
               value: error
             - name: TORCH_SENDNN_LOG
               value: CRITICAL
+            - name: VLLM_SPYRE_USE_CB
+              value: "1"
+            - name: VLLM_SPYRE_REQUIRE_PRECOMPILED_DECODERS
+              value: "1"
+            - name: TORCH_SENDNN_CACHE_ENABLE
+              value: "1"
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
Update vLLM spyre on Z ServingRuntime template

## Description

for IBM Z , only VF and continuous batching is supported. Updated serving-runtime accordingly. 

## How Has This Been Tested?
Locally Tested on Z cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM deployment configuration including accelerator settings and runtime environment variables.
  * Enhanced shared memory allocation (2Gi) for improved resource management.
  * Refined container startup process and model path handling for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->