### PR TITLE
Add to scheme Kuadrant and Authorino

### DIFF
--- a/internal/controller/testing/ctrl.go
+++ b/internal/controller/testing/ctrl.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"path/filepath"
 
+	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,6 +51,7 @@ func NewEnvTest(options ...Option) *Config {
 		netv1.AddToScheme,
 		kuadrantv1.AddToScheme,
 		kuadrantv1beta1.AddToScheme,
+		authorinooperatorv1beta1.AddToScheme,
 		gatewayapiv1.Install,
 		igwapi.Install,
 		istioclientv1alpha3.AddToScheme,

--- a/internal/controller/utils/init.go
+++ b/internal/controller/utils/init.go
@@ -4,7 +4,9 @@ import (
 	kedaapi "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	ocpconfigv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
@@ -33,6 +35,8 @@ func RegisterSchemes(s *runtime.Scheme) {
 	utilruntime.Must(authv1.AddToScheme(s))
 	utilruntime.Must(monitoringv1.AddToScheme(s))
 	utilruntime.Must(kuadrantv1.AddToScheme(s))
+	utilruntime.Must(kuadrantv1beta1.AddToScheme(s))
+	utilruntime.Must(authorinooperatorv1beta1.AddToScheme(s))
 	utilruntime.Must(nimv1.SchemeBuilder.AddToScheme(s))
 	utilruntime.Must(templatev1.AddToScheme(s))
 	utilruntime.Must(kedaapi.AddToScheme(s))


### PR DESCRIPTION
As per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Kubernetes operator integrations by registering additional API schemas, enabling support for Kuadrant and Authorino operator resources within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->