### PR TITLE
[RHOAIENG-46342] fix: UID mismatch error when updating ray-tls secrets across namespaces

### DIFF
--- a/internal/controller/serving/servingruntime_controller.go
+++ b/internal/controller/serving/servingruntime_controller.go
@@ -324,15 +324,32 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 		}
 		for _, sr := range servingRuntimeList.Items {
 			if isMultiNodeServingRuntime(sr) {
-				rayDefaultSecret.SetNamespace(sr.Namespace)
-				if err := r.Client.Update(ctx, rayDefaultSecret); err != nil {
+				// Get existing secret from this namespace
+				existingSecret := &corev1.Secret{}
+				err := r.Client.Get(ctx, types.NamespacedName{
+					Name:      constants.RayTLSSecretName,
+					Namespace: sr.Namespace,
+				}, existingSecret)
+
+				if err != nil {
 					if apierrs.IsNotFound(err) {
-						return nil
+						// Secret doesn't exist, skip
+						continue
 					}
-					logger.Error(err, "fail to update ray tls secret", "secret", constants.RayTLSSecretName, "namespace", targetNamespace)
+					logger.Error(err, "fail to get ray tls secret", "secret", constants.RayTLSSecretName, "namespace", sr.Namespace)
 					return err
 				}
-				logger.Info(fmt.Sprintf("Secret(%s) in namespace(%s) updated successfully", rayDefaultSecret.Name, sr.Namespace))
+
+				// Update the data of the EXISTING secret
+				existingSecret.Data = map[string][]byte{
+					rayCaCertNameInUserNS: caCertSecret.Data[corev1.TLSCertKey],
+				}
+
+				if err := r.Client.Update(ctx, existingSecret); err != nil {
+					logger.Error(err, "fail to update ray tls secret", "secret", constants.RayTLSSecretName, "namespace", sr.Namespace)
+					return err
+				}
+				logger.Info(fmt.Sprintf("Secret(%s) in namespace(%s) updated successfully", existingSecret.Name, sr.Namespace))
 			}
 		}
 	}


### PR DESCRIPTION
### Problem

  The odh-model-controller was encountering a StorageError when reconciling ray-tls secrets for multi-node serving runtimes:

 ```
ERROR Reconciler error {"controller": "servingruntime", "controllerGroup": "serving.kserve.io",
  "controllerKind": "ServingRuntime", "ServingRuntime": {"name":"ray-ca-tls","namespace":"redhat-ods-applications"},
  "namespace": "redhat-ods-applications", "name": "ray-ca-tls", "reconcileID": "0099f61c-169a-46ee-9087-2718128e97ca",
  "error": "Operation cannot be fulfilled on secrets \"ray-tls\": StorageError: invalid object, Code: 4,
  Key: /kubernetes.io/secrets/vllm-multinode-modelcar/ray-tls, ResourceVersion: 0, AdditionalErrorMsg:
  Precondition failed: UID in precondition: b28324cc-e388-4365-8c2e-12822b0f4348,
  UID in object meta: 81899a43-1a64-4728-ae79-e5c1382871ab"}
```

  This error occurred when the controller attempted to synchronize the CA certificate from ray-ca-tls secret in the controller namespace to ray-tls secrets across all user namespaces with multi-node serving runtimes.

###  Root Cause

  In reconcileDefaultRayServerCertSecretInUserNS (servingruntime_controller.go:327-352), when the ray-ca-tls secret was updated, the controller would iterate through all multi-node ServingRuntimes and update their corresponding ray-tls secrets.

  The bug: The code was creating a new Secret object, setting only the namespace field, and attempting to update it. This approach caused Kubernetes to reject the update because:
  1. The new Secret object had a different UID than the existing secret in the namespace
  2. Kubernetes uses UID preconditions to prevent accidental overwrites
  3. The ResourceVersion was 0, indicating it wasn't fetched from the API server

 ### Solution

  The fix properly handles the update workflow by:

  1. Fetching the existing secret from each namespace using Client.Get()
  2. Updating only the data field of the existing secret object (which has the correct UID and metadata)
  3. Properly handling NotFound errors by skipping namespaces where the secret doesn't exist yet
  4. Using the existing object for updates to ensure all metadata (UID, ResourceVersion) is correct

### Testing

  - ✅ Verified ray-ca-tls secret updates no longer cause UID mismatch errors
  - ✅ Confirmed ray-tls secrets are correctly synchronized across all namespaces with multi-node ServingRuntimes
  - ✅ Verified proper handling of namespaces where ray-tls secret doesn't exist yet