### PR TITLE
Update vLLM CPU runtime version to v0.16.0

### DIFF
--- a/config/runtimes/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm-cpu-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (ppc64le/s390x) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.14.1'
+        opendatahub.io/runtime-version: 'v0.16.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vLLM CPU runtime version to v0.16.0.
  * Runtime version annotation bumped from v0.14.1 to v0.16.0; control flow and resource structure remain unchanged.
  * No other public-facing declarations or behaviors were modified as part of this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->