### PR TITLE
Do not require a controller restart for LLMInferenceService reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -317,7 +317,7 @@ func setupReconcilers(mgr ctrl.Manager, setupLog logr.Logger, cfg *rest.Config) 
 		setupLog.Error(err, "unable to create controller", "controller", "ServingRuntime")
 		return err
 	}
-	if err := setupLLMInferenceServiceReconciler(mgr, cfg); err != nil {
+	if err := setupLLMInferenceServiceReconciler(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMInferenceService")
 		return err
 	}
@@ -371,10 +371,10 @@ func setupServingRuntimeReconciler(mgr ctrl.Manager) error {
 	}).SetupWithManager(mgr)
 }
 
-func setupLLMInferenceServiceReconciler(mgr ctrl.Manager, cfg *rest.Config) error {
+func setupLLMInferenceServiceReconciler(mgr ctrl.Manager) error {
 	return llmcontroller.NewLLMInferenceServiceReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		cfg,
+		mgr.GetEventRecorderFor("OpenDataHubModelController"),
 	).SetupWithManager(mgr, setupLog)
 }

--- a/internal/controller/serving/llm/fixture/envtest.go
+++ b/internal/controller/serving/llm/fixture/envtest.go
@@ -48,7 +48,7 @@ func SetupTestEnv() *pkgtest.Client {
 		return llmcontroller.NewLLMInferenceServiceReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
-			cfg,
+			mgr.GetEventRecorderFor("OpenDataHubModelController"),
 		).SetupWithManager(mgr, setupLog)
 	}
 


### PR DESCRIPTION
If RHCL or GatewayClass is created after ODH installation, odh-model-controller requires a restart, with this change, at least the creation of resources will be done, even though no watches will be created (for now).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced observability and monitoring: Kubernetes events are now recorded for all LLM Inference Service reconciliation operations, including errors and status updates. This enables operators to track system health and troubleshoot issues using Kubernetes-native event systems and monitoring tools. Authentication policy and Envoy filter reconcilers are now consistently registered during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->