### PR TITLE
Add MLServer ServingRuntime template in odh-model-controller

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -43,6 +43,17 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.mlserver-image
+    targets:
+      - select:
+          kind: Template
+          name: mlserver-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.vllm-cuda-image
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -5,6 +5,7 @@ kserve-state=managed
 modelregistry-state=removed
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2025.1-release
+mlserver-image=quay.io/opendatahub/mlserver:fast
 vllm-cuda-image=quay.io/opendatahub/vllm:fast
 vllm-cpu-image=quay.io/opendatahub/vllm:fast-cpu
 vllm-gaudi-image=quay.io/opendatahub/vllm:fast-gaudi

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -8,6 +8,9 @@ releases:
   - name: OpenVINO Model Server
     version: v2024.5
     repoUrl: https://github.com/openvinotoolkit/model_server
+  - name: MLServer
+    version: 1.7.1
+    repoUrl: https://github.com/SeldonIO/MLServer
   - name: Caikit
     version: v0.27.7
     repoUrl: https://github.com/caikit/caikit

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -7,6 +7,7 @@ labels:
     includeSelectors: true
 resources:
   - ovms-kserve-template.yaml
+  - mlserver-template.yaml
   - vllm-cuda-template.yaml
   - vllm-multinode-template.yaml
   - vllm-rocm-template.yaml

--- a/config/runtimes/mlserver-template.yaml
+++ b/config/runtimes/mlserver-template.yaml
@@ -1,0 +1,68 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: MLServer is a lightweight, extensible inference server for serving machine learning models across multiple frameworks.
+    openshift.io/display-name: MLServer ServingRuntime for KServe - Tech Preview
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/long-description: This template defines resources needed to deploy MLServer ServingRuntime with KServe in Red Hat OpenShift AI
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+    opendatahub.io/model-type: '["predictive"]'
+  name: mlserver-runtime-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: mlserver-runtime
+      annotations:
+        openshift.io/display-name: MLServer ServingRuntime for KServe - Tech Preview
+        opendatahub.io/runtime-version: '1.7.1'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        opendatahub.io/kserve-runtime: 'mlserver'
+        prometheus.io/port: '8082'
+        prometheus.io/path: /metrics
+        monitoring.opendatahub.io/scrape: 'true'
+      containers:
+        - name: kserve-container
+          image: $(mlserver-image)
+          env:
+            - name: MLSERVER_MODEL_NAME
+              value: '{{.Name}}'
+            - name: MLSERVER_HTTP_PORT
+              value: '8080'
+            - name: MODELS_DIR
+              value: /mnt/models
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsNonRoot: true
+      protocolVersions:
+        - v2
+      multiModel: false
+      supportedModelFormats:
+        - name: sklearn
+          version: '0'
+        - name: sklearn
+          version: '1'
+        - name: xgboost
+          version: '1'
+        - name: xgboost
+          version: '2'
+        - name: lightgbm
+          version: '3'
+        - name: lightgbm
+          version: '4'


### PR DESCRIPTION
Signed-off-by: Snomaan6846 <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description
Adding MLServer ServingRuntime Template in odh-model-controller.
Jira-Link : https://issues.redhat.com/browse/RHOAIENG-39825

## How Has This Been Tested?
In Openshift AI DSC used devFlags to validate the odh-model-controller changes and verified that the template is getting installed with proper image.
kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/<github username>/odh-model-controller/tarball/<branch name>'

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLServer serving runtime support to deploy/serve models in sklearn, XGBoost, and LightGBM formats (multiple versions supported).
* **Configuration**
  * Introduced a configurable parameter for the MLServer container image.
* **Chores**
  * Registered MLServer in component metadata and added its runtime template to the deployment set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->