### PR TITLE
fix: add MASTER_PORT env var to vllm multinode template

### DIFF
--- a/config/runtimes/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm-multinode-template.yaml
@@ -55,6 +55,8 @@ objects:
           - vllm
           - serve
           env:
+            - name: MASTER_PORT
+              value: "29500"
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Add MASTER_PORT=29500 env var to the vllm multinode head pod template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vLLM multi-node template configuration with explicit master port settings for head and worker containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->