### PR TITLE
[RHOAIENG-33157] Uninstalling Serverless (aka Advanced) model server doesn't delete istio namespace route

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_route_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_route_reconciler.go
@@ -79,8 +79,9 @@ func (r *KserveRouteReconciler) Reconcile(ctx context.Context, log logr.Logger, 
 }
 
 func (r *KserveRouteReconciler) Delete(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-	// handled by owner references
-	return nil
+	log.V(1).Info("Deleting Kserve inference service generic route")
+	_, meshNamespace := utils2.GetIstioControlPlaneName(ctx, r.client)
+	return r.routeHandler.DeleteRoute(ctx, types.NamespacedName{Name: getKServeRouteName(isvc), Namespace: meshNamespace})
 }
 
 func (r *KserveRouteReconciler) Cleanup(_ context.Context, _ logr.Logger, _ string) error {


### PR DESCRIPTION
The reported issue was reproducible in the current codebase.

I have reinstated the code change in the serverless mode route deletion logic. This change is crucial because it deletes the route based on the ISVC name from the istio-system namespace.

This code was previously removed by mistake while trying to address a separate issue. Although the original bug in [RHOAIENG-25522](https://issues.redhat.com/browse/RHOAIENG-25522) was not reproducible, the removal was implemented as a precautionary measure, which unfortunately introduced the current bug.

The changes were tested locally against the mentioned reproduction scenarios and are confirmed to be fixed.