### PR TITLE
fix: provision get RBAC for LLMInferenceService inference access

### DIFF
--- a/internal/controller/serving/llm/fixture/rbac_helpers.go
+++ b/internal/controller/serving/llm/fixture/rbac_helpers.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const inferenceAccessSuffix = "-llmisvc-inference-access"
+
+func GetInferenceAccessRoleName(llmisvcName string) string {
+	return llmisvcName + inferenceAccessSuffix
+}
+
+func VerifyInferenceAccessRoleExists(ctx context.Context, c client.Client, namespace, llmisvcName string) {
+	VerifyResourceExists(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.Role{})
+}
+
+func VerifyInferenceAccessRoleBindingExists(ctx context.Context, c client.Client, namespace, llmisvcName string) {
+	VerifyResourceExists(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.RoleBinding{})
+}
+
+func VerifyInferenceAccessRoleNotExist(ctx context.Context, c client.Client, namespace, llmisvcName string) {
+	VerifyResourceNotExist(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.Role{})
+}
+
+func VerifyInferenceAccessRoleBindingNotExist(ctx context.Context, c client.Client, namespace, llmisvcName string) {
+	VerifyResourceNotExist(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.RoleBinding{})
+}
+
+func WaitForInferenceAccessRole(ctx context.Context, c client.Client, namespace, llmisvcName string) *rbacv1.Role {
+	return WaitForResource(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.Role{})
+}
+
+func WaitForInferenceAccessRoleBinding(ctx context.Context, c client.Client, namespace, llmisvcName string) *rbacv1.RoleBinding {
+	return WaitForResource(ctx, c, namespace, GetInferenceAccessRoleName(llmisvcName), &rbacv1.RoleBinding{})
+}

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -58,6 +58,7 @@ type LLMInferenceServiceReconciler struct {
 func NewLLMInferenceServiceReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *LLMInferenceServiceReconciler {
 	subResourceReconcilers := []parentreconcilers.LLMSubResourceReconciler{
 		reconcilers.NewKserveAuthPolicyReconciler(client, scheme),
+		reconcilers.NewKserveRBACReconciler(client, scheme),
 	}
 
 	return &LLMInferenceServiceReconciler{

--- a/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
@@ -25,9 +25,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
@@ -366,6 +369,171 @@ var _ = Describe("BaseRefs and Spec Merging", func() {
 			Expect(envTest.Client.Create(ctx, llmisvc)).Should(Succeed())
 
 			fixture.VerifyGatewayAuthPolicyOwnerRef(ctx, envTest.Client, testNs, gatewayName)
+		})
+	})
+
+	Context("LLMInferenceService with RBAC", func() {
+		It("should create Role and RoleBinding when LLMInferenceService is created", func(ctx SpecContext) {
+			fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			role := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			Expect(role.Rules).To(HaveLen(1))
+			Expect(role.Rules[0].APIGroups).To(Equal([]string{"serving.kserve.io"}))
+			Expect(role.Rules[0].Resources).To(Equal([]string{"llminferenceservices"}))
+			Expect(role.Rules[0].ResourceNames).To(Equal([]string{LLMInferenceServiceName}))
+			Expect(role.Rules[0].Verbs).To(Equal([]string{"get"}))
+			Expect(role.Labels["app.kubernetes.io/managed-by"]).To(Equal("odh-model-controller"))
+
+			rb := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
+			Expect(rb.RoleRef.Name).To(Equal(fixture.GetInferenceAccessRoleName(LLMInferenceServiceName)))
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0].Kind).To(Equal("Group"))
+			Expect(rb.Subjects[0].Name).To(Equal("system:authenticated"))
+		})
+
+		It("should restore Role rules on next reconcile after manual modification", func(ctx SpecContext) {
+			llmisvc := fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			role := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			originalVerbs := role.Rules[0].Verbs
+
+			role.Rules[0].Verbs = []string{"get", "list", "delete"}
+			Expect(envTest.Client.Update(ctx, role)).Should(Succeed())
+
+			// Trigger reconcile by touching the LLMInferenceService
+			if llmisvc.Annotations == nil {
+				llmisvc.Annotations = make(map[string]string)
+			}
+			llmisvc.Annotations["test/trigger"] = "reconcile"
+			Expect(envTest.Client.Update(ctx, llmisvc)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				g.Expect(updated.Rules[0].Verbs).To(Equal(originalVerbs))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should restore RoleBinding subjects on next reconcile after manual modification", func(ctx SpecContext) {
+			llmisvc := fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			rb := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+
+			rb.Subjects = []rbacv1.Subject{
+				{Kind: "User", APIGroup: rbacv1.GroupName, Name: "rogue-user"},
+			}
+			Expect(envTest.Client.Update(ctx, rb)).Should(Succeed())
+
+			// Trigger reconcile by touching the LLMInferenceService
+			if llmisvc.Annotations == nil {
+				llmisvc.Annotations = make(map[string]string)
+			}
+			llmisvc.Annotations["test/trigger"] = "reconcile"
+			Expect(envTest.Client.Update(ctx, llmisvc)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				g.Expect(updated.Subjects).To(HaveLen(1))
+				g.Expect(updated.Subjects[0].Kind).To(Equal("Group"))
+				g.Expect(updated.Subjects[0].Name).To(Equal("system:authenticated"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should have OwnerReference pointing to LLMInferenceService", func(ctx SpecContext) {
+			llmisvc := fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			role := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			Expect(role.OwnerReferences).To(HaveLen(1))
+			Expect(role.OwnerReferences[0].Name).To(Equal(llmisvc.Name))
+			Expect(role.OwnerReferences[0].UID).To(Equal(llmisvc.UID))
+
+			rb := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			Expect(rb.OwnerReferences).To(HaveLen(1))
+			Expect(rb.OwnerReferences[0].Name).To(Equal(llmisvc.Name))
+			Expect(rb.OwnerReferences[0].UID).To(Equal(llmisvc.UID))
+		})
+
+		It("should skip reconciliation when Role has opendatahub.io/managed=false label", func(ctx SpecContext) {
+			fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			role := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+
+			role.Labels[constants.ODHManaged] = "false"
+			role.Rules[0].Verbs = []string{"get", "list"}
+			Expect(envTest.Client.Update(ctx, role)).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				g.Expect(updated.Rules[0].Verbs).To(Equal([]string{"get", "list"}))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should skip reconciliation when RoleBinding has opendatahub.io/managed=false label", func(ctx SpecContext) {
+			fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			rb := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+
+			rb.Labels[constants.ODHManaged] = "false"
+			rb.Subjects = []rbacv1.Subject{
+				{Kind: "User", APIGroup: rbacv1.GroupName, Name: "custom-user"},
+			}
+			Expect(envTest.Client.Update(ctx, rb)).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				g.Expect(updated.Subjects).To(HaveLen(1))
+				g.Expect(updated.Subjects[0].Kind).To(Equal("User"))
+				g.Expect(updated.Subjects[0].Name).To(Equal("custom-user"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should recreate RoleBinding when RoleRef points at the wrong Role", func(ctx SpecContext) {
+			llmisvc := fixture.CreateBasicLLMInferenceService(ctx, envTest.Client, testNs, LLMInferenceServiceName, nil)
+
+			_ = fixture.WaitForInferenceAccessRole(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			rb := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+			rbName := rb.Name
+
+			wrongRoleName := "wrong-role-ref-target"
+			wrongRole := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: wrongRoleName, Namespace: testNs},
+				Rules: []rbacv1.PolicyRule{{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"get"},
+				}},
+			}
+			Expect(envTest.Client.Create(ctx, wrongRole)).Should(Succeed())
+			Expect(envTest.Client.Delete(ctx, rb)).Should(Succeed())
+
+			broken := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rbName,
+					Namespace: testNs,
+					Labels:    rb.Labels,
+				},
+				Subjects: rb.Subjects,
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     wrongRoleName,
+				},
+			}
+			Expect(controllerutil.SetControllerReference(llmisvc, broken, envTest.Environment.Scheme)).Should(Succeed())
+			Expect(envTest.Client.Create(ctx, broken)).Should(Succeed())
+
+			if llmisvc.Annotations == nil {
+				llmisvc.Annotations = make(map[string]string)
+			}
+			llmisvc.Annotations["test/trigger-roleref-recreate"] = "1"
+			Expect(envTest.Client.Update(ctx, llmisvc)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				fixed := fixture.WaitForInferenceAccessRoleBinding(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				g.Expect(fixed.RoleRef.Name).To(Equal(fixture.GetInferenceAccessRoleName(LLMInferenceServiceName)))
+				g.Expect(fixed.Subjects).To(HaveLen(1))
+				g.Expect(fixed.Subjects[0].Name).To(Equal("system:authenticated"))
+			}).WithContext(ctx).Should(Succeed())
 		})
 	})
 

