### PR TITLE
drop not needed default deployment parameters in ovms

### DIFF
--- a/config/runtimes/ovms-kserve-template.yaml
+++ b/config/runtimes/ovms-kserve-template.yaml
@@ -58,9 +58,6 @@ objects:
             - '--rest_port=8888'
             - '--model_path=/mnt/models'
             - '--file_system_poll_wait_seconds=0'
-            - '--grpc_bind_address=0.0.0.0'
-            - '--rest_bind_address=0.0.0.0'
-            - '--target_device=AUTO'
             - '--metrics_enable'
           ports:
             - containerPort: 8888


### PR DESCRIPTION
Dropping not needed hardcoded parameters in OVMS deployment

## Description
--target_device should not be enforced to AUTO because such value is not enabled for generative use cases. Generative models can be deployed by pointing to the model folder in model_path including all runtime parameters in graph.pbtxt. In such scenario, target_device shouldn't be used at all because it is included in the model config. Other option is to set all runtime in ovms CLI parameters but in that scenario target_device mustn't be AUTO - it should be set explicitly if not default CPU. Removing this parameter won't have negative impact for any previous deployments if CPU device was the target.

--rest_bind_address and grpc_bind_address is not needed because that was always the default value. Starting from 2025.4, it will be possible to set in this parameter also for ipv6 binding if needed. 

## How Has This Been Tested?
Deployments via KServe operator without those removed parameters 
Deployments via docker run command
Checked with the latest and old versions of OVMS image

## Merge criteria:
NA

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenVINO Model Server container configuration to stop explicitly binding gRPC and REST services to 0.0.0.0 and to rely on the server's default device selection instead of an explicit AUTO setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->