### PR TITLE
fix: remove valid tier info from validation error message

### DIFF
--- a/internal/webhook/serving/v1alpha1/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha1/llminferenceservice_webhook_test.go
@@ -207,8 +207,8 @@ var _ = Describe("LLMInferenceService Webhook", func() {
 				Expect(err).Should(HaveOccurred())
 				Expect(k8sErrors.IsInvalid(err)).Should(BeTrue())
 				Expect(err.Error()).Should(ContainSubstring("not found in tier configuration"))
-				Expect(err.Error()).Should(ContainSubstring("Available tiers"))
-				Expect(err.Error()).Should(SatisfyAll(
+				Expect(err.Error()).ShouldNot(ContainSubstring("Available tiers"))
+				Expect(err.Error()).ShouldNot(SatisfyAny(
 					ContainSubstring("free"),
 					ContainSubstring("premium"),
 				))


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
When supplying an unknown/unused tier name to the tier annotation, the error message previously exposed all valid tier names. This information should not be exposed to unprivileged users.

This change:
- Removes the list of "Available tiers" from the user-facing error message.
- Logs the available tiers internally for troubleshooting purposes.
- Ensures the error message informs the user that the value is invalid without leaking configuration details.
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tier-validation error messages are now more concise for users: available tier lists are recorded in logs while users see the original error text, reducing clutter and improving readability. No public interfaces or behavior changes.
* **Tests**
  * Test expectations updated to reflect the simplified error message content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->