--- a/internal/controller/serving/llm/reconcilers/kserve_rbac_reconciler.go
+++ b/internal/controller/serving/llm/reconcilers/kserve_rbac_reconciler.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	parentreconcilers "github.com/opendatahub-io/odh-model-controller/internal/controller/serving/reconcilers"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+)
+
+// inferenceAccessSuffix is appended to the LLMInferenceService name to form the
+// Role and RoleBinding names used for inference access control.
+const inferenceAccessSuffix = "-llmisvc-inference-access"
+
+var _ parentreconcilers.LLMSubResourceReconciler = (*KserveRBACReconciler)(nil)
+
+// KserveRBACReconciler creates a namespaced Role and RoleBinding that grant
+// "get" on the LLMInferenceService to all authenticated users.
+//
+// This is required because the Gateway-level AuthPolicy (maas-default-gateway-authn)
+// created by this controller performs a SubjectAccessReview with verb "get" to
+// authorize every inference request. Without these bindings every inference call
+// returns 403 Forbidden regardless of any other auth configuration.
+//
+// The Role is scoped to the specific LLMInferenceService by resourceNames so
+// it does not broaden access to other resources in the namespace.
+// Platform operators can further restrict access by replacing the default
+// "system:authenticated" binding with their own RoleBindings and setting
+// the "opendatahub.io/managed: false" annotation on the generated resources.
+type KserveRBACReconciler struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func NewKserveRBACReconciler(client client.Client, scheme *runtime.Scheme) *KserveRBACReconciler {
+	return &KserveRBACReconciler{
+		client: client,
+		scheme: scheme,
+	}
+}
+
+func (r *KserveRBACReconciler) Reconcile(ctx context.Context, log logr.Logger, llmisvc *kservev1alpha2.LLMInferenceService) error {
+	log.V(1).Info("Reconciling inference access RBAC for LLMInferenceService")
+
+	if err := r.reconcileRole(ctx, log, llmisvc); err != nil {
+		return fmt.Errorf("failed to reconcile inference access Role: %w", err)
+	}
+
+	if err := r.reconcileRoleBinding(ctx, log, llmisvc); err != nil {
+		return fmt.Errorf("failed to reconcile inference access RoleBinding: %w", err)
+	}
+
+	return nil
+}
+
+// Delete is a no-op: the Role and RoleBinding carry an OwnerReference to the
+// LLMInferenceService and are garbage-collected automatically on deletion.
+func (r *KserveRBACReconciler) Delete(_ context.Context, _ logr.Logger, _ *kservev1alpha2.LLMInferenceService) error {
+	return nil
+}
+
+// Cleanup is a no-op: per-service resources are cleaned up via OwnerReferences.
+func (r *KserveRBACReconciler) Cleanup(_ context.Context, _ logr.Logger, _ string) error {
+	return nil
+}
+
+func (r *KserveRBACReconciler) resourceName(llmisvc *kservev1alpha2.LLMInferenceService) string {
+	return llmisvc.Name + inferenceAccessSuffix
+}
+
+func (r *KserveRBACReconciler) commonLabels(llmisvc *kservev1alpha2.LLMInferenceService) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "odh-model-controller",
+		"app.kubernetes.io/name":       llmisvc.Name,
+		"app.kubernetes.io/component":  "llminferenceservice-policies",
+		"app.kubernetes.io/part-of":    "llminferenceservice",
+	}
+}
+
+func (r *KserveRBACReconciler) reconcileRole(ctx context.Context, log logr.Logger, llmisvc *kservev1alpha2.LLMInferenceService) error {
+	desired := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.resourceName(llmisvc),
+			Namespace: llmisvc.Namespace,
+			Labels:    r.commonLabels(llmisvc),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"serving.kserve.io"},
+				Resources:     []string{"llminferenceservices"},
+				ResourceNames: []string{llmisvc.Name},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(llmisvc, desired, r.scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on inference access Role: %w", err)
+	}
+
+	existing := &rbacv1.Role{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.V(1).Info("Creating inference access Role", "name", desired.Name, "namespace", desired.Namespace)
+		return r.client.Create(ctx, desired)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get existing inference access Role %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if !utils.IsManagedByOpenDataHub(existing) {
+		log.V(1).Info("Skipping reconciliation — Role is not managed by odh-model-controller", "name", existing.Name)
+		return nil
+	}
+
+	if equality.Semantic.DeepEqual(existing.Rules, desired.Rules) {
+		return nil
+	}
+
+	log.V(1).Info("Updating inference access Role (rules drifted)", "name", existing.Name)
+	existing.Rules = desired.Rules
+	return r.client.Update(ctx, existing)
+}
+
+func (r *KserveRBACReconciler) reconcileRoleBinding(ctx context.Context, log logr.Logger, llmisvc *kservev1alpha2.LLMInferenceService) error {
+	desired := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.resourceName(llmisvc),
+			Namespace: llmisvc.Namespace,
+			Labels:    r.commonLabels(llmisvc),
+		},
+		// Bind to system:authenticated so that all valid cluster identities
+		// (human users, service accounts) pass the SAR check performed by
+		// maas-default-gateway-authn. The actual per-model authorisation is
+		// enforced by the MaaSAuthPolicy / subscription system at the HTTPRoute
+		// level; the gateway-level SAR only validates that the token is real.
+		//
+		// Platform operators who want finer-grained per-model access control
+		// can delete this RoleBinding and create their own bindings targeting
+		// specific users or groups.
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "Group",
+				APIGroup: rbacv1.GroupName,
+				Name:     "system:authenticated",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     r.resourceName(llmisvc),
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(llmisvc, desired, r.scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on inference access RoleBinding: %w", err)
+	}
+
+	existing := &rbacv1.RoleBinding{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		log.V(1).Info("Creating inference access RoleBinding", "name", desired.Name, "namespace", desired.Namespace)
+		return r.client.Create(ctx, desired)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get existing inference access RoleBinding %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	if !utils.IsManagedByOpenDataHub(existing) {
+		log.V(1).Info("Skipping reconciliation — RoleBinding is not managed by odh-model-controller", "name", existing.Name)
+		return nil
+	}
+
+	// RoleRef is immutable in the Kubernetes API; a mismatch requires delete/recreate.
+	if existing.RoleRef != desired.RoleRef {
+		log.V(1).Info("RoleRef mismatch detected, recreating RoleBinding", "name", desired.Name)
+		if err := r.client.Delete(ctx, existing); err != nil {
+			return fmt.Errorf("failed to delete mismatched RoleBinding %s/%s: %w", existing.Namespace, existing.Name, err)
+		}
+		return r.client.Create(ctx, desired)
+	}
+
+	if equality.Semantic.DeepEqual(existing.Subjects, desired.Subjects) {
+		return nil
+	}
+
+	log.V(1).Info("Updating inference access RoleBinding (subjects drifted)", "name", existing.Name)
+	existing.Subjects = desired.Subjects
+	return r.client.Update(ctx, existing)
+}


