### PR TITLE
Update servingruntime template for RHAIIS-spyre s390x

### DIFF
--- a/config/runtimes/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm-spyre-s390x-template.yaml
@@ -34,11 +34,6 @@ objects:
       containers:
         - image: $(vllm-spyre-image)
           name: kserve-container
-          command:
-            - /bin/bash
-            - -c
-            - source /etc/profile.d/ibm-aiu-setup.sh && exec python3 -m vllm.entrypoints.openai.api_server "$@"
-            - --
           args:
             - '--model=/mnt/models'
             - '--port=8000'


### PR DESCRIPTION
Removed command definition for kserve-container in vllm-spyre-s390x-template.yaml.


Current template is not utilizing by default entrypoint, which is causing DOOM mode issue due to wrong senlib.json is being picked up
Utilizing by default entrypoint resolved this issue and makes template much simpler

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
Tested locally

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified container startup configuration by removing custom initialization commands. The container now relies on default image configuration for initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->