### PR TITLE
Adding metrics support for mlserver runtime

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -103,6 +103,7 @@ const (
 	OvmsRuntimeName         = "ovms"
 	TgisRuntimeName         = "tgis"
 	VllmRuntimeName         = "vllm"
+	MLServerRuntimeName     = "mlserver"
 )
 
 // openshift

--- a/internal/controller/constants/runtime-metrics.go
+++ b/internal/controller/constants/runtime-metrics.go
@@ -349,4 +349,58 @@ const (
 			}
 		]
     }`
+
+	// MLServer
+	MLServerMetricsData = `{
+        "config": [
+			{
+				"title": "Requests per 5 minutes",
+				"type": "REQUEST_COUNT",
+				"queries": [
+					{
+						"title": "Number of successful incoming requests",
+						"query": "round(sum(increase(model_infer_request_success_total{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
+					},
+					{
+						"title": "Number of failed incoming requests",
+						"query": "round(sum(increase(model_infer_request_failure_total{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${REQUEST_RATE_INTERVAL}])))"
+					}
+				]
+			},
+			{
+				"title": "Average response time (ms)",
+				"type": "MEAN_LATENCY",
+				"queries": [
+					{
+						"title": "Average inference latency",
+						"query": "sum by (pod) (rate(model_infer_request_duration_sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}])) / sum by (pod) (rate(model_infer_request_duration_count{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}[${RATE_INTERVAL}]))"
+					},
+					{
+						"title": "Average e2e latency",
+						"query": "sum by (pod) (rate(rest_server_request_duration_seconds_sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*', path='/v2/models/{model_name}/infer'}[${RATE_INTERVAL}])) / sum by (pod) (rate(rest_server_request_duration_seconds_count{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*', path='/v2/models/{model_name}/infer'}[${RATE_INTERVAL}]))"
+					}
+				]
+			},
+			{
+				"title": "CPU utilization %",
+				"type": "CPU_USAGE",
+				"queries": [
+					{
+						"title": "CPU usage",
+						"query":  "sum(pod:container_cpu_usage:sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='cpu', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			},
+			{
+				"title": "Memory utilization %",
+				"type": "MEMORY_USAGE",
+				"queries": [
+					{
+						"title": "Memory usage",
+						"query":  "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='memory', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			}
+		]
+    }`
 )

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
@@ -201,6 +201,7 @@ func (r *KserveMetricsDashboardReconciler) processDelta(ctx context.Context, log
 //   - KServeRuntimeAnnotation with OvmsRuntimeName: Returns OvmsMetricsData
 //   - KServeRuntimeAnnotation with VllmRuntimeName: Returns VllmMetricsData
 //   - KServeRuntimeAnnotation with TgisRuntimeName: Returns TgisMetricsData
+//   - KServeRuntimeAnnotation with MLServerRuntimeName: Returns MLServerMetricsData
 //
 // Parameters:
 //   - runtime: A pointer to the ServingRuntime object containing annotations to evaluate
@@ -225,6 +226,8 @@ func getMetricsData(runtime *kservev1alpha1.ServingRuntime) (string, bool) {
 		return constants.VllmMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.TgisRuntimeName:
 		return constants.TgisMetricsData, true
+	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.MLServerRuntimeName:
+		return constants.MLServerMetricsData, true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding MLServer runtime to `getMetricsData` and adding `MLServerMetricsData` with metrics scraping configuration. This will allow for the `*-metrics-dashboard` configmap generated for the MLServer runtime to have `supported: "true"`, enabling metrics to be scraped and displayed in the UI.

## Description
<!--- Describe your changes in detail -->
Metrics will be scraped by prometheus from the server on port `8082` at the `/metrics` endpoint. The prometheus queries used to display metrics in the dashboard will be for:
- Requests per 5 minutes - utilizes MLServer's `model_infer_request_success_total` and `model_infer_request_failure_total` metrics
- Average response time (ms) - utilizes MLServer's `model_infer_request_duration_sum`, `model_infer_request_duration_count`, `rest_server_request_duration_seconds_sum`, and `rest_server_request_duration_seconds_count` metrics
- CPU utilization % - utilizes k8s `kube_pod_resource_limit` metric
- Memory utilization % - utilizes k8s `kube_pod_resource_limit` metric

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created odh-model-controller image with these changes and utilized it alongside odh-v3.4-ea1. The metrics are now displayed for models deployed using the MLServer runtime
<img width="1598" height="966" alt="Screenshot From 2026-03-11 17-16-12" src="https://github.com/user-attachments/assets/00afc0d5-cebd-46fa-ae8a-9f57f2603ddd" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for MLServer runtime integration with metrics monitoring capabilities
  * Integrated Prometheus-based metrics tracking for MLServer, including requests per 5 minutes, average response time, CPU utilization, and memory utilization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->