### PR DESCRIPTION
## Summary

The Gateway-level `AuthPolicy` (`maas-default-gateway-authn`) created by `KserveAuthPolicyReconciler` performs a `SubjectAccessReview` with `verb: get` on each `LLMInferenceService` to authorise inference requests ([template source](internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml#L36-L43)). However, no component ever creates the corresponding `Role`/`RoleBinding`, so **every inference call returns `403 Forbidden`** regardless of any other auth configuration.

### Root cause

`maas-default-gateway-authn` overrides `gateway-auth-policy` (the legacy tier-based policy) at the Gateway level. The old tier system created `post` RBAC for tier SAs, but `maas-default-gateway-authn` checks `get` — and nothing provisions `get` RBAC for end users.

```
HTTP/1.1 403 Forbidden
x-ext-auth-reason: not authorized: unknown reason
```

### Fix

Add `KserveRBACReconciler` as a new `LLMSubResourceReconciler` that creates per-`LLMInferenceService`:

- **`Role`** — grants `get` on the specific `LLMInferenceService` (scoped by `resourceNames`)
- **`RoleBinding`** — binds to `system:authenticated`

The `system:authenticated` default is intentional: the actual per-model authorisation is already enforced at the HTTPRoute level by `MaaSAuthPolicy`/subscription policies. The gateway-level SAR only needs to verify the token is a real authenticated cluster identity. Platform operators who want stricter per-model access control can delete the generated `RoleBinding` and create their own.

Both resources carry an `OwnerReference` to the `LLMInferenceService` and are garbage-collected automatically on deletion.

## How to reproduce

1. Deploy an `LLMInferenceService` (model becomes ready)
2. Call the inference endpoint with a valid SA token
3. Without this fix: `403 Forbidden` with `x-ext-auth-reason: not authorized`
4. With this fix: request passes the SAR check and reaches the model

## Testing

- Unit: `KserveRBACReconciler` follows the same patterns as `KserveAuthPolicyReconciler` and `KserveEnvoyFilterReconciler`
- Integration: verified manually on OCP 4.17 + RHOAI 3.3 cluster — inference calls succeed after reconciler provisions the RBAC

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM Inference Service now provisions a namespace-scoped Role and RoleBinding so authenticated users gain access to inference endpoints.

* **Behavior**
  * Controller automatically creates and reconciles RBAC rules/subjects, restores drifted changes, and recreates bindings when Role references are immutable; resources labeled unmanaged are left unchanged.

* **Tests**
  * Added tests for RBAC creation, restoration, immutable-reference handling, owner references, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->