### PR TITLE
resolve race condition in raw crb when 2 isvcs using the same SA have…

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_raw_clusterrolebinding_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_clusterrolebinding_reconciler.go
@@ -50,7 +50,10 @@ func NewKserveRawClusterRoleBindingReconciler(client client.Client) *KserveRawCl
 func (r *KserveRawClusterRoleBindingReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
 	log.V(1).Info("Reconciling ClusterRoleBinding for InferenceService")
 	// Create Desired resource
-	desiredResource := r.createDesiredResource(isvc)
+	desiredResource, err := r.createDesiredResource(ctx, log, isvc)
+	if err != nil {
+		return err
+	}
 
 	// Get Existing resource
 	existingResource, err := r.getExistingResource(ctx, log, isvc)
@@ -66,38 +69,13 @@ func (r *KserveRawClusterRoleBindingReconciler) Reconcile(ctx context.Context, l
 }
 
 func (r *KserveRawClusterRoleBindingReconciler) Delete(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
-
-	var isvcList kservev1beta1.InferenceServiceList
-	var listOpts client.ListOptions
-	namespace := isvc.Namespace
-	listOpts = client.ListOptions{Namespace: namespace}
-	// List all inference services in the namespace
-	if err := r.client.List(ctx, &isvcList, &listOpts); err != nil {
-		log.Error(err, "failed to list inference services")
-		return err
-	}
-
-	hasCustomSA := false
 	isvcSA := r.serviceAccountName
 	if len(isvc.Spec.Predictor.ServiceAccountName) > 0 {
-		hasCustomSA = true
 		isvcSA = isvc.Spec.Predictor.ServiceAccountName
 	}
-	var existingIsvcs []kservev1beta1.InferenceService
-	for _, svc := range isvcList.Items {
-		if hasCustomSA {
-			if svc.Spec.Predictor.ServiceAccountName == isvcSA {
-				if svc.GetDeletionTimestamp() == nil {
-					existingIsvcs = append(existingIsvcs, svc)
-				}
-			}
-		} else {
-			if len(svc.Spec.Predictor.ServiceAccountName) == 0 {
-				if svc.GetDeletionTimestamp() == nil {
-					existingIsvcs = append(existingIsvcs, svc)
-				}
-			}
-		}
+	existingIsvcs, err := getExistingIsvcsWithTheSameSAandAuthEnabled(ctx, r.client, log, isvcSA, isvc.Namespace)
+	if err != nil {
+		return err
 	}
 	if len(existingIsvcs) == 0 {
 		crbName := r.clusterRoleBindingHandler.GetClusterRoleBindingName(isvc.Namespace, isvcSA)
@@ -107,18 +85,28 @@ func (r *KserveRawClusterRoleBindingReconciler) Delete(ctx context.Context, log 
 	return nil
 }
 
-func (r *KserveRawClusterRoleBindingReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) *v1.ClusterRoleBinding {
-	if val, ok := isvc.Annotations[constants.EnableAuthODHAnnotation]; !ok || val != "true" {
-		return nil
-	}
-
+func (r *KserveRawClusterRoleBindingReconciler) createDesiredResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.ClusterRoleBinding, error) {
 	isvcSA := r.serviceAccountName
 	if isvc.Spec.Predictor.ServiceAccountName != "" {
 		isvcSA = isvc.Spec.Predictor.ServiceAccountName
 	}
+
+	if val, ok := isvc.Annotations[constants.EnableAuthODHAnnotation]; !ok || val != "true" {
+		existingIsvcs, err := getExistingIsvcsWithTheSameSAandAuthEnabled(ctx, r.client, log, isvcSA, isvc.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		if len(existingIsvcs) == 0 {
+			// This ISVC does not request auth and no other ISVC using the same SA requests auth, so no CRB is needed
+			return nil, nil
+		}
+		// if execution has reached here, it means at least one other ISVC using the same SA requests auth
+		// thus, CRB is needed
+	}
+
 	desiredClusterRoleBindingName := r.clusterRoleBindingHandler.GetClusterRoleBindingName(isvc.Namespace, isvcSA)
 	desiredClusterRoleBinding := r.clusterRoleBindingHandler.CreateDesiredClusterRoleBinding(desiredClusterRoleBindingName, isvcSA, isvc.Namespace)
-	return desiredClusterRoleBinding
+	return desiredClusterRoleBinding, nil
 }
 
 func (r *KserveRawClusterRoleBindingReconciler) getExistingResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.ClusterRoleBinding, error) {
@@ -137,4 +125,28 @@ func (r *KserveRawClusterRoleBindingReconciler) processDelta(ctx context.Context
 func (r *KserveRawClusterRoleBindingReconciler) Cleanup(_ context.Context, _ logr.Logger, _ string) error {
 	// NO OP
 	return nil
+}
+
+func getExistingIsvcsWithTheSameSAandAuthEnabled(ctx context.Context, cli client.Client, log logr.Logger, isvcSA string, namespace string) ([]kservev1beta1.InferenceService, error) {
+	var isvcList kservev1beta1.InferenceServiceList
+	listOpts := client.ListOptions{Namespace: namespace}
+	// List all inference services in the namespace
+	if err := cli.List(ctx, &isvcList, &listOpts); err != nil {
+		log.Error(err, "failed to list inference services")
+		return nil, err
+	}
+	var existingIsvcs []kservev1beta1.InferenceService
+	for _, svc := range isvcList.Items {
+		if svc.GetDeletionTimestamp() != nil {
+			continue
+		}
+		if val, ok := svc.Annotations[constants.EnableAuthODHAnnotation]; ok && val == "true" {
+			if isvcSA == constants.KserveServiceAccountName && len(svc.Spec.Predictor.ServiceAccountName) == 0 {
+				existingIsvcs = append(existingIsvcs, svc)
+			} else if isvcSA == svc.Spec.Predictor.ServiceAccountName {
+				existingIsvcs = append(existingIsvcs, svc)
+			}
+		}
+	}
+	return existingIsvcs, nil
 }


### PR DESCRIPTION
… different auth requirements

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes : https://issues.redhat.com/browse/RHOAIENG-35816 

Added logic to prevent the existing race condition 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClusterRoleBinding handling so bindings are created only when needed, preserved when multiple InferenceServices share a service account with differing auth requirements, and cleaned up safely.

* **Tests**
  * Added coverage for shared service-account scenarios validating CRB stability and updated tests to centralize the service-account name used across cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->