### PR TITLE
Fix Erroneous Tag Creation in Release Workflow 

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -144,13 +144,13 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ github.token }}
-          tag_name: $TAG_NAME
+          tag_name: ${{ env.TAG_NAME }}
           prerelease: false
           draft: false
           # this takes the path of payload to upload as an asset in the changelog
           files: bin/*
           generate_release_notes: true
-          name: $TAG_NAME
+          name: ${{ env.TAG_NAME }}
   
   bump-tag: 
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `TAG_NAME` env variable is currently referenced incorrectly in the `changelog` step of the create tag and release workflow, leading to a tag called `$TAG_NAME` to be created alongside the release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran workflow in fork - only correct tag and release versions are created now

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved release process reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->