### PR TITLE
fix: remove auto-merge and add tide/merge-method-merge label

### DIFF
--- a/.github/workflows/prow-merge-incubating-with-main.yaml
+++ b/.github/workflows/prow-merge-incubating-with-main.yaml
@@ -63,7 +63,7 @@ jobs:
             --base "$TARGET_BRANCH" \
             --head "$SYNC_BRANCH" \
             --title "Merge $SOURCE_BRANCH to $TARGET_BRANCH" \
-            --body "Automated merge of $SOURCE_BRANCH into $TARGET_BRANCH")
+            --body "Automated merge of $SOURCE_BRANCH into $TARGET_BRANCH" \
+            --label "tide/merge-method-merge")
 
-          # Enable auto-merge with merge strategy (not squash)
-          gh pr merge --auto --merge "$PR_URL"
+          echo "Created sync PR: $PR_URL"


### PR DESCRIPTION
Follow-up to #785. Two changes:

- Remove `gh pr merge --auto` since the repo doesn't have "Allow auto-merge" enabled
- Add `tide/merge-method-merge` label to sync PRs so Tide uses merge strategy
- Echo created PR URL for workflow log visibility