### PR TITLE
fix(maas): use downward API for MAAS_NAMESPACE to support dynamic namespace configuration

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -192,17 +192,6 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
-      fieldPath: data.maas-namespace
-    targets:
-      - select:
-          kind: Deployment
-          name: odh-model-controller
-        fieldPaths:
-          - spec.template.spec.containers.[name=manager].env.[name=MAAS_NAMESPACE].value
-  - source:
-      kind: ConfigMap
-      version: v1
-      name: odh-model-controller-parameters
       fieldPath: metadata.namespace
     targets:
       - select:
@@ -210,17 +199,6 @@ replacements:
           name: validating-webhook-configuration
         fieldPaths:
           - webhooks.0.clientConfig.service.namespace
-  - source:
-      kind: ConfigMap
-      version: v1
-      name: odh-model-controller-parameters
-      fieldPath: data.maas-namespace
-    targets:
-      - select:
-          kind: ValidatingWebhookConfiguration
-          name: validating-webhook-configuration
-        fieldPaths:
-          - webhooks.[name=validating.configmap.odh-model-controller.opendatahub.io].namespaceSelector.matchExpressions.[key=kubernetes.io/metadata.name].values.0
 
 patches:
 - path: remove-namespace.yaml

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -3,7 +3,6 @@ ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest
 nim-state=managed
 kserve-state=managed
 modelregistry-state=removed
-maas-namespace=opendatahub
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2025.1-release
 mlserver-image=quay.io/opendatahub/mlserver:fast

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -83,7 +83,9 @@ spec:
           - name: MODELREGISTRY_STATE
             value: replace
           - name: MAAS_NAMESPACE
-            value: replace
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -15,12 +15,6 @@ patches:
       clientConfig:
         service:
           name: odh-model-controller-webhook-service
-      namespaceSelector:
-        matchExpressions:
-          - key: kubernetes.io/metadata.name
-            operator: In
-            values:
-              - maas-api
       objectSelector:
         matchLabels:
           component: tier-mapping


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a hardcoded MAAS namespace parameter and its ConfigMap mapping.
  * MAAS_NAMESPACE now resolves dynamically from the pod's runtime namespace instead of a static value.
  * Simplified validating webhook selection by removing namespace-based selection and preserving object-based selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->