### PR TITLE
fix: update Go to 1.24.12 to address CVE-2025-61726

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-model-controller
 
-go 1.21
+go 1.24.12
 
 require (
 	github.com/go-logr/logr v1.3.0


### PR DESCRIPTION
**Updates Go version to 1.24.12 to address CVE-2025-61726, a high-severity memory exhaustion vulnerability in the `net/url` package.**
