### PR TITLE
Update tekton pipeline for ODH 3.4

### DIFF
--- a/.tekton/odh-model-controller-push.yaml
+++ b/.tekton/odh-model-controller-push.yaml
@@ -24,14 +24,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-v3.4
+    value: quay.io/opendatahub/odh-model-controller:odh-stable
   - name: dockerfile
     value: Containerfile
   - name: path-context
     value: .
-  - name: additional-tags
-    value:
-    - 'odh-stable'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Description

Cherry-pick of #723 from `incubating` to `main` with an additional fix to use `odh-stable` as the primary output image tag instead of `odh-v3.4-EA2`, removing the now-redundant `additional-tags` field.

## How Has This Been Tested?

Tekton pipeline config change only -- verified YAML structure is correct.

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model controller configuration to use the stable release version instead of an early access version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->