### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 version: "2"
-
 run:
   allow-parallel-runners: true
-
 linters:
   default: none
   enable:
@@ -45,11 +43,14 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - staticcheck
+        text: "ST1001"
+        path: "(test/|_test\\.go|internal/controller/testing/)"
     paths:
       - third_party$
       - builtin$
       - examples$
-
 formatters:
   enable:
     - gofmt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/opendatahub-io/odh-model-controller
 
-go 1.25.7
+go 1.25
+
+toolchain go1.25.8
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/internal/controller/comparators/route_comparator.go
+++ b/internal/controller/comparators/route_comparator.go
@@ -31,7 +31,7 @@ func GetKServeRouteComparator() ResourceComparator {
 			reflect.DeepEqual(deployedRoute.Spec.Port, requestedRoute.Spec.Port) &&
 			reflect.DeepEqual(deployedRoute.Spec.TLS, requestedRoute.Spec.TLS) &&
 			reflect.DeepEqual(deployedRoute.Spec.WildcardPolicy, requestedRoute.Spec.WildcardPolicy) &&
-			reflect.DeepEqual(deployedRoute.ObjectMeta.Labels, requestedRoute.ObjectMeta.Labels) &&
-			reflect.DeepEqual(deployedRoute.ObjectMeta.Annotations, requestedRoute.ObjectMeta.Annotations)
+			reflect.DeepEqual(deployedRoute.Labels, requestedRoute.Labels) &&
+			reflect.DeepEqual(deployedRoute.Annotations, requestedRoute.Annotations)
 	}
 }

--- a/internal/controller/core/pod_controller.go
+++ b/internal/controller/core/pod_controller.go
@@ -106,7 +106,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	controllerNs := os.Getenv("POD_NAMESPACE")
 
 	pod := &corev1.Pod{}
-	if err := r.Client.Get(ctx, req.NamespacedName, pod); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
@@ -123,7 +123,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 func (r *PodReconciler) reconcileRayTls(ctx context.Context, logger logr.Logger, controllerNamespace, targetNamespace string, pod *corev1.Pod) error {
 	// Get the CA certificate secret
 	caCertSecret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: constants.RayCASecretName, Namespace: controllerNamespace}, caCertSecret); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: constants.RayCASecretName, Namespace: controllerNamespace}, caCertSecret); err != nil {
 		logger.Error(err, "Failed to get ray CA secret", "secret", constants.RayCASecretName, "namespace", controllerNamespace)
 		return err
 	}

--- a/internal/controller/core/pod_controller.go
+++ b/internal/controller/core/pod_controller.go
@@ -78,7 +78,7 @@ func reconcileServingPod() predicate.Predicate {
 
 func checkPodHasIP(oldPod *corev1.Pod, newPod *corev1.Pod) bool {
 	if oldPod != nil {
-		return !(oldPod.Status.PodIP == newPod.Status.PodIP)
+		return oldPod.Status.PodIP != newPod.Status.PodIP
 	}
 
 	return newPod.Status.PodIP != ""

--- a/internal/controller/core/secret_controller.go
+++ b/internal/controller/core/secret_controller.go
@@ -82,7 +82,7 @@ func newStorageSecret(dataConnectionSecretsList *corev1.SecretList, kserveCustom
 
 // CompareStorageSecrets checks if two secrets are equal, if not return false
 func CompareStorageSecrets(s1 corev1.Secret, s2 corev1.Secret) bool {
-	return reflect.DeepEqual(s1.ObjectMeta.Labels, s2.ObjectMeta.Labels) && reflect.DeepEqual(s1.Data, s2.Data)
+	return reflect.DeepEqual(s1.Labels, s2.Labels) && reflect.DeepEqual(s1.Data, s2.Data)
 }
 
 // reconcileSecret grabs all data connection secrets in the triggering namespace and
@@ -172,7 +172,7 @@ func (r *SecretReconciler) reconcileSecret(secret *corev1.Secret,
 			}
 			// Reconcile labels and spec field
 			foundStorageSecret.Data = desiredStorageSecret.Data
-			foundStorageSecret.ObjectMeta.Labels = desiredStorageSecret.ObjectMeta.Labels
+			foundStorageSecret.Labels = desiredStorageSecret.Labels
 			return r.Update(ctx, foundStorageSecret)
 		})
 		if err != nil {

--- a/internal/controller/nim/account_controller.go
+++ b/internal/controller/nim/account_controller.go
@@ -124,7 +124,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	ctx = log.IntoContext(ctx, logger)
 
 	account := &v1.Account{}
-	if err := r.Client.Get(ctx, req.NamespacedName, account); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, account); err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.V(1).Info("account deleted")
 		}
