### PR TITLE
[RHOAIENG-42308] Fix CVE-2025-68156: Update expr-lang/expr to v1.17.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,3 +174,6 @@ replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.1
 // Use ODH release branch instead
 // odh-v3.2
 replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20251215142358-6caad3ad9820
+
+// CVE-2025-68156: Update expr-lang/expr to v1.17.7
+replace github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.7

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lSh
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
-github.com/expr-lang/expr v1.17.0 h1:+vpszOyzKLQXC9VF+wA8cVA0tlA984/Wabc/1hF9Whg=
-github.com/expr-lang/expr v1.17.0/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
+github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
This PR addresses CVE-2025-68156 by updating the `github.com/expr-lang/expr` dependency from v1.17.2 to v1.17.7 using a Go module replace directive.

  ### Vulnerability Details
  - **CVE ID**: CVE-2025-68156
  - **Affected Package**: github.com/expr-lang/expr
  - **Previous Version**: v1.17.2 (indirect dependency)
  - **Fixed Version**: v1.17.7

  ### Fix
  Added a replace directive in `go.mod` to ensure all transitive dependencies use the patched version v1.17.7: