### PR TITLE
[RHOAIENG-46368] FIPS Compliance: replace math/rand with crypto/rand

### DIFF
--- a/internal/controller/testing/utils.go
+++ b/internal/controller/testing/utils.go
@@ -17,8 +17,9 @@ package testing
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -76,5 +77,9 @@ func CreateNamespaceIfNotExists(ctx context.Context, c client.Client, name strin
 
 // GenerateUniqueTestName generates a unique namespace name with prefix
 func GenerateUniqueTestName(prefix string) string {
-	return fmt.Sprintf("%s-%d", prefix, rand.Intn(99999))
+	n, err := rand.Int(rand.Reader, big.NewInt(99999))
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s-%d", prefix, n.Int64())
 }

--- a/test/utils/NamespaceHolder.go
+++ b/test/utils/NamespaceHolder.go
@@ -2,7 +2,8 @@ package utils
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -26,7 +27,11 @@ func createTestNamespaceName() string {
 
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterRunes))))
+		if err != nil {
+			panic(err)
+		}
+		b[i] = letterRunes[idx.Int64()]
 	}
 	return "test-ns-" + string(b)
 }


### PR DESCRIPTION
## Summary
- Replace `math/rand` with `crypto/rand` in `test/utils/NamespaceHolder.go` and `internal/controller/testing/utils.go`
- Uses `crypto/rand.Int(rand.Reader, ...)` with `math/big` for FIPS 140-3 section 7.2.1 compliant random number generation
- All unit tests pass and binary builds successfully

## Test plan
- [x] `grep -r 'math/rand' --include='*.go'` returns zero matches
- [x] `make test` passes
- [x] `make build` succeeds
- [x] `go vet ./...` clean
- [x] FIPS compliance scan confirms both files now use `crypto/rand`

Jira: https://issues.redhat.com/browse/RHOAIENG-46368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cryptographic randomness generation in testing infrastructure to improve test reliability and security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->