### PR TITLE
Remove build platforms from CI configuration

### DIFF
--- a/.tekton/odh-model-serving-api-ci-on-push.yaml
+++ b/.tekton/odh-model-serving-api-ci-on-push.yaml
@@ -28,12 +28,6 @@ spec:
     value: Containerfile.server
   - name: path-context
     value: .
-  - name: build-platforms
-    value:
-    - linux/x86_64
-    - linux/aarch64
-    - linux/ppc64le
-    - linux/s390x
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Removed build platforms from the CI configuration.

Pipelines remain in pending state for days due to multi platform requirements, align with the controller image build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline configuration by removing multi-architecture build platform settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->