### PR TITLE
Update the namespace for the MaaS Config to be configurable

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -159,6 +159,17 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.maas-namespace
+    targets:
+      - select:
+          kind: Deployment
+          name: odh-model-controller
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=MAAS_NAMESPACE].value
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: metadata.namespace
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -3,6 +3,7 @@ ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest
 nim-state=managed
 kserve-state=managed
 modelregistry-state=removed
+maas-namespace=maas-api
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2025.1-release
 vllm-cuda-image=quay.io/opendatahub/vllm:fast

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -82,6 +82,8 @@ spec:
             value: replace
           - name: MODELREGISTRY_STATE
             value: replace
+          - name: MAAS_NAMESPACE
+            value: replace
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/controller/serving/reconcilers/tier_config.go
+++ b/internal/controller/serving/reconcilers/tier_config.go
@@ -39,17 +39,17 @@ const (
 	DefaultTenantNamespace = "maas-api"
 	DefaultTenantName      = "maas-default-gateway"
 
-	// Environment variable name for configuring the tenant namespace
-	TenantNamespaceEnvVar = "TENANT_NAMESPACE"
+	// Environment variable name for configuring the MaaS namespace
+	MaasNamespaceEnvVar = "MAAS_NAMESPACE"
 )
 
-// GetTenantNamespace returns the tenant namespace to use for tier configuration lookups.
-// It reads from the TENANT_NAMESPACE environment variable if set, otherwise returns
+// GetMaasNamespace returns the MaaS namespace to use for tier configuration lookups.
+// It reads from the MAAS_NAMESPACE environment variable if set, otherwise returns
 // the default namespace "maas-api".
 //
-// The tenant namespace is where the tier-to-group-mapping ConfigMap is expected to exist.
-func GetTenantNamespace() string {
-	if ns := os.Getenv(TenantNamespaceEnvVar); ns != "" {
+// The MaaS namespace is where the tier-to-group-mapping ConfigMap is expected to exist.
+func GetMaasNamespace() string {
+	if ns := os.Getenv(MaasNamespaceEnvVar); ns != "" {
 		return ns
 	}
 	return DefaultTenantNamespace
@@ -97,7 +97,7 @@ func (s *TierConfigLoader) ValidateTierAnnotation(ctx context.Context, log logr.
 		return nil, nil, err
 	}
 
-	tiers, err := s.loadTiers(ctx, log, GetTenantNamespace())
+	tiers, err := s.loadTiers(ctx, log, GetMaasNamespace())
 	if err != nil {
 		return requestedTiers, nil, err
 	}
@@ -127,7 +127,7 @@ func (s *TierConfigLoader) DefinedGroups(ctx context.Context, log logr.Logger, l
 		return nil, err
 	}
 
-	tiers, err := s.loadTiers(ctx, log, GetTenantNamespace())
+	tiers, err := s.loadTiers(ctx, log, GetMaasNamespace())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Setting the TENANT_NAMESPACE variable on the ODH Controller now allows the automation to work on a namespace other than maas-api.


**Note:** There is more to be done around the actual operator integration which is why I did not include documentation yet since this should really only be used internally for now. But that will be included in a future PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MaaS namespace is now configurable at runtime via the MAAS_NAMESPACE environment variable; when unset it falls back to the previous default. Tier configuration lookups and loading now respect the configured namespace.

* **Chores**
  * Deployment configs updated to expose MAAS_NAMESPACE and include parameter mapping for easy customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->