### PR TITLE
added cache mount and volume

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -484,6 +484,10 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 								MountPath: "/opt/nim/workspace",
 								Name:      "nim-workspace",
 							},
+							{
+								MountPath: "/.cache",
+								Name:      "nim-cache",
+							},
 						},
 					},
 				},
@@ -503,6 +507,12 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 					},
 					{
 						Name: "nim-workspace",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-cache",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},


### PR DESCRIPTION
This PR adds a writable volume mount at /.cache to the ServingRuntime template to address model compatibility issues in NIM deployments.

Motivation
Certain NVIDIA NIM models require /.cache to be a writable directory. Without this, the model initialization fails due to permission errors. This change introduces an emptyDir volume to meet that requirement.

Jira
Resolves [NVPE-335](https://issues.redhat.com/browse/NVPE-335)
✅ Changes
Added emptyDir volume named nim-cache
Mounted the volume to /.cache in the container spec
Notes
This change ensures compatibility across NIM models expecting a writable workspace path.
Tested with known failing model configurations to validate resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local cache mount at "/.cache" for Nim ServingRuntime deployments. The cache is provided as an empty-directory volume that reuses the existing workspace storage and coexists with current mounts, offering a local, ephemeral cache for runtime processes without changing APIs or runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->