### PR TITLE
odh 3.1 release tag bump

### DIFF
--- a/.tekton/odh-model-controller-push.yaml
+++ b/.tekton/odh-model-controller-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-v3.1
+    value: quay.io/opendatahub/odh-model-controller:odh-v3.2
   - name: dockerfile
     value: Containerfile
   - name: path-context


### PR DESCRIPTION
Update the tekton image to use the latest odh version (3.2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration to use the latest stable version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->