### PR TITLE
RHOAIENG-48076: fix ppc64le spyre template

### DIFF
--- a/config/runtimes/vllm-spyre-ppc64le-template.yaml
+++ b/config/runtimes/vllm-spyre-ppc64le-template.yaml
@@ -38,41 +38,9 @@ objects:
             - '--model=/mnt/models'
             - '--port=8000'
             - '--served-model-name={{.Name}}'
-            - '--max-model-len=$(MAX_MODEL_LEN)'
-            - '--max-num-seqs=$(MAX_BATCH_SIZE)'
           env:
             - name: HF_HOME
               value: /tmp/hf_home
-            - name: HF_HUB_OFFLINE
-              value: '0'
-            - name: FLEX_COMPUTE
-              value: SENTIENT
-            - name: FLEX_DEVICE
-              value: PF
-            - name: TOKENIZERS_PARALLELISM
-              value: 'false'
-            - name: DTLOG_LEVEL
-              value: error
-            - name: TORCH_SENDNN_LOG
-              value: CRITICAL
-            - name: VLLM_SPYRE_USE_CB
-              value: "1"
-            - name: VLLM_SPYRE_REQUIRE_PRECOMPILED_DECODERS
-              value: "1"
-            - name: TORCH_SENDNN_CACHE_ENABLE
-              value: "1"
-            - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
-              value: "256"
-            - name: VLLM_SPYRE_WARMUP_NEW_TOKENS
-              value: "128"
-            - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
-              value: "16"
-            # set defaults, let user override later
-            - name: MAX_MODEL_LEN
-              value: "3072"
-            - name: MAX_BATCH_SIZE
-              value: "16"
-
           ports:
             - containerPort: 8000
               protocol: TCP


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/RHOAIENG-48076

Changes:
    - remove redundant environment variables
    - remove max-model-len passed as default argument 
(differs for different use cases: rag, entity extraction / embedding, reranking)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified container configuration for the vllm-spyre-ppc64le template by removing preset default arguments and environment variables. This change provides greater configuration flexibility, allowing the system to use existing defaults or enabling users to define custom settings tailored to their specific deployment and operational requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->