@@ -133,7 +133,7 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	if account.DeletionTimestamp.IsZero() {
 		if controllerutil.AddFinalizer(account, constants.NimCleanupFinalizer) {
-			if fErr := r.Client.Update(ctx, account); fErr != nil {
+			if fErr := r.Update(ctx, account); fErr != nil {
 				if k8serrors.IsNotFound(fErr) {
 					logger.V(1).Info("account removed before the finalizer was added")
 				}

--- a/internal/controller/processors/deltaProcessor.go
+++ b/internal/controller/processors/deltaProcessor.go
@@ -38,7 +38,7 @@ func (d *deltaProcessor) ComputeDelta(comparator comparators.ResourceComparator,
 	var updated bool
 	var removed bool
 
-	if !(utils.IsNil(desiredResource) && utils.IsNil(existingResource)) {
+	if !utils.IsNil(desiredResource) || !utils.IsNil(existingResource) {
 		if utils.IsNotNil(desiredResource) && utils.IsNil(existingResource) {
 			added = true
 		} else if utils.IsNil(desiredResource) && utils.IsNotNil(existingResource) {

--- a/internal/controller/serving/inferencegraph_controller.go
+++ b/internal/controller/serving/inferencegraph_controller.go
@@ -57,7 +57,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	logger := log.FromContext(ctx).WithValues("InferenceGraph", req.Name, "namespace", req.Namespace)
 
 	ig := &servingv1alpha1.InferenceGraph{}
-	err := r.Client.Get(ctx, req.NamespacedName, ig)
+	err := r.Get(ctx, req.NamespacedName, ig)
 	if err != nil && apierrs.IsNotFound(err) {
 		if apierrs.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -107,7 +107,7 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 	// Get the InferenceService object when a reconciliation event is triggered (create,
 	// update, delete)
 	isvc := &kservev1beta1.InferenceService{}
-	err := r.Client.Get(ctx, req.NamespacedName, isvc)
+	err := r.Get(ctx, req.NamespacedName, isvc)
 	if err != nil && apierrs.IsNotFound(err) {
 		logger.Info("Stop InferenceService reconciliation")
 		// InferenceService not found, so we check for any other inference services that might be using Kserve
@@ -129,7 +129,7 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 		logger.Info("Adding Finalizer")
 		if !controllerutil.ContainsFinalizer(isvc, constants.InferenceServiceODHFinalizerName) {
 			controllerutil.AddFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
-			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
+			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.Finalizers, ",") + "]"
 			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
 			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
 				return reconcile.Result{}, err
@@ -149,7 +149,7 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 				deleteErrors = multierror.Append(deleteErrors, err1)
 			}
 			controllerutil.RemoveFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
-			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
+			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.Finalizers, ",") + "]"
 			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
 			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
 				return reconcile.Result{}, err
@@ -255,7 +255,7 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, setupLog
 				logger := log.FromContext(ctx)
 				logger.Info("Reconcile event triggered by Secret: " + o.GetName())
 				isvc := &kservev1beta1.InferenceService{}
-				err := r.Client.Get(ctx, types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}, isvc)
+				err := r.Get(ctx, types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}, isvc)
 				if err != nil {
 					if apierrs.IsNotFound(err) {
 						return []reconcile.Request{}
@@ -293,7 +293,7 @@ func (r *InferenceServiceReconciler) onDeletion(ctx context.Context, log logr.Lo
 func (r *InferenceServiceReconciler) DeleteResourcesIfNoIsvcExists(ctx context.Context, log logr.Logger, namespace string) error {
 	// Get all InferenceServices in the namespace
 	inferenceServiceList := &kservev1beta1.InferenceServiceList{}
-	if err := r.Client.List(ctx, inferenceServiceList, client.InNamespace(namespace)); err != nil {
+	if err := r.List(ctx, inferenceServiceList, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 

--- a/internal/controller/serving/llm/fixture/gwapi_builders.go
+++ b/internal/controller/serving/llm/fixture/gwapi_builders.go
@@ -168,13 +168,13 @@ func HTTPRoute(name string, opts ...HTTPRouteOption) *gatewayapi.HTTPRoute {
 
 func WithParentRef(ref gatewayapi.ParentReference) HTTPRouteOption {
 	return func(route *gatewayapi.HTTPRoute) {
-		route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, ref)
+		route.Spec.ParentRefs = append(route.Spec.ParentRefs, ref)
 	}
 }
 
 func WithParentRefs(refs ...gatewayapi.ParentReference) HTTPRouteOption {
 	return func(route *gatewayapi.HTTPRoute) {
-		route.Spec.CommonRouteSpec.ParentRefs = refs
+		route.Spec.ParentRefs = refs
 	}
 }
 
@@ -480,7 +480,7 @@ func WithHTTPRouteParentStatus(parentRef gatewayapi.ParentReference, controllerN
 			ControllerName: gatewayapi.GatewayController(controllerName),
 			Conditions:     conditions,
 		}
-		route.Status.RouteStatus.Parents = append(route.Status.RouteStatus.Parents, parentStatus)
+		route.Status.Parents = append(route.Status.Parents, parentStatus)
 	}
 }
 
@@ -488,9 +488,9 @@ func WithHTTPRouteParentStatus(parentRef gatewayapi.ParentReference, controllerN
 func WithHTTPRouteReadyStatus(controllerName string) HTTPRouteOption {
 	return func(route *gatewayapi.HTTPRoute) {
 		if len(route.Spec.ParentRefs) > 0 {
-			route.Status.RouteStatus.Parents = make([]gatewayapi.RouteParentStatus, len(route.Spec.ParentRefs))
+			route.Status.Parents = make([]gatewayapi.RouteParentStatus, len(route.Spec.ParentRefs))
 			for i, parentRef := range route.Spec.ParentRefs {
-				route.Status.RouteStatus.Parents[i] = gatewayapi.RouteParentStatus{
+				route.Status.Parents[i] = gatewayapi.RouteParentStatus{
 					ParentRef:      parentRef,
 					ControllerName: gatewayapi.GatewayController(controllerName),
 					Conditions: []metav1.Condition{
@@ -570,9 +570,9 @@ func WithGatewayNotReadyStatus(reason, message string) GatewayOption {
 func WithHTTPRouteNotReadyStatus(controllerName, reason, message string) HTTPRouteOption {
 	return func(route *gatewayapi.HTTPRoute) {
 		if len(route.Spec.ParentRefs) > 0 {
-			route.Status.RouteStatus.Parents = make([]gatewayapi.RouteParentStatus, len(route.Spec.ParentRefs))
+			route.Status.Parents = make([]gatewayapi.RouteParentStatus, len(route.Spec.ParentRefs))
 			for i, parentRef := range route.Spec.ParentRefs {
-				route.Status.RouteStatus.Parents[i] = gatewayapi.RouteParentStatus{
+				route.Status.Parents[i] = gatewayapi.RouteParentStatus{
 					ParentRef:      parentRef,
 					ControllerName: gatewayapi.GatewayController(controllerName),
 					Conditions: []metav1.Condition{

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -72,7 +72,7 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 	logger := log.FromContext(ctx).WithValues("LLMInferenceService", req.Name, "namespace", req.Namespace)
 
 	llmisvc := &kservev1alpha2.LLMInferenceService{}
-	err := r.Client.Get(ctx, req.NamespacedName, llmisvc)
+	err := r.Get(ctx, req.NamespacedName, llmisvc)
 	if err != nil && apierrs.IsNotFound(err) {
 		logger.Info("Stop LLMInferenceService reconciliation")
 		return ctrl.Result{}, nil
@@ -200,7 +200,7 @@ func (r *LLMInferenceServiceReconciler) globalResync(setupLog logr.Logger) handl
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 
 		llmSvcList := &kservev1alpha2.LLMInferenceServiceList{}
-		if err := r.Client.List(ctx, llmSvcList); err != nil {
+		if err := r.List(ctx, llmSvcList); err != nil {
 			setupLog.Error(err, "Failed to list LLMInferenceService")
 			return nil
 		}
@@ -260,7 +260,7 @@ func (r *LLMInferenceServiceReconciler) Cleanup(ctx context.Context, log logr.Lo
 
 func (r *LLMInferenceServiceReconciler) DeleteResourcesIfNoLLMIsvcExists(ctx context.Context, log logr.Logger, namespace string) error {
 	llmInferenceServiceList := &kservev1alpha2.LLMInferenceServiceList{}
-	if err := r.Client.List(ctx, llmInferenceServiceList, client.InNamespace(namespace)); err != nil {
+	if err := r.List(ctx, llmInferenceServiceList, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 
@@ -286,14 +286,14 @@ func (r *LLMInferenceServiceReconciler) DeleteResourcesIfNoLLMIsvcExists(ctx con
 // TODO: Reuse logic in Kserve, currently private and not very reusable.
 func (k *LLMInferenceServiceReconciler) getConfig(ctx context.Context, llmisvc *kservev1alpha2.LLMInferenceService, name string) (*kservev1alpha2.LLMInferenceServiceConfig, error) {
 	cfg := &kservev1alpha2.LLMInferenceServiceConfig{}
-	if err := k.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: llmisvc.Namespace}, cfg); err != nil {
+	if err := k.Get(ctx, client.ObjectKey{Name: name, Namespace: llmisvc.Namespace}, cfg); err != nil {
 		if apierrs.IsNotFound(err) {
 			systemNamespace := os.Getenv("POD_NAMESPACE")
 			if systemNamespace == "" {
 				return nil, nil
 			}
 			cfg = &kservev1alpha2.LLMInferenceServiceConfig{}
-			if err := k.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: systemNamespace}, cfg); err != nil {
+			if err := k.Get(ctx, client.ObjectKey{Name: name, Namespace: systemNamespace}, cfg); err != nil {
 				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmisvc.Namespace, systemNamespace, err)
 			}
 			return cfg, nil

--- a/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		llmList := &kservev1alpha2.LLMInferenceServiceList{}
 		if err := envTest.Client.List(ctx, llmList, client.InNamespace(testNs)); err == nil {
 			for i := range llmList.Items {
-				_ = envTest.Client.Delete(ctx, &llmList.Items[i])
+				_ = envTest.Delete(ctx, &llmList.Items[i])
 			}
 		}
 	})

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
@@ -316,7 +316,7 @@ func createServingRuntime(name string, annotations map[string]string) *kservev1a
 		},
 	}
 	if strings.Contains(name, "nim") {
-		sr.ObjectMeta.Annotations = annotations
+		sr.Annotations = annotations
 	} else {
 		sr.Spec.Annotations = annotations
 	}

--- a/internal/controller/serving/servingruntime_controller.go
+++ b/internal/controller/serving/servingruntime_controller.go
@@ -64,7 +64,7 @@ type ServingRuntimeReconciler struct {
 // RoleBindingsAreEqual checks if RoleBinding are equal, if not return false
 func RoleBindingsAreEqual(sm1 k8srbacv1.RoleBinding, sm2 k8srbacv1.RoleBinding) bool {
 	areEqual :=
-		reflect.DeepEqual(sm1.ObjectMeta.Labels, sm2.ObjectMeta.Labels) &&
+		reflect.DeepEqual(sm1.Labels, sm2.Labels) &&
 			reflect.DeepEqual(sm1.Subjects, sm2.Subjects) &&
 			reflect.DeepEqual(sm1.RoleRef, sm2.RoleRef)
 	return areEqual
@@ -97,7 +97,7 @@ func (r *ServingRuntimeReconciler) foundRB(ctx context.Context, actualRB *k8srba
 		Name:      RoleBindingName,
 		Namespace: ns,
 	}
-	err := r.Client.Get(ctx, namespacedName, actualRB)
+	err := r.Get(ctx, namespacedName, actualRB)
 	if apierrs.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
@@ -127,7 +127,7 @@ func (r *ServingRuntimeReconciler) createRBIfDNE(ctx context.Context, exists boo
 	}
 
 	// If it does exist but RoleBinding has changed, revert
-	err := r.Client.Update(ctx, desiredRB)
+	err := r.Update(ctx, desiredRB)
 	if apierrs.IsConflict(err) {
 		// may occur during if the RoleBinding was updated during this reconcile loop
 		logger.Error(err, "Failed to create/update RoleBinding: "+RoleBindingName+" due to resource conflict")
@@ -149,7 +149,7 @@ func (r *ServingRuntimeReconciler) reconcileRoleBinding(ctx context.Context, req
 	logger := log.FromContext(ctx)
 
 	ns := &corev1.Namespace{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: req.Namespace}, ns)
+	err := r.Get(ctx, types.NamespacedName{Name: req.Namespace}, ns)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	namespacedName := types.NamespacedName{
 		Name: req.Namespace,
 	}
-	err := r.Client.Get(ctx, namespacedName, ns)
+	err := r.Get(ctx, namespacedName, ns)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -262,7 +262,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	var servingRuntimeList servingv1alpha1.ServingRuntimeList
-	if err := r.Client.List(ctx, &servingRuntimeList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
+	if err := r.List(ctx, &servingRuntimeList, &client.ListOptions{Namespace: req.Namespace}); err != nil {
 		return ctrl.Result{}, err
 	}
 	multiNodeSRExistInNS := existMultiNodeServingRuntimeInNs(servingRuntimeList)
@@ -284,7 +284,7 @@ func (r *ServingRuntimeReconciler) reconcileMultiNodeSR(ctx context.Context, log
 		return createCaCertErr
 	}
 	caCertSecret := &corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: constants.RayCASecretName, Namespace: controllerNamespace}, caCertSecret)
+	err := r.Get(ctx, types.NamespacedName{Name: constants.RayCASecretName, Namespace: controllerNamespace}, caCertSecret)
 	if err != nil {
 		logger.Error(err, "fail to get ray ca cert secret", "secret", constants.RayCASecretName, "namespace", controllerNamespace)
 		return err
@@ -304,14 +304,14 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 	if targetNamespace == controllerNamespace {
 		logger.Info("ray ca tls secret modified so ray tls cert need to be updated to sync ca.crt")
 		var servingRuntimeList servingv1alpha1.ServingRuntimeList
-		if err := r.Client.List(ctx, &servingRuntimeList); err != nil {
+		if err := r.List(ctx, &servingRuntimeList); err != nil {
 			return err
 		}
 		for _, sr := range servingRuntimeList.Items {
 			if isMultiNodeServingRuntime(sr) {
 				// Get existing secret from this namespace
 				existingSecret := &corev1.Secret{}
-				err := r.Client.Get(ctx, types.NamespacedName{
+				err := r.Get(ctx, types.NamespacedName{
 					Name:      constants.RayTLSSecretName,
 					Namespace: sr.Namespace,
 				}, existingSecret)
@@ -330,7 +330,7 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 					rayCaCertNameInUserNS: caCertSecret.Data[corev1.TLSCertKey],
 				}
 
-				if err := r.Client.Update(ctx, existingSecret); err != nil {
+				if err := r.Update(ctx, existingSecret); err != nil {
 					logger.Error(err, "fail to update ray tls secret", "secret", constants.RayTLSSecretName, "namespace", sr.Namespace)
 					return err
 				}
@@ -342,9 +342,9 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 	if multiNodeSRExistInNS {
 		// it creates a ray tls secret with ca cert in the user namespace where multinode runtime created.
 		defaultCertSecret := &corev1.Secret{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: constants.RayTLSSecretName, Namespace: targetNamespace}, defaultCertSecret); err != nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: constants.RayTLSSecretName, Namespace: targetNamespace}, defaultCertSecret); err != nil {
 			if apierrs.IsNotFound(err) {
-				if err := r.Client.Create(ctx, rayDefaultSecret); err != nil {
+				if err := r.Create(ctx, rayDefaultSecret); err != nil {
 					logger.Error(err, "fail to create ray tls secret", "secret", constants.RayTLSSecretName, "namespace", targetNamespace)
 					return err
 				}
@@ -357,7 +357,7 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 			if !bytes.Equal(caCertSecret.Data[corev1.TLSCertKey], defaultCertSecret.Data[rayCaCertNameInUserNS]) {
 				updatedDefaultCertSecret := defaultCertSecret.DeepCopy()
 				updatedDefaultCertSecret.Data[rayCaCertNameInUserNS] = caCertSecret.Data[corev1.TLSCertKey]
-				if err := r.Client.Update(ctx, updatedDefaultCertSecret); err != nil {
+				if err := r.Update(ctx, updatedDefaultCertSecret); err != nil {
 					logger.Error(err, "fail to update ray tls secret", "secret", constants.RayTLSSecretName, "namespace", targetNamespace)
 					return err
 				}
@@ -365,7 +365,7 @@ func (r *ServingRuntimeReconciler) reconcileDefaultRayServerCertSecretInUserNS(c
 		}
 	} else {
 		if !utils.IsRayTLSSecret(reqName) {
-			if err := r.Client.Delete(ctx, rayDefaultSecret); err != nil {
+			if err := r.Delete(ctx, rayDefaultSecret); err != nil {
 				if apierrs.IsNotFound(err) {
 					return nil
 				}

--- a/internal/controller/testing/cleaner.go
+++ b/internal/controller/testing/cleaner.go
@@ -122,7 +122,7 @@ func lookupNamespacedResources(clientset *kubernetes.Clientset) map[string]schem
 	namespacedGVKs := make(map[string]schema.GroupVersionKind)
 
 	// Look up all namespaced resources under the discovery API
-	_, apiResources, listErr := clientset.DiscoveryClient.ServerGroupsAndResources()
+	_, apiResources, listErr := clientset.ServerGroupsAndResources()
 	if listErr != nil {
 		panic(listErr)
 	}

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -132,7 +132,7 @@ func init() {
 			return true
 		},
 		func(a, b metav1.Time) bool {
-			return a.UTC() == b.UTC()
+			return a.UTC().Equal(b.UTC())
 		},
 	)
 }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -207,7 +207,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 


### PR DESCRIPTION
## Description

Upgrades golangci-lint from v1.64.8 to v2 and bumps Go to 1.25.

The v2 migration brings a cleaner config format - formatters (gofmt, goimports) are now a separate section, linter settings are properly nested, and deprecated options are replaced. The GH Actions workflow is updated to use the v7 action which supports v2.

All existing staticcheck quick-fix suggestions are resolved - mainly simplifying embedded field access patterns (e.g. `.ObjectMeta.Labels` -> `.Labels`, `.Client.Get` -> `.Get`) and cleaning up boolean expressions. Stale `golint` nolint directives are removed since that linter no longer exists in v2.

## How Has This Been Tested?

- `make lint` and `make lint-fix` pass with 0 issues
- GH Actions workflow aligned with v2

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain version specifications.
  * Refined linter configuration for improved code analysis.

* **Refactor**
  * Simplified internal resource comparison logic.
  * Updated client API calls for consistency across controllers.
  * Enhanced test utilities and fixture builders for API alignment.

* **Tests**
  * Improved test infrastructure and cleanup procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->