### PR TITLE
Reduce RBAC permissions scope for odh-model-controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,7 +10,6 @@ rules:
   resources:
   - configmaps
   - secrets
-  - serviceaccounts
   - services
   verbs:
   - create
@@ -40,6 +39,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - update
 - apiGroups:
   - config.openshift.io
   resources:

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -87,13 +87,14 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;watch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces;pods;endpoints,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=secrets;configmaps;serviceaccounts;services,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=secrets;configmaps;services,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create;update;delete
 // +kubebuilder:rbac:groups=datasciencecluster.opendatahub.io,resources=datascienceclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dscinitialization.opendatahub.io,resources=dscinitializations,verbs=get;list;watch
 // +kubebuilder:rbac:groups=keda.sh,resources=triggerauthentications,verbs=get;list;watch;create;update;patch;watch;delete


### PR DESCRIPTION
## Summary
- Remove unused `roles` and `rolebindings` resources from InferenceServiceReconciler RBAC markers (only `clusterrolebindings` is actually used by this controller)
- Split ServiceAccount permissions into a separate RBAC marker with reduced verbs (`get`, `create`, `update`, `delete` only — removed unused `list`, `watch`, `patch`)
- Fix duplicate `watch` verb in RBAC marker
- Regenerated `config/rbac/role.yaml` via `make manifests`

## Test plan
- [x] `make manifests` regenerates cleanly
- [x] `make build` succeeds
- [x] All relevant unit tests pass (`serving`, `serving/llm`, `serving/reconcilers`, `resources`)
- [ ] Verify controller reconciles InferenceServices correctly in a test cluster
- [ ] Verify ClusterRoleBinding creation for auth-delegator still works
- [ ] Verify LLM Role/RoleBinding creation still works (managed by separate LLM controller markers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined role-based access control configurations to better organize and manage permissions across system components. Updated authorization rules for service accounts and cluster role bindings to improve permission specificity. These infrastructure improvements strengthen internal security governance and permission management without affecting end-user functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->