### PR TITLE
Add K8s probes for MLserver template

### DIFF
--- a/config/runtimes/mlserver-template.yaml
+++ b/config/runtimes/mlserver-template.yaml
@@ -38,8 +38,34 @@ objects:
               value: '{{.Name}}'
             - name: MLSERVER_HTTP_PORT
               value: '8080'
-            - name: MODELS_DIR
+            - name: MLSERVER_MODELS_DIR
               value: /mnt/models
+          startupProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            failureThreshold: 1
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  [ -n "$(ls -A /mnt/models 2>/dev/null)" ]
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 5
+            httpGet:
+              path: /v2/models/{{.Name}}/ready
+              port: 8080
+          livenessProbe:
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 5
+            httpGet:
+              path: /v2/models/{{.Name}}/ready
+              port: 8080
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
Signed-off-by: Snomaan6846 <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description
Adding K8s probes for MLserver template

Jira-Link : https://issues.redhat.com/browse/RHOAIENG-46109

## How Has This Been Tested?
Deployed model using this template with K8s Probes and verified model was deployed successfully, and inference was successful.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added startup, readiness, and liveness health checks to the MLServer runtime container to improve deployment stability and faster recovery.
  * Updated the environment variable used to locate the model directory in the runtime container configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->