### PR TITLE
feat: configure HTTP client with explicit TLS 1.2 minimum version

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -17,6 +17,7 @@ package utils
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -116,7 +117,14 @@ var NimHttpClient HttpClient
 var NimEqualities semantic.Equalities
 
 func init() {
-	NimHttpClient = &http.Client{Timeout: time.Second * 30}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	NimHttpClient = &http.Client{
+		Timeout:   time.Second * 30,
+		Transport: transport,
+	}
 	NimEqualities = semantic.EqualitiesOrDie(
 		func(a, b resource.Quantity) bool {
 			return true


### PR DESCRIPTION
Update NimHttpClient initialization to use a custom transport with explicit TLS configuration, enforcing TLS 1.2 as the minimum version for FIPS 140-3 compliance.

<!--- Provide a general summary of your changes in the Title above -->

## Description
[RHOAIENG-48049](https://issues.redhat.com/browse/RHOAIENG-48049)
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `Account status` section of the NIM acceptance test doc is sufficient to exercise these changes: [google doc](https://docs.google.com/document/d/1GlYxgkyYdIAs0mK2GeuHv3xCpUAQNl34__pxB67P1pw/edit?usp=sharing)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enforced TLS 1.2 minimum protocol version for HTTP client communications to enhance connection security and compliance with modern encryption standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->