### PR TITLE
Air gapped nim supported

### DIFF
--- a/internal/controller/nim/account_controller_test.go
+++ b/internal/controller/nim/account_controller_test.go
@@ -163,7 +163,7 @@ var _ = Describe("NIM Account Controller", func() {
 		pullSecretRef, _ := reference.GetReference(scheme.Scheme, pullSecret)
 
 		By("Create the supporting Template")
-		object, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme)
+		object, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme, false)
 		gvk, _ := apiutil.GVKForObject(object, scheme.Scheme)
 		object.SetGroupVersionKind(gvk)
 

--- a/internal/controller/nim/handlers/template_handler.go
+++ b/internal/controller/nim/handlers/template_handler.go
@@ -55,6 +55,7 @@ type TemplateHandler struct {
 	Client         client.Client
 	Scheme         *runtime.Scheme
 	TemplateClient *templatev1client.Clientset
+	AirGapped      bool
 }
 
 func (t *TemplateHandler) Handle(ctx context.Context, account *v1.Account) HandleResponse {
@@ -113,7 +114,7 @@ func (t *TemplateHandler) Handle(ctx context.Context, account *v1.Account) Handl
 func (t *TemplateHandler) getApplyConfig(ctx context.Context, account *v1.Account) (*templatev1config.TemplateApplyConfiguration, error) {
 	logger := log.FromContext(ctx)
 
-	servingRuntime, srErr := utils.GetNimServingRuntimeTemplate(t.Scheme)
+	servingRuntime, srErr := utils.GetNimServingRuntimeTemplate(t.Scheme, t.AirGapped)
 	if srErr != nil {
 		return nil, srErr
 	}

--- a/internal/controller/nim/handlers/template_handler_test.go
+++ b/internal/controller/nim/handlers/template_handler_test.go
@@ -173,7 +173,7 @@ var _ = Describe("NIM Template Handler", func() {
 		}
 		Expect(testClient.Create(ctx, acct)).To(Succeed())
 
-		sr, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme)
+		sr, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme, false)
 		By("Create a Template")
 		template := &templatev1.Template{
 			ObjectMeta: metav1.ObjectMeta{
@@ -238,7 +238,7 @@ var _ = Describe("NIM Template Handler", func() {
 		}
 		Expect(testClient.Create(ctx, acct)).To(Succeed())
 
-		sr, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme)
+		sr, _ := utils.GetNimServingRuntimeTemplate(scheme.Scheme, false)
 		By("Create a Template")
 		template := &templatev1.Template{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -36,11 +36,13 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/semantic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type (
@@ -125,6 +127,34 @@ func init() {
 			return a.UTC() == b.UTC()
 		},
 	)
+}
+
+// IsNimAirGapped returns true when DSC enables NIM air-gapped mode.
+// It is best-effort and returns false on any lookup error.
+func IsNimAirGapped(ctx context.Context, clt client.Client) bool {
+	logger := log.FromContext(ctx)
+
+	dscList := &unstructured.UnstructuredList{}
+	dscList.SetGroupVersionKind(GVK.DataScienceCluster)
+	if err := clt.List(ctx, dscList); err != nil {
+		logger.V(1).Error(err, "failed to list DataScienceCluster for NIM air-gapped flag")
+		return false
+	}
+
+	if len(dscList.Items) != 1 {
+		logger.V(1).Info("unexpected DataScienceCluster count for NIM air-gapped flag", "count", len(dscList.Items))
+		return false
+	}
+
+	airGapped, found, err := unstructured.NestedBool(dscList.Items[0].Object, "spec", "components", "kserve", "nim", "airGapped")
+	if err != nil {
+		logger.V(1).Error(err, "failed to read NIM air-gapped flag from DataScienceCluster")
+		return false
+	}
+	if !found {
+		return false
+	}
+	return airGapped
 }
 
 // GetAvailableNimRuntimes is used for fetching a list of available NIM custom runtimes
@@ -413,8 +443,36 @@ func isPersonalApiKey(apiKey string) bool {
 }
 
 // GetNimServingRuntimeTemplate returns the Template used by ODH for creating serving runtimes
-func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRuntime, error) {
+func GetNimServingRuntimeTemplate(scheme *runtime.Scheme, airGapped bool) (*v1alpha1.ServingRuntime, error) {
 	multiModel := false
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "NIM_CACHE_PATH",
+			Value: "/mnt/models/cache",
+		},
+	}
+	if !airGapped {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: "NGC_API_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "NGC_API_KEY",
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "nvidia-nim-secrets",
+					},
+				},
+			},
+		})
+	}
+
+	var imagePullSecrets []corev1.LocalObjectReference
+	if !airGapped {
+		imagePullSecrets = []corev1.LocalObjectReference{
+			{
+				Name: "ngc-secret",
+			},
+		}
+	}
 	sr := &v1alpha1.ServingRuntime{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -434,23 +492,7 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 					"prometheus.io/port": "8000",
 				},
 				Containers: []corev1.Container{
-					{Env: []corev1.EnvVar{
-						{
-							Name:  "NIM_CACHE_PATH",
-							Value: "/mnt/models/cache",
-						},
-						{
-							Name: "NGC_API_KEY",
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									Key: "NGC_API_KEY",
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "nvidia-nim-secrets",
-									},
-								},
-							},
-						},
-					},
+					{Env: envVars,
 						Image: "",
 						Name:  "kserve-container",
 						Ports: []corev1.ContainerPort{
@@ -491,11 +533,7 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 						},
 					},
 				},
-				ImagePullSecrets: []corev1.LocalObjectReference{
-					{
-						Name: "ngc-secret",
-					},
-				},
+				ImagePullSecrets: imagePullSecrets,
 				Volumes: []corev1.Volume{
 					{
 						Name: "nim-pvc",


### PR DESCRIPTION
Added support for nim air gapped implementation

## Description
This PR adds air‑gapped support for NIM in odh-model-controller. When the new spec.components.kserve.nim.airGapped flag is enabled, the controller skips external NVIDIA API calls and marks the API key validation and ConfigMap refresh as successful with explicit air‑gapped messages, while still creating the ServingRuntime template and pull secret as normal. It also adds DSC read permissions so the controller can fetch the air‑gapped flag.

## How Has This Been Tested?
Deployed the custom image to the cluster
Enabled airGapped: true in the DSC
Enabled NIM in the Dashboard
Verified Account conditions show air‑gapped success messages for API key validation and ConfigMap update
Confirmed ServingRuntime template and pull secret were created successfully

[NVPE-395](https://issues.redhat.com/browse/NVPE-395)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects air-gapped deployments and propagates that mode through validation, config, and template flows.
  * Adjusts runtime/template generation for air-gapped mode (environment and image-pull behavior).

* **Bug Fixes**
  * Ensures configuration and validation status are recorded and reported consistently for air-gapped setups.

* **Chores**
  * Added RBAC permission entry to support air-gapped handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->