### PR TITLE
feat(llmisvc): add opt-in annotation for Authorino TLS EnvoyFilter on unmanaged gateways

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -166,6 +166,13 @@ const (
 	KubernetesAudience      = "https://kubernetes.default.svc"
 	DefaultGatewayName      = "openshift-ai-inference"
 	DefaultGatewayNamespace = "openshift-ingress"
+
+	// AuthorinoTLSBootstrapAnnotation is a Gateway annotation that enables EnvoyFilter creation
+	// for Authorino TLS bootstrap even when the gateway has opendatahub.io/managed=false.
+	// This allows configuring TLS between the gateway and Authorino without creating AuthPolicies.
+	// This is in particular useful for MaaS gateway where custom policies are used, but we still need
+	// to configure TLS between the gateway and Authorino.
+	AuthorinoTLSBootstrapAnnotation = "security.opendatahub.io/authorino-tls-bootstrap"
 )
 
 func GetHTTPRouteAuthPolicyName(httpRouteName string) string {

--- a/internal/controller/serving/llm/fixture/gwapi_builders.go
+++ b/internal/controller/serving/llm/fixture/gwapi_builders.go
@@ -61,6 +61,40 @@ func WithClassName(className string) GatewayOption {
 	}
 }
 
+func WithGatewayLabels(labels map[string]string) GatewayOption {
+	return func(gw *gatewayapi.Gateway) {
+		if gw.Labels == nil {
+			gw.Labels = make(map[string]string)
+		}
+		for k, v := range labels {
+			gw.Labels[k] = v
+		}
+	}
+}
+
+func WithGatewayAnnotations(annotations map[string]string) GatewayOption {
+	return func(gw *gatewayapi.Gateway) {
+		if gw.Annotations == nil {
+			gw.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			gw.Annotations[k] = v
+		}
+	}
+}
+
+func WithUnmanagedLabel() GatewayOption {
+	return WithGatewayLabels(map[string]string{
+		"opendatahub.io/managed": "false",
+	})
+}
+
+func WithAuthorinoTLSBootstrapAnnotation(value string) GatewayOption {
+	return WithGatewayAnnotations(map[string]string{
+		"security.opendatahub.io/authorino-tls-bootstrap": value,
+	})
+}
+
 func WithInfrastructureLabels(key, value string) GatewayOption {
 	return func(gw *gatewayapi.Gateway) {
 		if gw.Spec.Infrastructure.Labels == nil {

--- a/internal/controller/utils/kuadrant.go
+++ b/internal/controller/utils/kuadrant.go
@@ -1,0 +1,92 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// GetKuadrantNamespace finds the namespace where Kuadrant is installed.
+func GetKuadrantNamespace(ctx context.Context, c client.Client) string {
+	logger := log.FromContext(ctx)
+	const defaultKuadrantNamespace = "kuadrant-system"
+	kuadrantNamespace := GetEnvOr("KUADRANT_NAMESPACE", defaultKuadrantNamespace)
+
+	kuadrantList := &kuadrantv1beta1.KuadrantList{}
+	if err := c.List(ctx, kuadrantList); err != nil {
+		logger.V(1).Info("Unable to list Kuadrant resources, using default namespace", "kuadrant.namespace", kuadrantNamespace, "error", err)
+		return kuadrantNamespace
+	}
+
+	if len(kuadrantList.Items) == 0 {
+		return kuadrantNamespace
+	}
+
+	// Ensure a stable ordering of resources.
+	slices.SortStableFunc(kuadrantList.Items, func(a, b kuadrantv1beta1.Kuadrant) int {
+		c := cmp.Compare(a.Namespace, b.Namespace)
+		if c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Prioritize Kuadrant in "default Kuadrant namespace"
+	for _, kuadrant := range kuadrantList.Items {
+		if kuadrant.Namespace == kuadrantNamespace {
+			return kuadrantNamespace
+		}
+	}
+
+	// Fall back to first Kuadrant found
+	return kuadrantList.Items[0].Namespace
+}
+
+// IsAuthorinoTLSEnabled checks if Authorino has TLS enabled in the given namespace.
+// Returns true if TLS is enabled or cannot be determined (safe default).
+func IsAuthorinoTLSEnabled(ctx context.Context, c client.Client, kuadrantNamespace string) bool {
+	logger := log.FromContext(ctx)
+
+	authorinoList := &authorinooperatorv1beta1.AuthorinoList{}
+	if err := c.List(ctx, authorinoList, client.InNamespace(kuadrantNamespace)); err != nil {
+		logger.V(1).Info("Unable to list Authorino resources, assuming TLS is enabled", "kuadrant.namespace", kuadrantNamespace, "error", err)
+		return true
+	}
+
+	if len(authorinoList.Items) == 0 {
+		return true
+	}
+
+	// Ensure a stable ordering of resources.
+	slices.SortStableFunc(authorinoList.Items, func(a, b authorinooperatorv1beta1.Authorino) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Check if TLS is disabled (default to false if unset)
+	tlsEnabled := ptr.Deref(authorinoList.Items[0].Spec.Listener.Tls.Enabled, false)
+	if !tlsEnabled {
+		logger.V(1).Info("Authorino has TLS disabled", "listener.tls", authorinoList.Items[0].Spec.Listener.Tls)
+	}
+	return tlsEnabled
+}

--- a/internal/controller/utils/llmisvc.go
+++ b/internal/controller/utils/llmisvc.go
@@ -1,0 +1,95 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// GetGatewaysForLLMIsvc returns gateways referenced by the LLMInferenceService.
+// If explicit refs are provided, returns those gateways. Otherwise falls back to the default gateway.
+func GetGatewaysForLLMIsvc(ctx context.Context, c client.Client, llmisvc *kservev1alpha1.LLMInferenceService) []*gatewayapiv1.Gateway {
+	logger := log.FromContext(ctx)
+	var gateways []*gatewayapiv1.Gateway
+
+	hasExplicitRefs := llmisvc.Spec.Router != nil &&
+		llmisvc.Spec.Router.Gateway.HasRefs()
+
+	if hasExplicitRefs {
+		for _, ref := range llmisvc.Spec.Router.Gateway.Refs {
+			gateway := &gatewayapiv1.Gateway{}
+			if err := GetResource(ctx, c, string(ref.Namespace), string(ref.Name), gateway); err == nil {
+				gateways = append(gateways, gateway)
+			} else {
+				logger.V(1).Info("Failed to get gateway", "namespace", ref.Namespace, "name", ref.Name, "error", err)
+			}
+		}
+		return gateways
+	}
+
+	// Fall back to default gateway
+	var ns, name string
+	if userDefinedGatewayNS, userDefinedGatewayName, err := GetGatewayInfoFromConfigMap(ctx, c); err == nil {
+		ns = userDefinedGatewayNS
+		name = userDefinedGatewayName
+	} else {
+		logger.V(1).Info("Using default gateway values due to ConfigMap parsing failure",
+			"error", err,
+			"defaultNamespace", constants.DefaultGatewayNamespace,
+			"defaultName", constants.DefaultGatewayName)
+		ns = constants.DefaultGatewayNamespace
+		name = constants.DefaultGatewayName
+	}
+
+	gateway := &gatewayapiv1.Gateway{}
+	if err := GetResource(ctx, c, ns, name, gateway); err == nil {
+		gateways = append(gateways, gateway)
+	} else {
+		logger.V(1).Info("Failed to get default gateway", "namespace", ns, "name", name, "error", err)
+	}
+
+	return gateways
+}
+
+// LLMIsvcUsesGateway checks if an LLMInferenceService uses the specified gateway.
+// Returns true if the service explicitly references the gateway, or if the service
+// uses the default gateway and the specified gateway matches the default.
+func LLMIsvcUsesGateway(ctx context.Context, c client.Client, llmisvc *kservev1alpha1.LLMInferenceService, gatewayNamespace, gatewayName string) bool {
+	// Check if service explicitly references gateways
+	if llmisvc.Spec.Router != nil && llmisvc.Spec.Router.Gateway != nil && llmisvc.Spec.Router.Gateway.HasRefs() {
+		for _, ref := range llmisvc.Spec.Router.Gateway.Refs {
+			if string(ref.Name) == gatewayName && string(ref.Namespace) == gatewayNamespace {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Service uses default gateway - check if specified gateway is the default
+	defaultGatewayNamespace, defaultGatewayName, err := GetGatewayInfoFromConfigMap(ctx, c)
+	if err != nil {
+		defaultGatewayNamespace = constants.DefaultGatewayNamespace
+		defaultGatewayName = constants.DefaultGatewayName
+	}
+
+	return gatewayNamespace == defaultGatewayNamespace && gatewayName == defaultGatewayName
+}


### PR DESCRIPTION
Introduces `security.opendatahub.io/authorino-tls-bootstrap` annotation on Gateway resources to enable EnvoyFilter creation for Authorino TLS even when the gateway has `opendatahub.io/managed=false`.

This is particularly useful for MaaS gateways where custom AuthPolicies are managed externally, but TLS communication between the gateway and Authorino is still required. Previously, setting `managed=false` would skip both AuthPolicy and EnvoyFilter creation, leaving no way to configure Authorino TLS independently.

Adds Gateway watch to trigger immediate reconciliation when the `managed` label or `authorino-tls-bootstrap` annotation changes, rather than waiting for the next LLMInferenceService update.

Also refactors gateway resolution and matching logic into reusable utilities, improving consistency across EnvoyFilter, AuthPolicy, and controller reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support opt-in Authorino TLS bootstrap annotation to enable EnvoyFilter creation for unmanaged gateways
  * Watch Gateway resources to trigger automatic reconciliation when gateway configuration changes

* **Improvements**
  * Per-gateway EnvoyFilter rendering and lifecycle handling (create/delete) based on gateway metadata
  * More reliable gateway detection and service-to-gateway association logic

* **Tests**
  * Expanded tests covering gateway annotations, unmanaged gateways, and EnvoyFilter ownership/behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->