### PR TITLE
feat: enable FIPS 140-3 compliant build configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ COPY internal/ internal/
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 USER root
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5


### PR DESCRIPTION
  Enable CGO and strictfipsruntime to ensure the binary links to
  RHEL's FIPS-certified cryptographic modules instead of using
  Go's pure Go crypto implementations.

  Signed-off-by: maskarb <mskarbek@redhat.com>
  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://issues.redhat.com/browse/RHOAIENG-46363
https://issues.redhat.com/browse/RHOAIENG-46364
https://issues.redhat.com/browse/RHOAIENG-46366


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work