### PR TITLE
Reject isvcs that have a name longer than 53 characters

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -48,6 +48,13 @@ const (
 	WorkerContainerName = "worker-container"
 )
 
+// InferenceService validation constants
+const (
+	/* The k8s character limit for names is 63 characters, and we need to account for the
+	"-predictor" suffix added to the deployment name */
+	MaxISVCLength = 53
+)
+
 // isvc modes
 var (
 	RawDeployment KServeDeploymentMode = "RawDeployment"

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -70,6 +70,12 @@ func (v *InferenceServiceCustomValidator) ValidateCreate(ctx context.Context, ob
 	logger := inferenceservicelog.WithValues("namespace", inferenceservice.Namespace, "isvc", inferenceservice.GetName())
 	logger.Info("Validation for InferenceService upon creation")
 
+	// Validate the InferenceService name length
+	if err := utils.ValidateInferenceServiceNameLength(inferenceservice); err != nil {
+		logger.V(1).Info("InferenceService name validation failed", "name", inferenceservice.GetName())
+		return nil, err
+	}
+
 	appNamespace, err := utils.GetApplicationNamespace(ctx, v.client)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes : https://issues.redhat.com/browse/RHOAIENG-18603 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added unit tests 

### Manual verification
- deployed branch using [`devspace dev`](https://github.com/opendatahub-io/odh-model-controller/blob/incubating/dev_tools/README.md#using-devspace-1) 
- Deploy a ISVC with a name that exceeds 53 characters. For e.g : `isvcisvcisvcisvcisvcisvcisvcisvcisvcisvcisvcisvcisvcis`
- Verify that the isvc cannot be created 
<img width="920" height="915" alt="Screenshot 2025-11-11 at 12 41 36 PM" src="https://github.com/user-attachments/assets/715ea260-621d-4caa-978b-082bdbcfc53b" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for InferenceService resource names to enforce Kubernetes naming limits and provide clearer error messages when invalid names are submitted.

* **Tests**
  * Added test coverage for InferenceService name length validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->