### PR TITLE
fix: reduce NIM ConfigMap size by storing only required model fields

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -420,7 +420,13 @@ func getModelData(logger logr.Logger, runtime NimRuntime, key string) (*NimModel
 		logger.Error(err, "failed to deserialize body")
 		return nil, ""
 	}
-	return model, string(body)
+	// Re-marshal to include only NimModel fields (excludes bloated fields like 'description')
+	minimalJSON, err := json.Marshal(model)
+	if err != nil {
+		logger.Error(err, "failed to serialize minimal model data")
+		return nil, ""
+	}
+	return model, string(minimalJSON)
 }
 
 func handleRequest(logger logr.Logger, req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary
- Fix NIM Account ConfigMap exceeding Kubernetes 1MB limit
- Re-marshal only NimModel struct fields instead of storing full API response body
- Reduces ConfigMap payload from ~1.1MB to ~165KB (184 models x ~900 bytes)

## Problem
The odh-nim-account-cm ConfigMap was failing to create because the total size exceeded Kubernetes 1MB limit. The controller was storing full NVIDIA API responses per model (~6KB each), with the description field alone being ~4KB of HTML/markdown content.

## Solution
Instead of storing string(body) (the full raw API response), re-marshal the NimModel struct which only contains the fields needed by the dashboard:
- name, displayName, shortDescription, namespace, tags, latestTag, updatedDate

## Test plan
- [x] Verified fix locally with custom image deployed to test cluster
- [x] ConfigMap created successfully with 184+ models
- [x] Unit tests pass

Resolves: [NVPE-416](https://issues.redhat.com/browse/NVPE-416)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data payload handling to reduce response size and improve efficiency by excluding unnecessary fields from serialized data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->