### PR TITLE
Add ONNX model format in MLServer ServingRuntime Template

### DIFF
--- a/config/runtimes/mlserver-template.yaml
+++ b/config/runtimes/mlserver-template.yaml
@@ -92,3 +92,5 @@ objects:
           version: '3'
         - name: lightgbm
           version: '4'
+        - name: onnx
+          version: '1'


### PR DESCRIPTION
Signed-off-by: Snomaan6846 <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


## Description
Added ONNX model format in MLServer ServingRuntime Template

## How Has This Been Tested?
The new template has been validated on RHOAI cluster with ONNX model deployment.

Jira Link : https://issues.redhat.com/browse/RHOAIENG-47104

## Merge criteria:
- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MLServer now supports ONNX model format. ONNX (Open Neural Network Exchange) is a widely-used format for machine learning models. This addition to MLServer's supported formats enables users to deploy and serve ONNX models directly, expanding the platform's compatibility with different model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->