### PR TITLE
update: github release to include wva and kv-cache

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -4,19 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       repository:
-        description: 'Target repository (odh-model-controller, kserve, llm-d-inference-scheduler)'
+        description: 'Target repository (odh-model-controller, kserve, llm-d-inference-scheduler, workload-variant-autoscaler and llm-d-kv-cache)'
         required: true
         type: choice
         options:
           - odh-model-controller
           - llm-d-inference-scheduler
           - kserve
+          - llm-d-kv-cache
+          - workload-variant-autoscaler
       tag_name: # The new release tag to be created and used as the search value.
         description: 'New release tag (e.g., odh-v2.35)'
         required: true
         type: string
       next_tag_name: # The next tag to replace the current one in the Konflux files.
-        description: 'Next development tag (e.g., odh-v2.36) - not required for llm-d-inference-scheduler'
+        description: 'Next development tag (e.g., odh-v2.36) - not required for llm-d-inference-scheduler, wva or kv-cache '
         required: false
         type: string
       target_branch:
@@ -89,7 +91,7 @@ jobs:
             errors.append(f"Tag '{tag_name}' does not match expected format 'odh-vX.Y' or 'odh-vX.Y.Z'")
           
           # next_tag validation only required for repos that need Tekton bumping
-          if repository != "llm-d-inference-scheduler":
+          if repository not in ("llm-d-inference-scheduler", "workload-variant-autoscaler", "llm-d-kv-cache"):
             if not next_tag:
               errors.append("next_tag_name is required for this repository")
             elif not re.match(tag_pattern, next_tag):
@@ -137,9 +139,9 @@ jobs:
           
           repository = "${{ github.event.inputs.repository }}"
           
-          # Skip file discovery for llm-d-inference-scheduler
-          if repository == "llm-d-inference-scheduler":
-            print("Skipping file discovery for llm-d-inference-scheduler")
+          # Skip file discovery for llm-d repo
+          if repository in ("llm-d-inference-scheduler", "workload-variant-autoscaler", "llm-d-kv-cache"): 
+            print("Skipping file discovery for llm-d repo")
             with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"params_env_files=[]\n")
               f.write(f"tekton_files=[]\n")
@@ -220,7 +222,7 @@ jobs:
           else:
             # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar)[\w.-]+):()(fast|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-kv-cache)[\w.-]+):()(fast|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
this is to include wva and kv-cache into the same release process as inference-scheduler
which is easier for either llm-d or serving team (to be defined) to work with ODH release.

it is not mandatory for 3.4 release, we can get it into 3.5ea1


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended release workflow to support `workload-variant-autoscaler` and `llm-d-kv-cache` repositories
  * Updated validation requirements for tag naming input across specified repositories
  * Refined file discovery and image tag update logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->