### PR TITLE
RHOAIENG-58209: fix(server): change metrics port from 9090 to 8080

### DIFF
--- a/config/server/server.yaml
+++ b/config/server/server.yaml
@@ -46,7 +46,7 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-            - containerPort: 9090
+            - containerPort: 8080
               name: metrics
               protocol: TCP
           livenessProbe:

--- a/config/server/service.yaml
+++ b/config/server/service.yaml
@@ -12,8 +12,8 @@ spec:
       protocol: TCP
       targetPort: 8443
     - name: metrics
-      port: 9090
+      port: 8080
       protocol: TCP
-      targetPort: 9090
+      targetPort: 8080
   selector:
     app: model-serving-api

--- a/server/README.md
+++ b/server/README.md
@@ -42,7 +42,7 @@ The server requires a kubeconfig and TLS certificates. Environment variables:
 | `TLS_CERT_DIR`                |         | Directory containing `tls.crt` and `tls.key` (required)                        |
 | `LOG_LEVEL`                   | `info`  | Log level (`debug`, `info`, `warn`, `error`)                                   |
 | `GATEWAY_LABEL_SELECTOR`      |         | Comma-separated `key=value` pairs to filter Gateways                           |
-| `METRICS_ADDR`                | `:9090` | HTTPS address for Prometheus `/metrics` endpoint (reuses main TLS certs)       |
+| `METRICS_ADDR`                | `:8080` | HTTPS address for Prometheus `/metrics` endpoint (reuses main TLS certs)       |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` |         | OTLP collector endpoint; enables trace export when set (e.g. `localhost:4317`) |
 
 ### Container Image

--- a/server/config.go
+++ b/server/config.go
@@ -31,7 +31,7 @@ func LoadConfig() (Config, error) {
 		ListenAddr:   envOrDefault("LISTEN_ADDR", ":8443"),
 		TLSCertDir:   os.Getenv("TLS_CERT_DIR"),
 		LogLevel:     envOrDefault("LOG_LEVEL", "info"),
-		MetricsAddr:  envOrDefault("METRICS_ADDR", ":9090"),
+		MetricsAddr:  envOrDefault("METRICS_ADDR", ":8080"),
 		OTLPEndpoint: os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 	}
 

--- a/server/docs/features/observability/README.md
+++ b/server/docs/features/observability/README.md
@@ -5,7 +5,7 @@ Prometheus-compatible metrics and optional distributed tracing via OpenTelemetry
 ## Metrics
 
 The `otelhttp` middleware automatically records HTTP server metrics, exported via a Prometheus `/metrics` endpoint on a
-dedicated HTTPS port (`:9090`, reusing the main server's TLS certs). A `ServiceMonitor` (
+dedicated HTTPS port (`:8080`, reusing the main server's TLS certs). A `ServiceMonitor` (
 `config/server/servicemonitor.yaml`) enables automatic scraping by Prometheus Operator.
 
 Metrics emitted (Prometheus exposition names):
@@ -28,5 +28,5 @@ spans for each request automatically.
 
 | Variable                      | Default | Description                                            |
 |-------------------------------|---------|--------------------------------------------------------|
-| `METRICS_ADDR`                | `:9090` | HTTPS listen address for `/metrics`                    |
+| `METRICS_ADDR`                | `:8080` | HTTPS listen address for `/metrics`                    |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | (none)  | OTLP collector endpoint; enables trace export when set |

--- a/server/observability/observability.go
+++ b/server/observability/observability.go
@@ -22,7 +22,7 @@ import (
 
 // Config holds the observability configuration.
 type Config struct {
-	MetricsAddr  string      // HTTPS listen address for Prometheus /metrics endpoint (default ":9090")
+	MetricsAddr  string      // HTTPS listen address for Prometheus /metrics endpoint (default ":8080")
 	TLSConfig    *tls.Config // TLS configuration for the metrics server
 	OTLPEndpoint string      // Optional OTLP collector endpoint; enables trace export when set
 	ServiceName  string      // OTel service name (default "model-serving-api")


### PR DESCRIPTION
The redhat-ods-applications NetworkPolicy restricts ingress to a fixed set of ports that does not include 9090, causing all metrics traffic to be dropped. Align the model-serving-api metrics port to 8080, which is in the allowed list and matches the controller manager's metrics port.

Ref: [RHOAIENG-58209](https://redhat.atlassian.net/browse/RHOAIENG-58209)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metrics monitoring port from 9090 to 8080 across deployment and service configurations.
  * Updated corresponding documentation and default configuration values to reflect the new metrics port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->