### PR TITLE
Make LLMISVC AuthPolicy auth rules apply as OR

### DIFF
--- a/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
@@ -41,6 +41,7 @@ spec:
               expression: request.path.split("/")[2]
             verb:
               value: get
+        priority: 1
     response:
       success:
         headers:


### PR DESCRIPTION
## Description

AuthPolicy for user-defined LLM inference services previously evaluated both `inference-access` (GET) and `endpoint-access` (POST) with AND semantics, so users needed both get and post RBAC on the LLMInferenceService.

**Resolution:** The endpoint-access block was removed and the inference-access rule was broadened to apply to all requests (no `when`). A single authorization rule (`inference-access`, SAR verb `get`) now runs for every request, so there is no vacuous pass and users need only `get` permission on the LLMInferenceService for all supported methods.

## How Has This Been Tested?

Manual verification that requests are authorized based on get RBAC. Existing E2E or integration tests that cover LLM ISVC auth should be run as a regression check.

## Merge criteria

- [ ] JIRA(s) are linked in the PR description (if applicable)
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authorization policy configuration with modifications to endpoint access controls and policy prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->