### PR TITLE
Adding workflows to update runtime and component version

### DIFF
--- a/.github/workflows/component-metadata-version-update.yml
+++ b/.github/workflows/component-metadata-version-update.yml
@@ -93,7 +93,6 @@ jobs:
         shell: python
 
       - name: Create Pull Request
-        id: create_pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -124,7 +123,7 @@ jobs:
 
           # Create PR
           PR_URL=$(gh pr create \
-            --base incubating \
+            --base ${{ github.ref_name }} \
             --head "$BRANCH_NAME" \
             --title "chore(metadata): Update ${{ github.event.inputs.component }} version to ${{ github.event.inputs.component_version }}" \
             --body "## Summary
@@ -138,4 +137,3 @@ jobs:
           *This PR was automatically created by the Component Metadata Version Update Workflow.*")
 
           echo "✓ PR created: $PR_URL"
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/runtime-version-update.yml
+++ b/.github/workflows/runtime-version-update.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       runtime_template:
-        description: 'Comma seperate list of runtime templates for which the runtime version will be updated. The format of each entry in the list should be the template file name with "-template.yaml" dropped'
+        description: 'Comma seperated list of runtime templates for which the runtime version will be updated. The format of each entry in the list should be the template file name with "-template.yaml" dropped'
         required: true
         type: string
       runtime_version:
@@ -100,7 +100,6 @@ jobs:
         shell: python
 
       - name: Create Pull Request
-        id: create_pr
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -129,7 +128,7 @@ jobs:
 
           # Create PR
           PR_URL=$(gh pr create \
-            --base incubating \
+            --base ${{ github.ref_name }} \
             --head "$BRANCH_NAME" \
             --title "chore(runtimes): Update runtime version to ${{ github.event.inputs.runtime_version }}" \
             --body "## Summary
@@ -142,4 +141,3 @@ jobs:
           *This PR was automatically created by the Runtime Version Update Workflow.*")
 
           echo "✓ PR created: $PR_URL"
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding two workflows to make the chore of updating runtime and component metadata versions more straightforward.

1. `Update Component Metadata Version` allows the user to select from a dropdown of supported components and then input a new version for the component's metadata to be updated to.
2. `Update Runtime Version in Template` allows the user to input a comma separated list of runtime templates. Each of these templates, if valid, will have the `opendatahub.io/runtime-version` annotation updated to the input version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed both workflows within my fork and tested against edge cases.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two automated GitHub Actions workflows to streamline version updates: one for component metadata versions and one for runtime-template version annotations. Both perform validation, apply changes only when needed, handle errors, create dedicated branches, commit/push updates, and automatically open pull requests with summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->