### PR TITLE
RHAIRFE-947: [Spike] Multi-cluster authn/z

### DIFF
--- a/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
+++ b/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
@@ -1,8 +1,8 @@
 # Multi-Cluster Authentication with JWT Token Exchange
 
-Extend `authpolicy_llm_isvc_userdefined.yaml` to support multi-cluster authentication
-using signed JWT tokens for cross-cluster identity portability (implemented via
-Kuadrant's wristband feature).
+Extend `authpolicy_llm_isvc_userdefined.yaml` to support JWT-based authentication
+beyond local Kubernetes tokens: cross-cluster identity portability (via Kuadrant's
+wristband feature) and external OIDC providers (e.g., HashiCorp Vault, Keycloak).
 
 ## Problem
 
@@ -10,6 +10,11 @@ Kubernetes tokens are cluster-scoped. A ServiceAccount token valid on cluster A 
 authenticate on cluster B. In a multi-cluster topology where inference workloads are
 distributed across clusters, users need a portable identity token to access models on
 any cluster where they have been granted RBAC.
+
+Additionally, organizations may have existing identity providers (HashiCorp Vault,
+Keycloak, Auth0) that issue JWTs to users outside the Kubernetes ecosystem. These
+users need to authenticate to inference endpoints without requiring a Kubernetes
+identity on every cluster.
 
 ## Architecture: peer-to-peer
 
@@ -34,7 +39,9 @@ Each cluster enforces its own RBAC independently.
  │  │                                        │  │    │  │                                        │  │
  │  │  Listener ──► Authorino                │  │    │  │  Listener ──► Authorino                │  │
  │  │                  │                     │  │    │  │                  │                     │  │
- │  │                  ├─ authn: k8s / JWT   │  │    │  │                  ├─ authn: k8s / JWT   │  │
+ │  │                  ├─ authn: k8s token   │  │    │  │                  ├─ authn: k8s token   │  │
+ │  │                  ├─ authn: peer JWT    │  │    │  │                  ├─ authn: peer JWT    │  │
+ │  │                  ├─ authn: external JWT│  │    │  │                  ├─ authn: external JWT│  │
  │  │                  ├─ authz: SAR (RBAC)  │  │    │  │                  ├─ authz: SAR (RBAC)  │  │
  │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
  │                     │                        │    │                     │                        │
@@ -58,7 +65,14 @@ Each cluster enforces its own RBAC independently.
  │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
  └──────────────────────────────────────────────┘    └──────────────────────────────────────────────┘
                                           ▲            ▲
-                          Signing keys distributed via GitOps / ACM / HashiCorp Vault
+                          Signing keys distributed via GitOps / ACM
+
+                              ┌──────────────────────────────────────┐
+                              │ External OIDC Provider               │
+                              │ (Vault, Keycloak, Auth0, ...)        │
+                              │                                      │
+                              │  JWKS endpoint ◄── Authorino fetches │
+                              └──────────────────────────────────────┘
 ```
 
 ### Token exchange flow
@@ -195,9 +209,9 @@ Responder
 All changes are additive. The existing `kubernetesTokenReview` + `SubjectAccessReview`
 flow remains the primary authentication/authorization path for local users.
 
-On peer clusters, the `jwt` authentication method is configured alongside
-`kubernetesTokenReview`. Authorino evaluates all authentication configs — at least one
-must succeed. Local Kubernetes tokens continue to work unchanged.
+Additional `jwt` authentication methods (peer wristbands and/or external OIDC providers)
+are configured alongside `kubernetesTokenReview`. Authorino evaluates all authentication
+configs — at least one must succeed. Local Kubernetes tokens continue to work unchanged.
 
 ## Token endpoint: `/api/v1/token`
 
@@ -1423,6 +1437,218 @@ oc exec -n default dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
   $GW/api/v1/token
 # Expected: 401 (wristband-user auth is disabled on /api/v1/token via when predicate)
 ```
+
+## External JWT issuers
+
+In addition to the built-in wristband token exchange, operators can configure external
+OIDC providers (e.g., HashiCorp Vault, Keycloak, Auth0) as additional JWT authentication
+sources. This runs in parallel with both `kubernetes-user` and `wristband-user` — Authorino
+evaluates all authentication methods and succeeds if at least one matches.
+
+### Annotation
+
+Configure external issuers via a Gateway annotation. The value is a JSON array of
+issuer objects:
+
+```yaml
+annotations:
+  security.opendatahub.io/authn-jwt-jwks: |
+    [
+      {"prefix": "vault", "jwksUrl": "https://vault.example.com/v1/identity/oidc/.well-known/keys"},
+      {"prefix": "keycloak", "jwksUrl": "https://keycloak.example.com/realms/inference/protocol/openid-connect/certs"}
+    ]
+```
+
+Each object has the following fields:
+
+| Field     | Required | Description                                                                                                         |
+|-----------|----------|---------------------------------------------------------------------------------------------------------------------|
+| `prefix`  | Yes      | Short identifier used to namespace the auth rule and prefix identities (e.g., `vault` → `jwt-vault`, `vault:alice`) |
+| `jwksUrl` | Yes      | JWKS endpoint URL. Authorino fetches public keys from this URL                                                      |
+
+JSON is used instead of a simpler key-value format to allow future extensibility (e.g.,
+adding `jwksSecretRef` for air-gapped environments without a format migration).
+
+The `prefix` must be unique within the annotation. It is used to:
+1. Name the authentication rule in the AuthPolicy (`jwt-<prefix>`)
+2. Prefix usernames and groups to prevent identity collisions (`<prefix>:<identity>`)
+
+### Generated authentication rules
+
+For each entry, the controller generates a `jwt` authentication rule in the AuthPolicy:
+
+```yaml
+authentication:
+  kubernetes-user:
+    # ... unchanged ...
+
+  wristband-user:
+    # ... unchanged (built-in token exchange) ...
+
+  # Generated from annotation entry: {"prefix": "vault", "jwksUrl": "https://vault.example.com/..."}
+  jwt-vault:
+    when:
+      - predicate: "request.path != '/api/v1/token'"
+    jwt:
+      jwksUrl: "https://vault.example.com/v1/identity/oidc/.well-known/keys"
+    overrides:
+      user:
+        expression: "{'username': 'vault:' + auth.identity.sub, 'groups': has(auth.identity.groups) ? auth.identity.groups.map(g, 'vault:' + g) : []}"
+      fairness:
+        expression: auth.identity.iss
+      objective:
+        expression: "'authenticated'"
+    priority: 2
+```
+
+Key points:
+
+- **Token escalation prevention**: The `when` predicate disables external JWT auth on
+  `/api/v1/token`, same as `wristband-user`. Only `kubernetesTokenReview` can mint
+  wristband tokens.
+- **Priority**: External issuers use `priority: 2` (after `kubernetes-user` at 0 and
+  `wristband-user` at 1). Authorino evaluates lower-priority methods first, so local
+  auth is preferred when both could match.
+- **Credential extraction**: Uses the default `Authorization: Bearer` header, same as
+  all other auth methods.
+
+### Identity normalization
+
+External JWTs have different claim structures than Kubernetes tokens or wristbands.
+The `overrides` section normalizes the identity so that downstream authorization rules
+(`auth.identity.user.username`, `auth.identity.user.groups`) work without modification.
+
+The username is **prefixed with the issuer prefix** to avoid collisions with local
+Kubernetes identities or across multiple providers:
+
+| Auth method       | `auth.identity.user.username`                          | `auth.identity.user.groups`                     |
+|-------------------|--------------------------------------------------------|-------------------------------------------------|
+| `kubernetes-user` | `system:serviceaccount:ns:name`                        | `["system:serviceaccounts", ...]`               |
+| `wristband-user`  | `system:serviceaccount:ns:name` (from wristband claim) | `["system:serviceaccounts", ...]` (from claim)  |
+| `jwt-vault`       | `vault:<sub-claim>`                                    | `["vault:ml-engineers", ...]` or `[]`           |
+
+The prefix (`vault:`) is applied to both usernames and groups to ensure that external
+identities cannot collide with local Kubernetes identities. A Vault user `alice` is
+authorized as `vault:alice`, and a Vault group `ml-engineers` becomes `vault:ml-engineers`.
+RoleBindings must reference the prefixed identities.
+
+### Vault example
+
+HashiCorp Vault can act as an OIDC provider via its
+[Identity Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/identity/oidc-provider).
+Vault issues JWTs and serves JWKS at a well-known endpoint.
+
+**Vault setup** (outside the scope of this controller):
+
+1. Enable the OIDC provider in Vault
+2. Create a named key and role that issues tokens with `sub`, `groups`, and other claims
+3. Vault serves JWKS at `https://vault.example.com/v1/identity/oidc/.well-known/keys`
+
+**Cluster setup**:
+
+```yaml
+# 1. Annotate the Gateway
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: openshift-ai-inference
+  namespace: openshift-ingress
+  annotations:
+    security.opendatahub.io/authn-jwt-jwks: |
+      [{"prefix": "vault", "jwksUrl": "https://vault.example.com/v1/identity/oidc/.well-known/keys"}]
+
+# 2. Create RoleBindings for Vault identities (using prefixed username)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-alice-inference-access
+  namespace: model-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: User
+    name: "vault:alice"
+    apiGroup: rbac.authorization.k8s.io
+```
+
+**Group-based RBAC** (recommended): Instead of binding individual Vault users, bind
+Vault groups. This scales better — adding a user to the Vault group automatically grants
+inference access without creating per-user RoleBindings:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-ml-team-inference-access
+  namespace: model-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: Group
+    name: "vault:ml-engineers"    # Prefixed Vault group name
+    apiGroup: rbac.authorization.k8s.io
+```
+
+For group-based RBAC to work, the Vault OIDC role must include a `groups` claim in the
+JWT. The controller's override expression (`has(auth.identity.groups) ? auth.identity.groups : []`)
+handles JWTs with or without a groups claim.
+
+**Usage**:
+
+```bash
+# 1. Obtain a Vault token (via Vault CLI, API, or UI)
+VAULT_JWT=$(vault read -field=token identity/oidc/token/inference-role)
+
+# 2. Use the Vault JWT for inference
+curl -H "Authorization: Bearer $VAULT_JWT" \
+  https://inference.example.com/<ns>/<model>/v1/chat/completions
+```
+
+### Template changes
+
+Add to `authPolicyTemplateData`:
+
+```go
+type authPolicyTemplateData struct {
+    // ... existing fields ...
+    // External JWT issuers
+    ExternalIssuers []ExternalIssuer
+}
+
+type ExternalIssuer struct {
+    Prefix  string `json:"prefix"`  // e.g., "vault"
+    JwksUrl string `json:"jwksUrl"` // e.g., "https://vault.example.com/v1/identity/oidc/.well-known/keys"
+}
+```
+
+The controller parses the `security.opendatahub.io/authn-jwt-jwks` annotation and
+populates `ExternalIssuers`. The template iterates over the list to generate one `jwt`
+authentication rule per issuer.
+
+### Security considerations
+
+- **No hard dependency**: External issuers are optional. If the annotation is absent,
+  only `kubernetes-user` and `wristband-user` (if token exchange is enabled) are
+  configured. Removing the annotation removes the external auth rules.
+- **JWKS URL reachability**: Authorino must be able to reach the JWKS URL. For external
+  providers (Vault, Keycloak), this typically requires network connectivity from the
+  cluster to the provider. Authorino caches JWKS and refreshes periodically.
+- **Identity prefix prevents escalation**: The `vault:` prefix ensures that a Vault user
+  cannot impersonate a Kubernetes ServiceAccount (e.g., `vault:alice` ≠
+  `system:serviceaccount:ns:alice`). The SAR checks the prefixed identity against RBAC.
+- **Token validation**: Authorino verifies the JWT signature against the JWKS, checks
+  `exp` for expiration, and (with `issuerUrl` instead of `jwksUrl`) validates the `iss`
+  claim. The controller uses `jwksUrl` by default for flexibility — operators who want
+  issuer validation can manually configure `issuerUrl` in the AuthPolicy.
+- **Trust boundary**: Adding an external issuer extends the trust boundary to that
+  provider. A compromised Vault instance could mint JWTs with arbitrary claims. This
+  is equivalent to the compromised peer scenario (see "Compromised peer trust boundary")
+  — the mitigation is the same: rapid annotation removal to revoke trust.
 
 ## Open questions
 

--- a/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
+++ b/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
@@ -1493,7 +1493,7 @@ authentication:
       jwksUrl: "https://vault.example.com/v1/identity/oidc/.well-known/keys"
     overrides:
       user:
-        expression: "{'username': 'vault:' + auth.identity.sub, 'groups': has(auth.identity.groups) ? auth.identity.groups.map(g, 'vault:' + g) : []}"
+        expression: "{'username': 'vault:' + auth.identity.username, 'groups': has(auth.identity.groups) && auth.identity.groups != null ? auth.identity.groups.map(g, 'vault:' + g) : []}"
       fairness:
         expression: auth.identity.iss
       objective:
@@ -1511,6 +1511,14 @@ Key points:
   auth is preferred when both could match.
 - **Credential extraction**: Uses the default `Authorization: Bearer` header, same as
   all other auth methods.
+- **Username claim**: The expression uses `auth.identity.username` (a custom claim
+  containing the entity name), not `auth.identity.sub` (which is the entity UUID in
+  Vault). Vault OIDC roles must include a `username` claim in their token template:
+  `"username": {{identity.entity.name}}`. Other OIDC providers may use `sub` directly
+  if it contains a human-readable identifier.
+- **Null groups handling**: The `groups` claim may be `null` (not `[]`) when the entity
+  has no group membership (validated with Vault). The CEL expression checks both
+  `has(auth.identity.groups)` and `auth.identity.groups != null` before mapping.
 
 ### Identity normalization
 
@@ -1525,7 +1533,7 @@ Kubernetes identities or across multiple providers:
 |-------------------|--------------------------------------------------------|-------------------------------------------------|
 | `kubernetes-user` | `system:serviceaccount:ns:name`                        | `["system:serviceaccounts", ...]`               |
 | `wristband-user`  | `system:serviceaccount:ns:name` (from wristband claim) | `["system:serviceaccounts", ...]` (from claim)  |
-| `jwt-vault`       | `vault:<sub-claim>`                                    | `["vault:ml-engineers", ...]` or `[]`           |
+| `jwt-vault`       | `vault:<username-claim>`                               | `["vault:ml-engineers", ...]` or `[]`           |
 
 The prefix (`vault:`) is applied to both usernames and groups to ensure that external
 identities cannot collide with local Kubernetes identities. A Vault user `alice` is
@@ -1541,8 +1549,17 @@ Vault issues JWTs and serves JWKS at a well-known endpoint.
 **Vault setup** (outside the scope of this controller):
 
 1. Enable the OIDC provider in Vault
-2. Create a named key and role that issues tokens with `sub`, `groups`, and other claims
+2. Create a named key (must use RS256 — see note below) and an OIDC role that issues
+   tokens with `username` (entity name), `groups`, and other claims. The role's token
+   template must include `"username": {{identity.entity.name}}` because Vault's default
+   `sub` claim contains the entity UUID, not the human-readable name
 3. Vault serves JWKS at `https://vault.example.com/v1/identity/oidc/.well-known/keys`
+
+**Note on signing algorithm**: Vault's OIDC JWKS endpoint serves all named keys
+alongside default RS256 keys. Authorino's go-jose library may reject JWTs signed with
+a different algorithm (e.g., ES256) when the JWKS contains RS256 keys first. Use RS256
+for the named key to avoid algorithm mismatch errors. See
+`VAULT_INTEGRATION_TEST_PLAN.md` for validated details.
 
 **Cluster setup**:
 
@@ -1595,8 +1612,10 @@ subjects:
 ```
 
 For group-based RBAC to work, the Vault OIDC role must include a `groups` claim in the
-JWT. The controller's override expression (`has(auth.identity.groups) ? auth.identity.groups : []`)
-handles JWTs with or without a groups claim.
+JWT. The controller's override expression
+(`has(auth.identity.groups) && auth.identity.groups != null ? auth.identity.groups.map(g, 'vault:' + g) : []`)
+handles JWTs with or without a groups claim. Note: Vault returns `"groups": null` (not
+`[]`) when an entity has no group membership — the null check is required.
 
 **Usage**:
 

--- a/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
+++ b/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
@@ -1,0 +1,1441 @@
+# Multi-Cluster Authentication with JWT Token Exchange
+
+Extend `authpolicy_llm_isvc_userdefined.yaml` to support multi-cluster authentication
+using signed JWT tokens for cross-cluster identity portability (implemented via
+Kuadrant's wristband feature).
+
+## Problem
+
+Kubernetes tokens are cluster-scoped. A ServiceAccount token valid on cluster A cannot
+authenticate on cluster B. In a multi-cluster topology where inference workloads are
+distributed across clusters, users need a portable identity token to access models on
+any cluster where they have been granted RBAC.
+
+## Architecture: peer-to-peer
+
+Every cluster is an equal peer — each can issue JWT tokens and consume tokens
+issued by other peers. There is no hub/spoke distinction. The token proves the
+user's **identity** (who they are), not their **authorization** (what they can do).
+Each cluster enforces its own RBAC independently.
+
+### Component diagram
+
+```text
+                                                 Client
+                                                   │
+                                           External LB / DNS
+                                  ┌────────────────┴────────────────┐
+                                  ▼                                 ▼
+ ┌──────────────────────────────────────────────┐    ┌──────────────────────────────────────────────┐
+ │  Cluster A                                   │    │  Cluster B                                   │
+ │                                              │    │                                              │
+ │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
+ │  │ Gateway                                │  │    │  │ Gateway                                │  │
+ │  │                                        │  │    │  │                                        │  │
+ │  │  Listener ──► Authorino                │  │    │  │  Listener ──► Authorino                │  │
+ │  │                  │                     │  │    │  │                  │                     │  │
+ │  │                  ├─ authn: k8s / JWT   │  │    │  │                  ├─ authn: k8s / JWT   │  │
+ │  │                  ├─ authz: SAR (RBAC)  │  │    │  │                  ├─ authz: SAR (RBAC)  │  │
+ │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
+ │                     │                        │    │                     │                        │
+ │       ┌─────────────┴────────────┐           │    │       ┌─────────────┴────────────┐           │
+ │       ▼                          ▼           │    │       ▼                          ▼           │
+ │  ┌────────────────┐  ┌────────────────┐      │    │  ┌────────────────┐  ┌────────────────┐      │
+ │  │model-serving-  │  │ Inference      │      │    │  │model-serving-  │  │ Inference      │      │
+ │  │api (system ns) │  │ Backends       │      │    │  │api (system ns) │  │ Backends       │      │
+ │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │    │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │
+ │  └────────────────┘  └────────────────┘      │    │  └────────────────┘  └────────────────┘      │
+ │                                              │    │                                              │
+ │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
+ │  │ Authorino OIDC (:8083, TLS)            │  │    │  │ Authorino OIDC (:8083, TLS)            │  │
+ │  │ JWKS: cluster-a-key + cluster-b-key    │  │    │  │ JWKS: cluster-b-key + cluster-a-key    │  │
+ │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
+ │                                              │    │                                              │
+ │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
+ │  │ Signing Key Secrets (kuadrant-system)  │  │    │  │ Signing Key Secrets (kuadrant-system)  │  │
+ │  │ ├─ cluster-a-key (auto, signs)         │◄─┼────┼─►│ ├─ cluster-b-key (auto, signs)         │  │
+ │  │ └─ cluster-b-key (peer, verify)        │  │    │  │ └─ cluster-a-key (peer, verify)        │  │
+ │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
+ └──────────────────────────────────────────────┘    └──────────────────────────────────────────────┘
+                                          ▲            ▲
+                          Signing keys distributed via GitOps / ACM / HashiCorp Vault
+```
+
+### Token exchange flow
+
+```text
+Cluster A (or B) (issuing)                        Cluster B (or A) (consuming)
+
+User ──► Gateway /api/v1/token                    Client ──► Gateway ──► Authorino ──► Inference Backend
+           │                                                │
+           ├─ 1. kubernetesTokenReview (authn)              ├─ 1. jwt verification (authn)
+           ├─ 2. No authorization (token path)              ├─ 2. SubjectAccessReview (local RBAC)
+           └─ 3. Issue signed JWT (response)                └─ 3. Set flow control headers (response)
+                    │                                                  ▲
+                    │              signed JWT                          │
+                    └──────────────────────────────────────────────────┘
+```
+
+**Flow**:
+
+1. User authenticates on cluster A with a local Kubernetes token via `GET /api/v1/token`
+2. Cluster A skips authorization for the token path (authentication only)
+3. Cluster A issues a signed JWT containing the user's identity (username, groups)
+4. Client extracts the JWT from the response
+5. Client sends the JWT to cluster B's inference endpoint
+6. Cluster B verifies the JWT signature via JWKS
+7. Cluster B extracts the username and groups from the JWT
+8. Cluster B performs a **local** SubjectAccessReview — the user/SA must exist and have
+   RBAC on cluster B
+
+**Key property**: the token carries identity, not authorization. A stolen or leaked
+token is useless on a cluster where the user has no RBAC. Each cluster is responsible
+for its own access control.
+
+### Assumptions and limitations
+
+- **Identity consistency across clusters**: The JWT encodes the user's Kubernetes
+  identity (e.g., `system:serviceaccount:ns:name`). For RBAC to succeed on a peer
+  cluster, the same user or ServiceAccount (namespace + name) must exist on that cluster.
+  The token does not create identities — it only carries them.
+- **Kuadrant and Authorino installed on every cluster**: Each peer cluster must have
+  Kuadrant with Authorino deployed and configured.
+- **Token carries identity only**: The JWT does not encode authorization decisions.
+  Each cluster enforces its own RBAC via SubjectAccessReview. A valid token from a
+  peer is insufficient without local RoleBindings.
+- **Zero-config single cluster**: The controller auto-generates a local signing key
+  per Gateway. Token exchange via `/api/v1/token` works without any annotation or
+  manual key creation. Multi-cluster requires only adding peer key names to the
+  `security.opendatahub.io/token-exchange-signing-keys` annotation.
+- **Signing key distribution**: Authorino's `signingKeyRefs` requires private keys —
+  it cannot import public-key-only Secrets (rejects with `"invalid signing key
+  algorithm"`). The local signing key is auto-generated; peer signing key pairs
+  (private key Secrets) must be distributed to every cluster that needs to verify
+  their tokens. Authorino publishes all `signingKeyRefs` in a single JWKS endpoint,
+  so a single `jwt` authentication entry is sufficient to verify tokens from all
+  peers whose keys are configured.
+
+## Workflow overview
+
+### Platform admin: multi-cluster setup
+
+```text
+Admin
+  │
+  ├─ 1. On each cluster: export the auto-generated signing key or generate a new one
+  │     ├─ Export: oc get secret <gw>-wristband-signing-key -n kuadrant-system -o yaml
+  │     └─ Generate: openssl ecparam -name prime256v1 -genkey -noout | oc create secret
+  │        generic peer-key -n kuadrant-system --from-file=key.pem=/dev/stdin
+  │
+  ├─ 2. Distribute each cluster's signing key to every peer cluster
+  │     └─ Via GitOps, RH Advanced Cluster Management (ACM), or manual `oc apply` (on each cluster)
+  │
+  ├─ 3. Annotate the Gateway on each cluster with peer key names
+  │     └─ security.opendatahub.io/token-exchange-signing-keys: "peer-a-key,peer-b-key"
+  │
+  ├─ 4. Create RoleBindings for remote identities on each cluster
+  │     └─ Grant remote SAs/users access to local LLMInferenceServices
+  │
+  └─ 5. (Optional) Configure token duration
+        └─ security.opendatahub.io/token-exchange-duration: "31536000"
+
+Controller (on annotation change)
+  │
+  └─ Update AuthPolicy signingKeyRefs: [auto-generated, peer-a-key, peer-b-key]
+     └─ Authorino publishes all keys in a single JWKS endpoint
+```
+
+### Application developer: token exchange flow
+
+```text
+Developer / CI pipeline
+  │
+  ├─ 1. Authenticate on home cluster
+  │     GET /api/v1/token
+  │     Authorization: Bearer <k8s-token>
+  │     └─ Response: {"token": "<jwt>"}
+  │
+  ├─ 2. Use JWT on any peer cluster
+  │     GET /<ns>/<model>/v1/chat/completions
+  │     Authorization: Bearer <jwt>
+  │     │
+  │     ├─ Authorino verifies JWT signature (JWKS)
+  │     ├─ Extracts username/groups from claims
+  │     ├─ SubjectAccessReview against local RBAC
+  │     └─ 200 (authorized) or 403 (no local RBAC)
+  │
+  └─ 3. Same JWT works on any peer where user has RoleBindings
+```
+
+### Incident responder: token revocation
+
+```text
+Responder
+  │
+  ├─ Scope: single identity
+  │  ├─ Remove RoleBindings on affected clusters → 403
+  │  └─ (Optional) Add patternMatching deny rule → 401
+  │
+  ├─ Scope: single token
+  │  └─ Add patternMatching deny rule on sub claim → 401
+  │
+  ├─ Scope: signing key compromised
+  │  ├─ Rotate the signing key Secret
+  │  ├─ Redistribute JWKS to peers
+  │  └─ All existing tokens from that key → 401
+  │
+  └─ Scope: cluster compromised
+     ├─ Remove peer's signing key Secret from all clusters
+     ├─ Update Gateway annotation to exclude peer
+     └─ All tokens from that peer → 401
+```
+
+## Backward compatibility
+
+All changes are additive. The existing `kubernetesTokenReview` + `SubjectAccessReview`
+flow remains the primary authentication/authorization path for local users.
+
+On peer clusters, the `jwt` authentication method is configured alongside
+`kubernetesTokenReview`. Authorino evaluates all authentication configs — at least one
+must succeed. Local Kubernetes tokens continue to work unchanged.
+
+## Token endpoint: `/api/v1/token`
+
+A dedicated gateway path for wristband token exchange. The client authenticates with a
+local Kubernetes token and receives a wristband JWT in the response.
+
+### Routing
+
+The `GatewayReconciler` (`gateway_controller.go`) automatically creates an HTTPRoute
+for `/api/v1/token` for every managed Gateway. The HTTPRoute routes to the
+`model-serving-api` server (`server/`, deployed via `config/server/`).
+
+The server needs a `/api/v1/token` handler that returns the wristband token from the
+`X-Wristband-Token` response header (injected by Authorino into the upstream request)
+in the response body:
+
+```go
+// server/handlers/token.go
+func Token(w http.ResponseWriter, r *http.Request) {
+    token := r.Header.Get("X-Wristband-Token")
+    w.Header().Set("Content-Type", "application/json")
+    w.Header().Set("Cache-Control", "no-store")
+    if token == "" {
+        w.WriteHeader(http.StatusBadGateway)
+        json.NewEncoder(w).Encode(map[string]string{"error": "missing wristband token"})
+        return
+    }
+    json.NewEncoder(w).Encode(map[string]string{"token": token})
+}
+```
+
+Note: `X-Wristband-Token` here is the **internal** response header that Authorino injects
+into the upstream request (configured in `response.success.headers`). It is not the
+client-facing header. The client sends and receives tokens via `Authorization: Bearer`.
+
+Register in `server/server.go`:
+```go
+mux.HandleFunc("/api/v1/token", handlers.Token)
+```
+
+The controller creates the following HTTPRoute (owned by the Gateway for garbage collection):
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <gateway-name>-token-endpoint
+  namespace: <server-namespace>   # opendatahub or redhat-ods-applications
+  labels:
+    app.kubernetes.io/managed-by: odh-model-controller
+spec:
+  parentRefs:
+    - name: openshift-ai-inference
+      namespace: openshift-ingress
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /api/v1/token
+      backendRefs:
+        - name: model-serving-api
+          port: 443
+```
+
+The reconciler follows the same create/update/delete pattern as the existing AuthPolicy
+and EnvoyFilter reconciliation.
+
+The `opendatahub.io/managed: "false"` label/annotation on the Gateway disables all
+controller-managed resources (AuthPolicy, EnvoyFilter, signing key Secret, and the
+token endpoint HTTPRoute).
+
+To disable only the token exchange automation while keeping other controller-managed
+resources, set (on the Gateway):
+
+```yaml
+annotations:
+  security.opendatahub.io/token-exchange: "false"
+```
+
+When set to `"false"`, the controller skips signing key generation, HTTPRoute creation,
+and wristband configuration in the AuthPolicy. This allows operators to manage token
+exchange manually or disable it entirely without affecting other controller behavior.
+
+### Cross-namespace routing
+
+The `model-serving-api` runs in the system namespace (`opendatahub` or
+`redhat-ods-applications`), while the Gateway is in `openshift-ingress`. The HTTPRoute's
+`parentRefs` is a cross-namespace reference.
+
+Gateway API handles this via the Gateway listener's `allowedRoutes` setting:
+
+- **`from: All`** (current default): Any namespace can attach HTTPRoutes — no additional
+  resources needed.
+- **`from: Same`**: Only HTTPRoutes in the gateway's own namespace are accepted. The
+  system namespace would be rejected.
+- **`from: Selector`**: Only namespaces matching a label selector are accepted. The system
+  namespace must carry the required labels.
+
+If the listener restricts namespaces (`Same` or `Selector`), either:
+
+1. **Update the listener** to include the system namespace (preferred — the controller
+   already manages the Gateway spec), or
+2. **Deploy the HTTPRoute in the gateway namespace** and use a `backendRef` with a
+   cross-namespace Service reference. This requires a `ReferenceGrant` in the server's
+   namespace:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-gateway-to-model-serving-api
+  namespace: <server-namespace>   # opendatahub or redhat-ods-applications
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: openshift-ingress
+  to:
+    - group: ""
+      kind: Service
+      name: model-serving-api
+```
+
+Note: `backendRefs` cross-namespace references are **not** controlled by `allowedRoutes`
+— they require a `ReferenceGrant` in the target Service's namespace regardless of the
+listener config.
+
+Since the controller already manages the Gateway and its listeners (see
+`gateway_controller.go`), option 1 is the natural choice — ensure the system namespace
+is allowed in `allowedRoutes`.
+
+### Authorization exclusion
+
+The `/api/v1/token` path must be excluded from authorization rules (like batch paths).
+Authentication is sufficient — if the user has a valid Kubernetes token, they can
+request a wristband:
+
+```yaml
+authorization:
+  inference-access:
+    when:
+      - predicate: >-
+          !(request.path == '/api/v1/token' ||
+            request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+            request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+    # ... existing SAR config unchanged ...
+  inference-access-delegate:
+    when:
+      - predicate: >-
+          !(request.path == '/api/v1/token' ||
+            request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+            request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+      - predicate: "'x-maas-user' in request.headers"
+    # ... existing SAR config unchanged ...
+```
+
+### Wristband response (scoped to `/api/v1/token`)
+
+The wristband is only issued for the token endpoint — not on every request:
+
+```yaml
+response:
+  success:
+    headers:
+      # ... existing headers (fairness, objective, maas-user, maas-groups) unchanged ...
+
+      x-wristband-token:
+        when:
+          - predicate: "request.path == '/api/v1/token'"
+        wristband:
+          issuer: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
+          tokenDuration: 31536000   # configurable via Gateway annotation, default 1 year
+          signingKeyRefs:
+            - name: <gateway-name>-wristband-signing-key   # auto-generated
+              algorithm: ES256
+            # ... peer keys from annotation appended here ...
+          customClaims:
+            username:
+              expression: auth.identity.user.username
+            groups:
+              expression: auth.identity.user.groups
+        priority: 0
+```
+
+**Claims**: The wristband encodes identity only:
+
+| Claim      | Source                        | Purpose                               |
+|------------|-------------------------------|---------------------------------------|
+| `username` | `auth.identity.user.username` | User or SA identity                   |
+| `groups`   | `auth.identity.user.groups`   | Group memberships (stored as array)   |
+| `iss`      | (standard)                    | Issuing cluster's Authorino endpoint  |
+| `sub`      | (standard, auto-generated)    | Unique per token — usable as token ID |
+| `exp`      | (standard)                    | Token expiration                      |
+| `iat`      | (standard)                    | Token issued-at time                  |
+
+Note: Authorino does not include `jti` by default, but `sub` is unique per issuance
+(different hash each time, even for the same user). It can be used to identify specific
+tokens in audit logs.
+
+No authorization-scoped claims (namespace, model) — the wristband is not bound to a
+specific resource. The same wristband works for any model on any peer cluster where the
+user has RBAC.
+
+## Signing keys
+
+### Auto-generated local signing key
+
+The controller automatically generates an ES256 signing key for each Gateway and creates
+a Secret named `<gateway-name>-wristband-signing-key` in the AuthConfig namespace
+(typically `kuadrant-system`). This key is always the **first entry** in `signingKeyRefs`
+— it signs new wristband tokens. No user configuration is needed for single-cluster
+token exchange.
+
+The controller generates the key on first reconciliation if the Secret does not exist,
+and never rotates it automatically (see "Key rotation" for manual rotation). The Secret
+will need to be deleted by the controller when not needed anymore.
+
+```yaml
+# Auto-generated by the controller — no user action required
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <gateway-name>-wristband-signing-key
+  namespace: kuadrant-system
+type: Opaque
+data:
+  key.pem: <auto-generated ES256 private key>
+```
+
+### Adding peer signing keys (multi-cluster)
+
+For multi-cluster scenarios, operators add peer signing keys via the
+`security.opendatahub.io/token-exchange-signing-keys` Gateway annotation. This is a
+comma-separated list of Secret names that are **appended after** the auto-generated
+local key in `signingKeyRefs`:
+
+```yaml
+annotations:
+  # Peer keys for verification — local key is always prepended automatically
+  security.opendatahub.io/token-exchange-signing-keys: "peer-cluster-a-key,peer-cluster-b-key"
+```
+
+The resulting `signingKeyRefs` order is:
+1. `<gateway-name>-wristband-signing-key` (auto-generated, signs new tokens)
+2. `peer-cluster-a-key` (from annotation, verification only)
+3. `peer-cluster-b-key` (from annotation, verification only)
+
+All keys are published in the JWKS. The first key signs; Authorino matches the JWT's
+`kid` against all keys for verification.
+
+Each Secret contains an ES256 private key (Authorino requires private keys in
+`signingKeyRefs` — public-key-only Secrets are rejected). Each peer cluster's signing
+key pair must be distributed to every cluster that needs to verify its tokens.
+
+**Namespace**: All Secrets must be in the namespace where Kuadrant creates AuthConfigs —
+this is the Kuadrant system namespace (typically `kuadrant-system`). Authorino's
+`signingKeyRefs` resolves Secrets by name only (no namespace field), so it looks in the
+AuthConfig's own namespace. Verify with `oc get authconfigs.authorino.kuadrant.io -A`.
+
+Each peer Secret must have a `key.pem` entry:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: peer-cluster-a-key
+  namespace: kuadrant-system
+type: Opaque
+stringData:
+  key.pem: |
+    -----BEGIN EC PRIVATE KEY----- # notsecret
+    <ES256 private key>
+    -----END EC PRIVATE KEY-----
+```
+
+Generate a key pair:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out key.pem
+openssl ec -in key.pem -pubout -out pub.pem
+```
+
+## Wristband issuer URL
+
+The `issuer` field follows the format:
+
+```
+<scheme>://<host>:<port>/<authconfig-namespace>/<authconfig-name>/<wristband-config-name>
+```
+
+- `<host>:<port>`: Authorino OIDC service
+  (`authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083`)
+- `<authconfig-namespace>/<authconfig-name>`: The AuthConfig for the **token endpoint
+  HTTPRoute rule**. Kuadrant creates separate AuthConfigs per topology path (one per
+  HTTPRoute rule). The wristband OIDC/JWKS endpoint is served under the token endpoint's
+  AuthConfig, not the inference endpoints'. AuthConfig names are SHA-256 hashes.
+- `<wristband-config-name>`: The key in `response.success.headers` (`x-wristband-token`)
+
+The issuer URL serves dual purpose:
+1. It becomes the `iss` claim in the wristband JWT
+2. Authorino serves OIDC discovery at `<issuer>/.well-known/openid-configuration` and JWKS
+   at `<issuer>/.well-known/openid-connect/certs`
+
+### OIDC server TLS
+
+The Authorino OIDC server must have TLS enabled so that the `issuer` and `jwksUrl` use
+`https://`. TLS is configured on the Authorino CR (`operator.authorino.kuadrant.io/v1beta1`):
+
+```yaml
+# kuadrant-system/authorino
+spec:
+  oidcServer:
+    tls:
+      enabled: true
+      certSecretRef:
+        name: authorino-oidc-tls   # Secret with tls.crt and tls.key
+```
+
+The controller should verify that `spec.oidcServer.tls.enabled` is `true` on the
+Authorino CR. If TLS is disabled, the wristband issuer URL would use `http://`, which
+means the `iss` claim in issued tokens would contain an `http://` URL. Consumers
+configured with an `https://` issuer URL would reject these tokens due to issuer
+mismatch.
+
+### Computing the AuthConfig name
+
+Kuadrant generates AuthConfig names as the SHA-256 of a **pathID** — a deterministic
+string built from the full Gateway API topology path:
+
+```
+<gatewayClassName>|<gwNs>/<gwName>|<gwNs>/<gwName>#<listenerName>|<routeNs>/<routeName>|<routeNs>/<routeName>#<ruleSectionName>
+```
+
+For example, with GatewayClass `openshift-default`, Gateway `openshift-ingress/openshift-ai-inference`,
+listener `http`, and HTTPRoute `echo-service/token-endpoint` rule `rule-1`:
+
+```
+openshift-default|openshift-ingress/openshift-ai-inference|openshift-ingress/openshift-ai-inference#http|echo-service/token-endpoint|echo-service/token-endpoint#rule-1
+```
+
+SHA-256 of this string → AuthConfig name.
+
+**The controller can predict the AuthConfig name** at AuthPolicy creation time because
+all inputs to the hash (GatewayClass, Gateway, Listener, HTTPRoute, Rule) are known.
+
+Source: `kuadrant-operator` — `api/v1/merge_strategies.go:PathID()` and
+`internal/controller/auth_workflow_helpers.go:AuthConfigNameForPath()`.
+
+**Reusing Kuadrant utilities**: `PathID` is exported and importable from
+`github.com/kuadrant/kuadrant-operator/api/v1` (already a dependency). It takes
+`[]machinery.Targetable` from `github.com/kuadrant/policy-machinery` (already a transitive
+dependency). `AuthConfigNameForPath` is in `internal/controller/` (not importable), but
+it's trivial — SHA-256 of the pathID string:
+
+```go
+import (
+    "crypto/sha256"
+    "encoding/hex"
+
+    kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+    "github.com/kuadrant/policy-machinery/machinery"
+)
+
+// Build the topology path from known objects
+path := []machinery.Targetable{gatewayClass, gateway, listener, httpRoute, httpRouteRule}
+pathID := kuadrantv1.PathID(path)
+
+// Compute the AuthConfig name (same as kuadrant's internal AuthConfigNameForPath)
+hash := sha256.Sum256([]byte(pathID))
+authConfigName := hex.EncodeToString(hash[:])
+```
+
+The `machinery.Targetable` objects can be constructed from the Gateway API objects the
+controller already reconciles (Gateway, HTTPRoute, etc.) using `policy-machinery`'s
+type adapters.
+
+### Rule section name: `rule-<index>`
+
+The rule section name in the pathID (e.g., `rule-1`) is auto-generated by
+`policy-machinery` as `fmt.Sprintf("rule-%d", i+1)` — it's the 1-based index of the
+rule in the HTTPRoute's `spec.rules` array. The HTTPRouteRule `name` field from
+Gateway API is **not used yet** (tracked upstream:
+`TODO: Use the 'name' field of the HTTPRouteRule once it's implemented`).
+
+Since the controller auto-creates the `/api/v1/token` HTTPRoute with a single rule,
+the rule index is always `rule-1` and the hash is stable. Other HTTPRoutes attached to
+the same Gateway do not affect it — each HTTPRoute produces its own AuthConfig(s).
+
+**Important**: The token endpoint HTTPRoute **must not** use named rules
+(`spec.rules[].name`). The controller computes the AuthConfig hash using `rule-1`
+(index-based). If `policy-machinery` adopts the `name` field in the future, using a
+named rule would change the pathID (e.g., `rule-1` → `token-exchange`), producing a
+different AuthConfig hash. This would invalidate the wristband issuer URL and break
+all in-flight tokens. If Kuadrant changes the default behavior from index-based to
+name-based, the controller's hash computation must be updated to match, therefore
+we won't set names on the HTTPRoute rule for the token endpoint.
+
+### Discovering the AuthConfig name (alternative)
+
+If the controller doesn't compute the hash, discover it after deployment:
+
+```bash
+oc get authconfigs.authorino.kuadrant.io -A
+# Example output:
+# NAMESPACE         NAME                                                               READY
+# kuadrant-system   41e136873d122b95c4212edfec0070d5e94fa1954a8dbbf54767f3b85cfde37a   true
+```
+
+The issuer URL would be:
+```
+https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/kuadrant-system/41e136873d122b95c4212edfec0070d5e94fa1954a8dbbf54767f3b85cfde37a/x-wristband-token
+```
+
+## Peer cluster: consuming wristband tokens
+
+### JWT authentication
+
+Each peer cluster's AuthPolicy adds a `jwt` authentication method that verifies wristband
+tokens from other peers:
+
+```yaml
+authentication:
+  # Local cluster auth (unchanged)
+  kubernetes-user:
+    kubernetesTokenReview:
+      audiences:
+        - https://kubernetes.default.svc
+    overrides:
+      fairness:
+        value: "https://kubernetes.default.svc"
+      objective:
+        expression: >-
+          auth.identity.user.username.startsWith('system:serviceaccount:')
+            ? auth.identity.user.username.split(':')[2]
+            : 'authenticated'
+
+  # JWT auth from peer clusters (disabled on /api/v1/token to prevent token escalation)
+  wristband-user:
+    when:
+      - predicate: "request.path != '/api/v1/token'"
+    jwt:
+      jwksUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token/.well-known/openid-connect/certs"
+    overrides:
+      user:
+        expression: "{'username': auth.identity.username, 'groups': auth.identity.groups}"
+      fairness:
+        expression: auth.identity.iss
+      objective:
+        expression: >-
+          auth.identity.username.startsWith('system:serviceaccount:')
+            ? auth.identity.username.split(':')[2]
+            : 'authenticated'
+    priority: 1
+```
+
+**Credential extraction**: Both `kubernetes-user` and `wristband-user` use the default
+`Authorization: Bearer` header. Authorino evaluates all authentication methods — at
+least one must succeed. A Kubernetes token passes `kubernetes-user`; a JWT passes
+`wristband-user`. The client uses the same header regardless of token type.
+
+**Identity normalization via overrides**: The `kubernetesTokenReview` produces an identity
+with nested structure (`auth.identity.user.username`). The JWT produces a flat structure
+(`auth.identity.username`). The `user` override on `wristband-user` reshapes the flat JWT
+claims to match the nested structure so that authorization rules work without modification:
+
+```
+kubernetesTokenReview identity:        Wristband JWT identity (after override):
+  auth.identity.user.username    →      auth.identity.user.username
+  auth.identity.user.groups      →      auth.identity.user.groups
+```
+
+### Authorization: local RBAC enforcement
+
+The existing `inference-access` SubjectAccessReview rule works unchanged for both
+authentication methods. After identity normalization, `auth.identity.user.username`
+and `auth.identity.user.groups` are available regardless of whether the user authenticated
+via Kubernetes token or wristband:
+
+```yaml
+authorization:
+  inference-access:
+    when:
+      - predicate: >-
+          !(request.path == '/api/v1/token' ||
+            request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+            request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+    kubernetesSubjectAccessReview:
+      user:
+        expression: >-
+          'x-maas-user' in request.headers
+            ? request.headers['x-maas-user']
+            : auth.identity.user.username
+      authorizationGroups:
+        expression: >-
+          'x-maas-user' in request.headers
+            ? ('x-maas-groups' in request.headers
+                ? request.headers['x-maas-groups'].split(',')
+                : [])
+            : auth.identity.user.groups
+      resourceAttributes:
+        group:
+          value: serving.kserve.io
+        resource:
+          value: llminferenceservices
+        namespace:
+          expression: request.path.split("/")[1]
+        name:
+          expression: request.path.split("/")[2]
+        verb:
+          value: get
+    priority: 1
+```
+
+The SAR checks the **local** cluster's RBAC. The user/SA identified by the wristband must
+have the appropriate RoleBinding on the consuming cluster. If they don't, the request is
+rejected with 403 — regardless of what permissions they have on the issuing cluster.
+
+### Response headers
+
+The `fairness` and `objective` overrides on `wristband-user` ensure that
+`auth.identity.fairness` and `auth.identity.objective` are populated correctly for
+both auth methods. The existing response header expressions work unchanged:
+
+```yaml
+response:
+  success:
+    headers:
+      x-gateway-inference-fairness-id:
+        metrics: false
+        plain:
+          expression: auth.identity.fairness
+        priority: 0
+      x-gateway-inference-objective:
+        metrics: false
+        plain:
+          expression: auth.identity.objective
+        priority: 0
+```
+
+## JWKS distribution
+
+Authorino natively serves JWKS for each wristband config at:
+
+```
+https://authorino-authorino-oidc.<kuadrant-ns>.svc.cluster.local:8083/<authconfig-ns>/<authconfig-name>/<wristband-name>/.well-known/openid-connect/certs
+```
+
+The consumer AuthPolicy's `jwt.jwksUrl` points directly to this endpoint. Since the
+AuthConfig name is deterministic (see "Computing the AuthConfig name" above), the
+controller can compute the full JWKS URL at AuthPolicy creation time.
+
+### Same-cluster wristband verification
+
+When a cluster issues and consumes its own wristbands (e.g., self-testing or single-cluster
+setups), the `jwksUrl` points to the local Authorino OIDC service. No additional
+infrastructure is needed — Authorino serves the JWKS automatically when a wristband
+`signingKeyRefs` is configured.
+
+### Cross-cluster JWKS distribution
+
+For multi-cluster scenarios, the JWKS must be pre-distributed to each peer cluster.
+This is an operational concern — operators export the JWKS from the issuing cluster's
+Authorino OIDC endpoint and make it available on each peer (e.g. via GitOps or RH ACM).
+
+```bash
+# On the issuing cluster: export the JWKS
+JWKS=$(curl -s https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<authconfig-ns>/<authconfig-name>/x-wristband-token/.well-known/openid-connect/certs)
+
+# Transfer $JWKS to each peer cluster and make it available at a URL
+# that Authorino on the peer can reach via jwt.jwksUrl
+```
+
+The exact mechanism for serving the imported JWKS on the peer cluster (ConfigMap-backed
+endpoint, shared object storage, external OIDC proxy, etc.) is outside the scope of
+this design. The only requirement is that the `jwt.jwksUrl` in the peer's AuthPolicy
+resolves to a valid JWKS JSON endpoint reachable from Authorino.
+
+### Multiple peers
+
+Since each peer's signing key (private key Secret) is distributed to every cluster,
+all keys are configured as `signingKeyRefs` on the wristband config. Authorino publishes
+all of them in a single JWKS endpoint. The consumer side needs only **one `jwt`
+authentication entry** — its `jwksUrl` points to the local Authorino OIDC JWKS endpoint,
+which already contains all peer keys:
+
+```yaml
+authentication:
+  kubernetes-user:
+    # ... local auth unchanged ...
+  wristband-user:
+    when:
+      - predicate: "request.path != '/api/v1/token'"
+    jwt:
+      jwksUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token/.well-known/openid-connect/certs"
+    overrides:
+      user:
+        expression: "{'username': auth.identity.username, 'groups': auth.identity.groups}"
+      fairness:
+        expression: auth.identity.iss
+      objective:
+        expression: "auth.identity.username.startsWith('system:serviceaccount:') ? auth.identity.username.split(':')[2] : 'authenticated'"
+    priority: 1
+```
+
+Authorino matches the JWT's `kid` against the JWKS keys. The first key whose `kid`
+matches verifies the signature. Revoking a peer means removing its signing key Secret
+from `signingKeyRefs` on all clusters.
+
+### Key rotation
+
+1. Generate a new ES256 key pair on the peer cluster
+2. Update `Secret/wristband-signing-key` on the peer — Authorino picks up the new key
+3. The local JWKS endpoint updates automatically (Authorino watches the Secret)
+4. For cross-cluster peers: export the updated JWKS and redistribute to each peer
+5. Remove the old key from the peer after all in-flight wristbands expire
+
+## Required Kubernetes resources (per cluster)
+
+| Resource                            | Namespace                                | Purpose                                      | Created by        |
+|-------------------------------------|------------------------------------------|----------------------------------------------|-------------------|
+| `Secret/<gw>-wristband-signing-key` | AuthConfig namespace (`kuadrant-system`) | ES256 private key for signing wristband JWTs | Controller (auto) |
+| HTTPRoute for `/api/v1/token`       | Server namespace                         | Routes token exchange requests               | Controller (auto) |
+| Peer signing key Secrets            | AuthConfig namespace (`kuadrant-system`) | Peer keys for multi-cluster verification     | Operator (manual) |
+| RoleBindings for remote users       | Model namespaces                         | RBAC for users from peer clusters            | Operator (manual) |
+
+### RBAC for remote users
+
+Users/SAs identified by wristbands must have RBAC on the consuming cluster. Since the
+same SA name/namespace is used across clusters, the same RoleBinding works:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: remote-user-inference-access
+  namespace: model-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: ServiceAccount
+    name: inference-client
+    namespace: client-namespace
+```
+
+This grants `system:serviceaccount:client-namespace:inference-client` from **any** peer
+cluster access to models in `model-namespace` on this cluster.
+
+### Key rotation
+
+1. Generate a new ES256 key pair
+2. Update `Secret/wristband-signing-key` with the new `key.pem`
+3. Authorino picks up the new key automatically (watches the Secret)
+4. The JWKS endpoint updates to include the new key (identified by `kid`)
+5. **Option A**: Peers auto-refresh JWKS — no action needed
+6. **Option B**: Export updated JWKS and redistribute to all peers
+7. Remove the old key after all in-flight wristbands expire
+
+## Security considerations
+
+- **Identity only, not authorization**: The wristband proves who the user is, not what
+  they can do. Each cluster enforces its own RBAC via SubjectAccessReview. A stolen
+  wristband is useless on a cluster where the user has no RoleBindings.
+- **Asymmetric signing**: Use ES256 (ECDSA P-256). Peer clusters only need the public
+  key (JWKS), never the private key. Compromising one cluster's JWKS does not compromise
+  another cluster's signing key.
+- **Token duration**: Default is 1 year (31536000s), configurable via
+  `security.opendatahub.io/token-exchange-duration`. Long-lived tokens are acceptable
+  because the wristband carries identity only — each cluster enforces its own RBAC.
+  Revoking access is done by removing RoleBindings, not by expiring tokens.
+- **No token re-minting**: The `wristband-user` authentication is disabled on
+  `/api/v1/token` via a `when` predicate. This prevents using a wristband to mint a
+  new wristband (token escalation). Only `kubernetesTokenReview` is accepted on the
+  token endpoint.
+- **SA name consistency**: The same SA name/namespace must exist across clusters for
+  RBAC to work. This is a deployment constraint, not an Authorino constraint.
+- **Issuer validation**: With `jwksUrl`, Authorino verifies the JWT signature but does
+  not validate the `iss` claim. With `issuerUrl` (alternative), Authorino also validates
+  the `iss` claim — but this does not mitigate a compromised peer, since the attacker
+  controls the signing key and can set `iss` to any value.
+- **Compromised peer trust boundary**: A compromised peer cluster has access to its
+  signing key (private key Secret) and can mint wristband JWTs with arbitrary `username`
+  and `groups` claims. The consuming cluster verifies the signature (valid, since the
+  peer's key is in the JWKS) and performs a SubjectAccessReview using the asserted
+  identity. If that identity has RoleBindings on the consuming cluster, access is
+  granted. This is inherent to any federated trust model with shared signing keys —
+  trusting a peer's key means trusting any token it signs. Neither `issuerUrl` validation
+  nor additional JWT claims mitigate this, since the attacker controls the signing key
+  and can set any claim. The mitigation is operational: rapid signing key revocation
+  (see "Scenario 3: Peer cluster compromised") and the "Hardening: one JWKS per cluster"
+  recommendation to enable surgical revocation per peer.
+
+## Token revocation (incident response)
+
+JWTs are stateless — there is no server-side session to invalidate. Revocation depends
+on the severity of the incident. The table below summarizes the options, followed by
+detailed procedures.
+
+### Inspecting a token
+
+Every wristband JWT contains a `kid` (key ID) in the header matching the signing key
+Secret name, and identity claims in the payload. Decode a token to identify its origin
+and the identity it carries:
+
+```bash
+# Decode JWT header (kid identifies the signing key / originating cluster)
+echo "<token>" | cut -d. -f1 | tr '_-' '/+' | base64 -d | jq .
+# {
+#   "alg": "ES256",
+#   "kid": "local-signing-key",    <-- Secret name that signed this token
+#   "typ": "JWT"
+# }
+
+# Decode JWT payload (identity and expiration)
+echo "<token>" | cut -d. -f2 | tr '_-' '/+' | base64 -d | jq .
+# {
+#   "username": "system:serviceaccount:echo-service:test-user",
+#   "groups": ["system:serviceaccounts", "system:serviceaccounts:echo-service", "system:authenticated"],
+#   "iss": "https://authorino-authorino-oidc...",
+#   "exp": 1776674508,
+#   "iat": 1776674208,
+#   "sub": "f088720b..."
+# }
+```
+
+The `kid` tells you which key id signed the token (each cluster's local signing key has
+a unique name). Use this to scope revocation to the right key or cluster.
+
+| Scenario                                 | Action                      | Scope                        | Effect                                  | Downtime                   |
+|------------------------------------------|-----------------------------|------------------------------|-----------------------------------------|----------------------------|
+| Single identity compromised              | Remove RoleBindings         | Per-identity, per-cluster    | 403 on authz, token still authenticates | None                       |
+| Single identity compromised (full block) | Add deny rule to AuthPolicy | Per-identity, all clusters   | 403 before SAR                          | None                       |
+| Signing key compromised                  | Rotate signing key Secret   | All tokens from that cluster | 401 for all existing tokens             | Token re-issuance required |
+| Cluster compromised                      | Remove peer signing key     | Per-cluster                  | 401 for all tokens from that peer       | Token re-issuance required |
+
+### Scenario 1: Single identity compromised
+
+**Immediate response** — remove RoleBindings for the compromised identity on all
+clusters where it has access:
+
+```bash
+# On each affected cluster: remove the RoleBinding
+oc delete rolebinding <binding-name> -n <model-namespace>
+```
+
+This blocks authorization (403) immediately. The wristband still passes authentication
+(the JWT is valid), but the SubjectAccessReview fails because the identity has no RBAC.
+
+**Full block** — if the token must be rejected at the authentication layer (401 instead
+of 403), add a `patternMatching` deny rule to the AuthPolicy. This uses Authorino's
+CEL-based pattern matching to reject specific identities before authorization:
+
+```yaml
+authorization:
+  deny-compromised-identity:
+    patternMatching:
+      patterns:
+        - predicate: "auth.identity.user.username != 'system:serviceaccount:ns:compromised-sa'"
+    priority: 0   # evaluate before inference-access
+```
+
+This denies the specific identity across all routes on the Gateway. Remove the rule
+after the incident is resolved.
+
+**Revoking a specific token** — if only a single token is compromised (not the entire
+identity), deny it by its `sub` claim. Since `sub` is unique per issuance (see claims
+table), it acts as a de facto token ID:
+
+```yaml
+authorization:
+  deny-compromised-token:
+    patternMatching:
+      patterns:
+        - predicate: "auth.identity.sub != 'f088720b...'"
+    priority: 0
+```
+
+Identify the `sub` value by decoding the compromised token (see "Inspecting a token").
+This is more surgical than blocking the entire identity — other tokens issued to the
+same user remain valid. Note: Authorino does not include `jti` by default; `sub` serves
+this purpose.
+
+Both approaches (identity-level and token-level deny rules) can be automated via Gateway
+annotations in the future (e.g., `security.opendatahub.io/denied-identities`,
+`security.opendatahub.io/denied-tokens`) if frequent use is expected, but for incident
+response a manual AuthPolicy patch is sufficient.
+
+### Scenario 2: Signing key compromised
+
+If the private signing key is compromised, all tokens signed by that key must be
+considered compromised. Rotate the key immediately:
+
+```bash
+# 1. Generate a new key
+openssl ecparam -name prime256v1 -genkey -noout -out /tmp/new-key.pem
+
+# 2. Replace the signing key Secret
+oc create secret generic wristband-signing-key \
+  -n kuadrant-system \
+  --from-file=key.pem=/tmp/new-key.pem \
+  --dry-run=client -o yaml | oc apply -f -
+
+# 3. Authorino picks up the new key automatically (watches the Secret)
+# All existing tokens fail signature verification (401) immediately
+
+# 4. Export the new JWKS and distribute to all peer clusters
+NEW_JWKS=$(curl -s https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<authconfig-ns>/<authconfig-name>/x-wristband-token/.well-known/openid-connect/certs)
+
+# 5. On each peer: update the JWKS
+# (mechanism depends on deployment — Secret, ConfigMap, etc.)
+
+# 6. Users must re-authenticate to obtain new tokens
+```
+
+**Impact**: all existing wristband tokens from this cluster are invalidated. Users
+must re-authenticate via `/api/v1/token` to get new tokens signed with the new key.
+
+### Scenario 3: Peer cluster compromised
+
+If a peer cluster is fully compromised, remove trust by removing its signing key
+from all other clusters:
+
+```bash
+# 1. Remove the compromised peer's signing key Secret from each cluster
+oc delete secret <peer-signing-key-name> -n kuadrant-system
+
+# 2. Remove the corresponding signingKeyRefs entry from the AuthPolicy on each cluster
+# (or update the Gateway annotation to exclude the peer's key name)
+
+# 3. Authorino updates the JWKS endpoint — the peer's public key is no longer published
+# All existing tokens signed by that key fail verification (401)
+```
+
+No tokens from healthy peers are affected — their signing keys remain in
+`signingKeyRefs` and their `kid` entries are still in the JWKS.
+
+### Hardening: one JWKS per cluster
+
+Maintain a separate JWKS artifact (Secret, file, etc.) for each trusted cluster —
+including the local cluster. This enables surgical revocation: to revoke a compromised
+cluster, remove only its JWKS from the distribution. Tokens from other clusters remain
+valid because their signing keys are unaffected.
+
+If JWKS from multiple clusters are merged into a single artifact, revoking one cluster
+requires re-exporting and redistributing the merged JWKS without that cluster's keys —
+a slower and more error-prone process during an incident.
+
+### Recovery checklist
+
+1. Identify the scope: single identity, single key, or full cluster compromise
+2. Apply the immediate action from the table above
+3. Audit access logs for unauthorized requests during the compromise window
+4. For key rotation: redistribute JWKS to all peers
+5. For identity compromise: verify RoleBindings are removed on all clusters
+6. Remove any temporary deny rules added to AuthPolicies
+7. Re-issue tokens to legitimate users if signing key was rotated
+
+## Multi-Gateway isolation and multi-tenancy
+
+When multiple Gateways exist on the same cluster (e.g., per-tenant Gateways), each
+Gateway has its own AuthPolicy and can use a different signing key. This section
+documents the isolation properties validated on a live cluster.
+
+### Isolation properties
+
+Each Gateway's AuthPolicy generates a separate AuthConfig. When different AuthPolicies
+reference different `signingKeyRefs`, the resulting wristband endpoints serve **different
+JWKS** — each containing only the public key for that Gateway's signing key.
+
+| Property                | Behavior                                                                   |
+|-------------------------|----------------------------------------------------------------------------|
+| JWKS per Gateway        | Isolated — each AuthConfig serves its own JWKS with a unique `kid`         |
+| Cross-gateway wristband | Rejected (401) — signature verification fails because the JWKS don't match |
+| Same-gateway wristband  | Accepted for authn, then SAR enforced — 200 if RBAC exists, 403 otherwise  |
+| Signing key per Gateway | Independent — each AuthPolicy can reference a different Secret             |
+| AuthConfig naming       | SHA-256 hash per AuthPolicy — distinct per Gateway                         |
+
+### Validated test matrix
+
+Two Gateways (`openshift-ai-inference` in `openshift-ingress`, `tenant-b-gateway` in
+`tenant-b`), each with its own signing key:
+
+| Token issuer  | Target Gateway | Result     | Reason                                                     |
+|---------------|----------------|------------|------------------------------------------------------------|
+| GW1 wristband | GW1            | 200 or 403 | Authn passes (same JWKS), authz depends on RBAC            |
+| GW2 wristband | GW2            | 200 or 403 | Authn passes (same JWKS), authz depends on RBAC            |
+| GW1 wristband | GW2            | 401        | Signature verification fails — different signing key       |
+| GW2 wristband | GW1            | 401        | Signature verification fails — different signing key       |
+| K8s token     | GW1 or GW2     | 200 or 403 | `kubernetesTokenReview` is independent of wristband config |
+
+### Within a single Gateway
+
+All HTTPRoutes attached to the same Gateway share the same AuthPolicy. There is **no
+per-route wristband isolation** within a single Gateway:
+
+- All routes use the same signing key
+- All routes serve the same JWKS
+- A wristband obtained via one route's `/api/v1/token` is valid for any route on that
+  Gateway (subject to SAR authorization)
+
+This is by design — wristband tokens carry identity, not route-specific authorization.
+The SAR check provides per-resource access control.
+
+### OIDC endpoint accessibility
+
+Authorino's OIDC server (`authorino-authorino-oidc:8083`) is a ClusterIP service
+accessible from any namespace within the cluster:
+
+- **No NetworkPolicies** restrict access by default
+- **Not enumerable** — AuthConfig names are SHA-256 hashes; there is no directory listing
+  endpoint. An attacker would need to know the exact hash to access a specific JWKS
+- **Security through hashing, not secrecy** — the JWKS contains only public keys.
+  Knowing the JWKS endpoint does not compromise signing capability
+
+### Limitations
+
+1. **Per-tenant isolation requires separate Gateways**: If tenants must have independent
+   signing keys and isolated wristband verification, each tenant needs its own Gateway
+   with its own AuthPolicy. A shared Gateway means shared wristband keys.
+
+2. **Signing key Secret namespace**: The signing key Secret must be in the namespace where
+   the AuthConfig is created (typically `kuadrant-system`). Multiple Gateways in different
+   namespaces all reference Secrets in the same AuthConfig namespace, which means Secret
+   names must be unique across all tenants.
+
+3. **OIDC endpoint is cluster-wide**: Any pod in the cluster can reach the OIDC endpoint.
+   While the paths are not enumerable (SHA-256 hashes), this is defense-in-depth only.
+   The JWKS public keys are not sensitive, but operators should be aware of this surface.
+
+4. **AuthConfig hash stability**: If routes are added/removed from a Gateway, the
+   AuthConfig hash may change, invalidating the wristband issuer URL. This affects both
+   the `iss` claim in wristbands and any peer `issuerUrl` configurations. Use `jwksUrl`
+   (not `issuerUrl`) on the consumer side to avoid dependency on the issuer URL.
+
+## Template changes (future implementation)
+
+### Template data struct
+
+Add optional fields to `authPolicyTemplateData` in `authpolicy.go`:
+
+```go
+type authPolicyTemplateData struct {
+    Name       string
+    Namespace  string
+    TargetKind string
+    TargetName string
+    // Wristband token exchange
+    WristbandIssuer      string   // Authorino OIDC endpoint for this wristband config
+    SigningKeyRefs       []string // Secret names: first signs, all published in JWKS
+    TokenDuration        int      // Seconds (default 31536000 = 1 year)
+    WristbandJwksUrl     string   // Local Authorino OIDC JWKS URL (contains all peer keys)
+}
+```
+
+Since all peer signing keys are distributed as Secrets and configured in `signingKeyRefs`,
+the local Authorino OIDC JWKS endpoint publishes all keys. The consumer side needs only
+a single `jwt.jwksUrl` pointing to the local JWKS — no separate peer URLs are needed.
+
+### New ObjectOption functions
+
+Add to `options.go`:
+
+```go
+// WithWristbandResponse configures wristband token issuance on /api/v1/token.
+// signingKeyRefs: first key signs, all keys published in JWKS for verification.
+func WithWristbandResponse(issuer string, signingKeyRefs []string, tokenDuration int) ObjectOption
+
+// WithWristbandAuthentication adds JWT authentication for wristband tokens.
+// jwksUrl points to the local Authorino OIDC JWKS endpoint (which contains all peer keys).
+func WithWristbandAuthentication(jwksUrl string) ObjectOption
+```
+
+### Detection mechanism
+
+Token exchange is enabled by default for every managed Gateway. The controller
+auto-generates a local signing key and configures wristband issuance/consumption
+without any annotation.
+
+For multi-cluster, operators add peer signing keys via an optional annotation:
+
+```yaml
+metadata:
+  annotations:
+    # Optional: peer keys appended after auto-generated local key in signingKeyRefs
+    security.opendatahub.io/token-exchange-signing-keys: "peer-cluster-a-key,peer-cluster-b-key"
+    # Optional: token duration in seconds (default: 31536000 = 1 year)
+    security.opendatahub.io/token-exchange-duration: "31536000"
+```
+
+The controller:
+1. Auto-generates `<gateway-name>-wristband-signing-key` Secret if it doesn't exist
+2. Parses the annotation (if present) for additional peer key names
+3. Builds `signingKeyRefs` as: `[auto-generated, ...peer-keys]`
+4. Computes the JWKS URL from the AuthConfig name (see "Computing the AuthConfig name")
+
+## Testing
+
+### Prerequisites
+
+Deploy the echo service infrastructure from `BATCH.md` (gateway, echo server, HTTPRoutes,
+ServiceAccounts with RBAC).
+
+### Test setup
+
+The controller auto-generates the signing key Secret and creates the HTTPRoute for
+`/api/v1/token`. No manual setup is needed for single-cluster token exchange.
+
+```bash
+# Verify the auto-generated signing key exists
+oc get secret openshift-ai-inference-wristband-signing-key -n kuadrant-system
+
+# Verify the token endpoint HTTPRoute was created
+oc get httproute -A -l app.kubernetes.io/managed-by=odh-model-controller
+
+# Discover AuthConfig name
+oc get authconfigs.authorino.kuadrant.io -A
+```
+
+### Test setup: AuthPolicy (controller-generated)
+
+The controller generates this AuthPolicy automatically. Shown here for reference and
+manual testing. Replace `<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>` with actual values from
+`oc get authconfigs`:
+
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: openshift-ai-inference-authn
+  namespace: openshift-ingress
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: openshift-ai-inference
+  rules:
+    authentication:
+      kubernetes-user:
+        kubernetesTokenReview:
+          audiences:
+            - https://kubernetes.default.svc
+        overrides:
+          fairness:
+            value: "https://kubernetes.default.svc"
+          objective:
+            expression: >-
+              auth.identity.user.username.startsWith('system:serviceaccount:')
+                ? auth.identity.user.username.split(':')[2]
+                : 'authenticated'
+
+      # Accept JWT tokens (disabled on /api/v1/token to prevent token escalation)
+      wristband-user:
+        when:
+          - predicate: "request.path != '/api/v1/token'"
+        jwt:
+          issuerUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
+        overrides:
+          user:
+            expression: "{'username': auth.identity.username, 'groups': auth.identity.groups}"
+          fairness:
+            expression: auth.identity.iss
+          objective:
+            expression: >-
+              auth.identity.username.startsWith('system:serviceaccount:')
+                ? auth.identity.username.split(':')[2]
+                : 'authenticated'
+        priority: 1
+
+    authorization:
+      inference-access:
+        when:
+          - predicate: >-
+              !(request.path == '/api/v1/token' ||
+                request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+        kubernetesSubjectAccessReview:
+          user:
+            expression: >-
+              'x-maas-user' in request.headers
+                ? request.headers['x-maas-user']
+                : auth.identity.user.username
+          authorizationGroups:
+            expression: >-
+              'x-maas-user' in request.headers
+                ? ('x-maas-groups' in request.headers
+                    ? request.headers['x-maas-groups'].split(',')
+                    : [])
+                : auth.identity.user.groups
+          resourceAttributes:
+            group:
+              value: serving.kserve.io
+            resource:
+              value: llminferenceservices
+            namespace:
+              expression: request.path.split("/")[1]
+            name:
+              expression: request.path.split("/")[2]
+            verb:
+              value: get
+        priority: 1
+      inference-access-delegate:
+        when:
+          - predicate: >-
+              !(request.path == '/api/v1/token' ||
+                request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+          - predicate: "'x-maas-user' in request.headers"
+        kubernetesSubjectAccessReview:
+          user:
+            expression: "auth.identity.user.username"
+          authorizationGroups:
+            expression: "auth.identity.user.groups"
+          resourceAttributes:
+            group:
+              value: serving.kserve.io
+            resource:
+              value: llminferenceservices/delegate
+            namespace:
+              expression: request.path.split("/")[1]
+            name:
+              expression: request.path.split("/")[2]
+            verb:
+              value: post-delegate
+        priority: 1
+
+    response:
+      success:
+        headers:
+          x-gateway-inference-fairness-id:
+            metrics: false
+            plain:
+              expression: auth.identity.fairness
+            priority: 0
+          x-gateway-inference-objective:
+            metrics: false
+            plain:
+              expression: auth.identity.objective
+            priority: 0
+          x-maas-user:
+            when:
+              - predicate: >-
+                  request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                  request.path == '/v1/batches' || request.path.startsWith('/v1/batches/')
+            plain:
+              expression: auth.identity.user.username
+            priority: 0
+          x-maas-groups:
+            when:
+              - predicate: >-
+                  request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                  request.path == '/v1/batches' || request.path.startsWith('/v1/batches/')
+            plain:
+              expression: "auth.identity.user.groups.join(',')"
+            priority: 0
+          x-wristband-token:
+            when:
+              - predicate: "request.path == '/api/v1/token'"
+            wristband:
+              issuer: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
+              tokenDuration: 31536000
+              signingKeyRefs:
+                - name: openshift-ai-inference-wristband-signing-key   # auto-generated
+                  algorithm: ES256
+                # ... peer keys from annotation appended here ...
+              customClaims:
+                username:
+                  expression: auth.identity.user.username
+                groups:
+                  expression: auth.identity.user.groups
+            priority: 0
+```
+
+### Test scenarios
+
+| # | Scenario                                      | Auth                   | Path                | Expected                            |
+|---|-----------------------------------------------|------------------------|---------------------|-------------------------------------|
+| 1 | Get JWT via token endpoint                    | `Bearer <k8s-token>`   | `/api/v1/token`     | 200, response body contains JWT     |
+| 2 | Decode JWT, verify claims                     | —                      | —                   | JWT has `username`, `groups` claims |
+| 3 | Verify JWKS endpoint                          | —                      | —                   | OIDC discovery returns public key   |
+| 4 | Use JWT for inference (local RBAC exists)     | `Bearer <jwt>`         | `/<ns>/<model>/...` | 200, SAR passes                     |
+| 5 | Use JWT for inference (no local RBAC)         | `Bearer <jwt>`         | `/<ns>/<model>/...` | 403, SAR fails                      |
+| 6 | Expired JWT                                   | `Bearer <expired-jwt>` | `/<ns>/<model>/...` | 401                                 |
+| 7 | Local k8s token still works (backward compat) | `Bearer <k8s-token>`   | `/<ns>/<model>/...` | 200                                 |
+| 8 | JWT on token endpoint (no escalation)         | `Bearer <jwt>`         | `/api/v1/token`     | 401, JWT auth disabled on this path |
+
+### Test commands
+
+```bash
+GW=http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local
+TEST_USER_TOKEN=$(oc create token test-user -n echo-service)
+
+# Scenario 1: Get JWT via /api/v1/token
+RESPONSE=$(oc exec -n default dnsutils -- curl -s \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  $GW/api/v1/token)
+JWT=$(echo "$RESPONSE" | jq -r .token)
+echo "JWT: ${JWT:0:50}..."
+
+# Scenario 2: Decode the JWT
+echo "$JWT" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+# Expected: {"username": "system:serviceaccount:echo-service:test-user", "groups": [...], ...}
+
+# Scenario 3: Verify JWKS endpoint
+oc exec -n default dnsutils -- curl -s \
+  https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token/.well-known/openid-connect/certs | jq .
+
+# Scenario 4: Use JWT for inference (test-user has RBAC in echo-service)
+oc exec -n default dnsutils -- curl -s \
+  -H "Authorization: Bearer $JWT" \
+  $GW/echo-service/echo-server/v1/chat/completions | jq .request.headers
+# Expected: 200, headers show x-gateway-inference-fairness-id and x-gateway-inference-objective
+
+# Scenario 7: Local k8s token still works
+oc exec -n default dnsutils -- curl -s \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  $GW/echo-service/echo-server/v1/chat/completions | jq .request.headers
+# Expected: 200, same as before
+
+# Scenario 8: JWT on token endpoint (no escalation)
+oc exec -n default dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $JWT" \
+  $GW/api/v1/token
+# Expected: 401 (wristband-user auth is disabled on /api/v1/token via when predicate)
+```
+
+## Open questions
+
+1. **Token endpoint backend**: The `model-serving-api` server (`server/`, `config/server/`)
+   is the production backend. Add a `/api/v1/token` handler that reads the wristband token
+   from the upstream request header (injected by Authorino) and returns it in the response
+   body as JSON.
+
+2. **Multiple signing keys**: For key rotation, Authorino supports multiple
+   `signingKeyRefs`. The first key is used for signing; all keys are published in the JWKS
+   for verification. Document the rotation procedure with overlapping keys.
+
+3. **Cross-cluster JWKS delivery**: The Authorino OIDC JWKS endpoint is a ClusterIP
+   service, not reachable from peer clusters. The mechanism for making a peer's JWKS
+   available on the consuming cluster (external endpoint, shared storage, manual export)
+   is an operational concern to be defined per deployment topology.

--- a/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
+++ b/internal/controller/resources/template/MULTI_CLUSTER_AUTH.md
@@ -47,11 +47,11 @@ Each cluster enforces its own RBAC independently.
  │                     │                        │    │                     │                        │
  │       ┌─────────────┴────────────┐           │    │       ┌─────────────┴────────────┐           │
  │       ▼                          ▼           │    │       ▼                          ▼           │
- │  ┌────────────────┐  ┌────────────────┐      │    │  ┌────────────────┐  ┌────────────────┐      │
- │  │model-serving-  │  │ Inference      │      │    │  │model-serving-  │  │ Inference      │      │
- │  │api (system ns) │  │ Backends       │      │    │  │api (system ns) │  │ Backends       │      │
- │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │    │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │
- │  └────────────────┘  └────────────────┘      │    │  └────────────────┘  └────────────────┘      │
+ │  ┌────────────────────┐  ┌────────────────┐  │    │  ┌────────────────────┐  ┌────────────────┐  │
+ │  │ model-serving-api  │  │ Inference      │  │    │  │ model-serving-api  │  │ Inference      │  │
+ │  │ (system ns)        │  │ Backends       │  │    │  │ (system ns)        │  │ Backends       │  │
+ │  │ /api/v1/auth/token │  │ /<ns>/<model>/ │  │    │  │ /api/v1/auth/token │  │ /<ns>/<model>/ │  │
+ │  └────────────────────┘  └────────────────┘  │    │  └────────────────────┘  └────────────────┘  │
  │                                              │    │                                              │
  │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
  │  │ Authorino OIDC (:8083, TLS)            │  │    │  │ Authorino OIDC (:8083, TLS)            │  │
@@ -78,24 +78,27 @@ Each cluster enforces its own RBAC independently.
 ### Token exchange flow
 
 ```text
-Cluster A (or B) (issuing)                        Cluster B (or A) (consuming)
+Token issuance (any cluster)                      Token consumption (any cluster)
 
-User ──► Gateway /api/v1/token                    Client ──► Gateway ──► Authorino ──► Inference Backend
+User ──► Gateway /api/v1/auth/token               Client ──► Gateway ──► Authorino ──► Inference Backend
            │                                                │
-           ├─ 1. kubernetesTokenReview (authn)              ├─ 1. jwt verification (authn)
-           ├─ 2. No authorization (token path)              ├─ 2. SubjectAccessReview (local RBAC)
-           └─ 3. Issue signed JWT (response)                └─ 3. Set flow control headers (response)
-                    │                                                  ▲
-                    │              signed JWT                          │
-                    └──────────────────────────────────────────────────┘
+           ├─ 1a. kubernetesTokenReview (k8s token)         ├─ 1. jwt verification (authn)
+           │  OR                                            ├─ 2. SubjectAccessReview (local RBAC)
+           ├─ 1b. jwt verification (external JWT)           └─ 3. Set flow control headers (response)
+           ├─ 2. No authorization (token path)                        ▲
+           └─ 3. Issue signed wristband (response)                    │
+                    │                    signed JWT                   │
+                    └─────────────────────────────────────────────────┘
 ```
 
 **Flow**:
 
-1. User authenticates on cluster A with a local Kubernetes token via `GET /api/v1/token`
+1. User authenticates on cluster A via `GET /api/v1/auth/token` using either:
+   - A local Kubernetes token (`kubernetesTokenReview`), or
+   - An external JWT from a configured OIDC provider (e.g., Vault)
 2. Cluster A skips authorization for the token path (authentication only)
-3. Cluster A issues a signed JWT containing the user's identity (username, groups)
-4. Client extracts the JWT from the response
+3. Cluster A issues a signed wristband JWT containing the user's identity (username, groups)
+4. Client extracts the JWT from the response (`access_token` field)
 5. Client sends the JWT to cluster B's inference endpoint
 6. Cluster B verifies the JWT signature via JWKS
 7. Cluster B extracts the username and groups from the JWT
@@ -118,7 +121,7 @@ for its own access control.
   Each cluster enforces its own RBAC via SubjectAccessReview. A valid token from a
   peer is insufficient without local RoleBindings.
 - **Zero-config single cluster**: The controller auto-generates a local signing key
-  per Gateway. Token exchange via `/api/v1/token` works without any annotation or
+  per Gateway. Token exchange via `/api/v1/auth/token` works without any annotation or
   manual key creation. Multi-cluster requires only adding peer key names to the
   `security.opendatahub.io/token-exchange-signing-keys` annotation.
 - **Signing key distribution**: Authorino's `signingKeyRefs` requires private keys —
@@ -151,7 +154,7 @@ Admin
   │     └─ Grant remote SAs/users access to local LLMInferenceServices
   │
   └─ 5. (Optional) Configure token duration
-        └─ security.opendatahub.io/token-exchange-duration: "31536000"
+        └─ security.opendatahub.io/token-exchange-duration: "86400"
 
 Controller (on annotation change)
   │
@@ -165,7 +168,7 @@ Controller (on annotation change)
 Developer / CI pipeline
   │
   ├─ 1. Authenticate on home cluster
-  │     GET /api/v1/token
+  │     GET /api/v1/auth/token
   │     Authorization: Bearer <k8s-token>
   │     └─ Response: {"token": "<jwt>"}
   │
@@ -213,7 +216,7 @@ Additional `jwt` authentication methods (peer wristbands and/or external OIDC pr
 are configured alongside `kubernetesTokenReview`. Authorino evaluates all authentication
 configs — at least one must succeed. Local Kubernetes tokens continue to work unchanged.
 
-## Token endpoint: `/api/v1/token`
+## Token endpoint: `/api/v1/auth/token`
 
 A dedicated gateway path for wristband token exchange. The client authenticates with a
 local Kubernetes token and receives a wristband JWT in the response.
@@ -221,12 +224,13 @@ local Kubernetes token and receives a wristband JWT in the response.
 ### Routing
 
 The `GatewayReconciler` (`gateway_controller.go`) automatically creates an HTTPRoute
-for `/api/v1/token` for every managed Gateway. The HTTPRoute routes to the
+for `/api/v1/auth/token` for every managed Gateway. The HTTPRoute routes to the
 `model-serving-api` server (`server/`, deployed via `config/server/`).
 
-The server needs a `/api/v1/token` handler that returns the wristband token from the
+The server needs a `/api/v1/auth/token` handler that returns the wristband token from the
 `X-Wristband-Token` response header (injected by Authorino into the upstream request)
-in the response body:
+in the response body. The response follows OAuth 2.0 formats: success per RFC 6749 §5.1,
+errors per RFC 6749 §5.2.
 
 ```go
 // server/handlers/token.go
@@ -236,12 +240,34 @@ func Token(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Cache-Control", "no-store")
     if token == "" {
         w.WriteHeader(http.StatusBadGateway)
-        json.NewEncoder(w).Encode(map[string]string{"error": "missing wristband token"})
+        json.NewEncoder(w).Encode(map[string]string{
+            "error":             "server_error",
+            "error_description": "missing wristband token",
+        })
         return
     }
-    json.NewEncoder(w).Encode(map[string]string{"token": token})
+    json.NewEncoder(w).Encode(map[string]any{
+        "access_token": token,
+        "token_type":   "Bearer",
+        "expires_in":   expiresIn(token),
+    })
 }
 ```
+
+Success response (200):
+
+| Field          | Type    | Description                                        |
+|----------------|---------|----------------------------------------------------|
+| `access_token` | string  | The wristband JWT                                  |
+| `token_type`   | string  | Always `Bearer`                                    |
+| `expires_in`   | integer | Seconds until the token expires (from `exp` claim) |
+
+Error response (502):
+
+| Field               | Type   | Description                                    |
+|---------------------|--------|------------------------------------------------|
+| `error`             | string | OAuth 2.0 error code (e.g., `server_error`)    |
+| `error_description` | string | Human-readable explanation                     |
 
 Note: `X-Wristband-Token` here is the **internal** response header that Authorino injects
 into the upstream request (configured in `response.success.headers`). It is not the
@@ -249,7 +275,7 @@ client-facing header. The client sends and receives tokens via `Authorization: B
 
 Register in `server/server.go`:
 ```go
-mux.HandleFunc("/api/v1/token", handlers.Token)
+mux.HandleFunc("/api/v1/auth/token", handlers.Token)
 ```
 
 The controller creates the following HTTPRoute (owned by the Gateway for garbage collection):
@@ -270,7 +296,7 @@ spec:
     - matches:
         - path:
             type: Exact
-            value: /api/v1/token
+            value: /api/v1/auth/token
       backendRefs:
         - name: model-serving-api
           port: 443
@@ -345,7 +371,7 @@ is allowed in `allowedRoutes`.
 
 ### Authorization exclusion
 
-The `/api/v1/token` path must be excluded from authorization rules (like batch paths).
+The `/api/v1/auth/token` path must be excluded from authorization rules (like batch paths).
 Authentication is sufficient — if the user has a valid Kubernetes token, they can
 request a wristband:
 
@@ -354,21 +380,21 @@ authorization:
   inference-access:
     when:
       - predicate: >-
-          !(request.path == '/api/v1/token' ||
+          !(request.path == '/api/v1/auth/token' ||
             request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
             request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
     # ... existing SAR config unchanged ...
   inference-access-delegate:
     when:
       - predicate: >-
-          !(request.path == '/api/v1/token' ||
+          !(request.path == '/api/v1/auth/token' ||
             request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
             request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
       - predicate: "'x-maas-user' in request.headers"
     # ... existing SAR config unchanged ...
 ```
 
-### Wristband response (scoped to `/api/v1/token`)
+### Wristband response (scoped to `/api/v1/auth/token`)
 
 The wristband is only issued for the token endpoint — not on every request:
 
@@ -380,10 +406,10 @@ response:
 
       x-wristband-token:
         when:
-          - predicate: "request.path == '/api/v1/token'"
+          - predicate: "request.path == '/api/v1/auth/token'"
         wristband:
           issuer: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
-          tokenDuration: 31536000   # configurable via Gateway annotation, default 1 year
+          tokenDuration: 86400   # configurable via Gateway annotation, default 24 hours
           signingKeyRefs:
             - name: <gateway-name>-wristband-signing-key   # auto-generated
               algorithm: ES256
@@ -596,7 +622,7 @@ rule in the HTTPRoute's `spec.rules` array. The HTTPRouteRule `name` field from
 Gateway API is **not used yet** (tracked upstream:
 `TODO: Use the 'name' field of the HTTPRouteRule once it's implemented`).
 
-Since the controller auto-creates the `/api/v1/token` HTTPRoute with a single rule,
+Since the controller auto-creates the `/api/v1/auth/token` HTTPRoute with a single rule,
 the rule index is always `rule-1` and the hash is stable. Other HTTPRoutes attached to
 the same Gateway do not affect it — each HTTPRoute produces its own AuthConfig(s).
 
@@ -648,10 +674,10 @@ authentication:
             ? auth.identity.user.username.split(':')[2]
             : 'authenticated'
 
-  # JWT auth from peer clusters (disabled on /api/v1/token to prevent token escalation)
+  # JWT auth from peer clusters (disabled on /api/v1/auth/token to prevent token escalation)
   wristband-user:
     when:
-      - predicate: "request.path != '/api/v1/token'"
+      - predicate: "request.path != '/api/v1/auth/token'"
     jwt:
       jwksUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token/.well-known/openid-connect/certs"
     overrides:
@@ -695,7 +721,7 @@ authorization:
   inference-access:
     when:
       - predicate: >-
-          !(request.path == '/api/v1/token' ||
+          !(request.path == '/api/v1/auth/token' ||
             request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
             request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
     kubernetesSubjectAccessReview:
@@ -803,7 +829,7 @@ authentication:
     # ... local auth unchanged ...
   wristband-user:
     when:
-      - predicate: "request.path != '/api/v1/token'"
+      - predicate: "request.path != '/api/v1/auth/token'"
     jwt:
       jwksUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token/.well-known/openid-connect/certs"
     overrides:
@@ -833,7 +859,7 @@ from `signingKeyRefs` on all clusters.
 | Resource                            | Namespace                                | Purpose                                      | Created by        |
 |-------------------------------------|------------------------------------------|----------------------------------------------|-------------------|
 | `Secret/<gw>-wristband-signing-key` | AuthConfig namespace (`kuadrant-system`) | ES256 private key for signing wristband JWTs | Controller (auto) |
-| HTTPRoute for `/api/v1/token`       | Server namespace                         | Routes token exchange requests               | Controller (auto) |
+| HTTPRoute for `/api/v1/auth/token`       | Server namespace                         | Routes token exchange requests               | Controller (auto) |
 | Peer signing key Secrets            | AuthConfig namespace (`kuadrant-system`) | Peer keys for multi-cluster verification     | Operator (manual) |
 | RoleBindings for remote users       | Model namespaces                         | RBAC for users from peer clusters            | Operator (manual) |
 
@@ -876,17 +902,31 @@ cluster access to models in `model-namespace` on this cluster.
 - **Identity only, not authorization**: The wristband proves who the user is, not what
   they can do. Each cluster enforces its own RBAC via SubjectAccessReview. A stolen
   wristband is useless on a cluster where the user has no RoleBindings.
-- **Asymmetric signing**: Use ES256 (ECDSA P-256). Peer clusters only need the public
-  key (JWKS), never the private key. Compromising one cluster's JWKS does not compromise
-  another cluster's signing key.
-- **Token duration**: Default is 1 year (31536000s), configurable via
-  `security.opendatahub.io/token-exchange-duration`. Long-lived tokens are acceptable
-  because the wristband carries identity only — each cluster enforces its own RBAC.
-  Revoking access is done by removing RoleBindings, not by expiring tokens.
+- **Signing algorithm**: Use ES256 (ECDSA P-256). Ideally, peer clusters would only
+  need the public key (JWKS) for verification. However, Authorino's `signingKeyRefs`
+  requires private keys — it rejects public-key-only Secrets. This means every peer
+  cluster holds every other peer's private signing key. Consequence: compromising **any**
+  peer cluster exposes **all** peers' private keys, enabling the attacker to forge
+  tokens that appear to originate from any cluster in the federation. This is a
+  cascading compromise risk inherent to the current Authorino limitation. If Authorino
+  adds support for public-key-only verification Secrets in the future, the design
+  should be updated to distribute only public keys.
+- **Token duration**: Default is 24 hours (86400s), configurable via
+  `security.opendatahub.io/token-exchange-duration`. Short-lived tokens limit the
+  exposure window if a token is leaked — a leaked wristband expires within a day,
+  unlike a leaked K8s token that could be exchanged for a longer-lived one. Each
+  cluster enforces its own RBAC via SubjectAccessReview, so revoking access is
+  immediate (remove RoleBindings). Organizations needing longer-lived tokens for
+  CI pipelines or batch workloads can increase the duration via the annotation.
+  Note that any authenticated user can exchange a credential for a wristband. If
+  this is a concern, add an authorization rule on `/api/v1/auth/token` requiring a
+  specific RBAC permission (e.g., `create` on a `tokenexchanges` resource) to
+  control who can mint wristbands.
 - **No token re-minting**: The `wristband-user` authentication is disabled on
-  `/api/v1/token` via a `when` predicate. This prevents using a wristband to mint a
-  new wristband (token escalation). Only `kubernetesTokenReview` is accepted on the
-  token endpoint.
+  `/api/v1/auth/token` via a `when` predicate. This prevents using a wristband to mint a
+  new wristband (token escalation). External JWT authentication (from the
+  `authn-jwt-jwks` annotation) is allowed on `/api/v1/auth/token` — this is intentional,
+  enabling users to exchange external tokens for wristbands.
 - **SA name consistency**: The same SA name/namespace must exist across clusters for
   RBAC to work. This is a deployment constraint, not an Authorino constraint.
 - **Issuer validation**: With `jwksUrl`, Authorino verifies the JWT signature but does
@@ -1028,7 +1068,7 @@ NEW_JWKS=$(curl -s https://authorino-authorino-oidc.kuadrant-system.svc.cluster.
 ```
 
 **Impact**: all existing wristband tokens from this cluster are invalidated. Users
-must re-authenticate via `/api/v1/token` to get new tokens signed with the new key.
+must re-authenticate via `/api/v1/auth/token` to get new tokens signed with the new key.
 
 ### Scenario 3: Peer cluster compromised
 
@@ -1110,7 +1150,7 @@ per-route wristband isolation** within a single Gateway:
 
 - All routes use the same signing key
 - All routes serve the same JWKS
-- A wristband obtained via one route's `/api/v1/token` is valid for any route on that
+- A wristband obtained via one route's `/api/v1/auth/token` is valid for any route on that
   Gateway (subject to SAR authorization)
 
 This is by design — wristband tokens carry identity, not route-specific authorization.
@@ -1162,7 +1202,7 @@ type authPolicyTemplateData struct {
     // Wristband token exchange
     WristbandIssuer      string   // Authorino OIDC endpoint for this wristband config
     SigningKeyRefs       []string // Secret names: first signs, all published in JWKS
-    TokenDuration        int      // Seconds (default 31536000 = 1 year)
+    TokenDuration        int      // Seconds (default 86400 = 24 hours)
     WristbandJwksUrl     string   // Local Authorino OIDC JWKS URL (contains all peer keys)
 }
 ```
@@ -1176,7 +1216,7 @@ a single `jwt.jwksUrl` pointing to the local JWKS — no separate peer URLs are 
 Add to `options.go`:
 
 ```go
-// WithWristbandResponse configures wristband token issuance on /api/v1/token.
+// WithWristbandResponse configures wristband token issuance on /api/v1/auth/token.
 // signingKeyRefs: first key signs, all keys published in JWKS for verification.
 func WithWristbandResponse(issuer string, signingKeyRefs []string, tokenDuration int) ObjectOption
 
@@ -1198,8 +1238,8 @@ metadata:
   annotations:
     # Optional: peer keys appended after auto-generated local key in signingKeyRefs
     security.opendatahub.io/token-exchange-signing-keys: "peer-cluster-a-key,peer-cluster-b-key"
-    # Optional: token duration in seconds (default: 31536000 = 1 year)
-    security.opendatahub.io/token-exchange-duration: "31536000"
+    # Optional: token duration in seconds (default: 86400 = 24 hours)
+    security.opendatahub.io/token-exchange-duration: "86400"
 ```
 
 The controller:
@@ -1218,7 +1258,7 @@ ServiceAccounts with RBAC).
 ### Test setup
 
 The controller auto-generates the signing key Secret and creates the HTTPRoute for
-`/api/v1/token`. No manual setup is needed for single-cluster token exchange.
+`/api/v1/auth/token`. No manual setup is needed for single-cluster token exchange.
 
 ```bash
 # Verify the auto-generated signing key exists
@@ -1263,10 +1303,10 @@ spec:
                 ? auth.identity.user.username.split(':')[2]
                 : 'authenticated'
 
-      # Accept JWT tokens (disabled on /api/v1/token to prevent token escalation)
+      # Accept JWT tokens (disabled on /api/v1/auth/token to prevent token escalation)
       wristband-user:
         when:
-          - predicate: "request.path != '/api/v1/token'"
+          - predicate: "request.path != '/api/v1/auth/token'"
         jwt:
           issuerUrl: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
         overrides:
@@ -1285,7 +1325,7 @@ spec:
       inference-access:
         when:
           - predicate: >-
-              !(request.path == '/api/v1/token' ||
+              !(request.path == '/api/v1/auth/token' ||
                 request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
                 request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
         kubernetesSubjectAccessReview:
@@ -1316,7 +1356,7 @@ spec:
       inference-access-delegate:
         when:
           - predicate: >-
-              !(request.path == '/api/v1/token' ||
+              !(request.path == '/api/v1/auth/token' ||
                 request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
                 request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
           - predicate: "'x-maas-user' in request.headers"
@@ -1369,10 +1409,10 @@ spec:
             priority: 0
           x-wristband-token:
             when:
-              - predicate: "request.path == '/api/v1/token'"
+              - predicate: "request.path == '/api/v1/auth/token'"
             wristband:
               issuer: "https://authorino-authorino-oidc.kuadrant-system.svc.cluster.local:8083/<AUTHCONFIG_NS>/<AUTHCONFIG_NAME>/x-wristband-token"
-              tokenDuration: 31536000
+              tokenDuration: 86400
               signingKeyRefs:
                 - name: openshift-ai-inference-wristband-signing-key   # auto-generated
                   algorithm: ES256
@@ -1389,14 +1429,15 @@ spec:
 
 | # | Scenario                                      | Auth                   | Path                | Expected                            |
 |---|-----------------------------------------------|------------------------|---------------------|-------------------------------------|
-| 1 | Get JWT via token endpoint                    | `Bearer <k8s-token>`   | `/api/v1/token`     | 200, response body contains JWT     |
+| 1 | Get JWT via token endpoint                    | `Bearer <k8s-token>`   | `/api/v1/auth/token`     | 200, OAuth 2.0 token response       |
 | 2 | Decode JWT, verify claims                     | —                      | —                   | JWT has `username`, `groups` claims |
 | 3 | Verify JWKS endpoint                          | —                      | —                   | OIDC discovery returns public key   |
 | 4 | Use JWT for inference (local RBAC exists)     | `Bearer <jwt>`         | `/<ns>/<model>/...` | 200, SAR passes                     |
 | 5 | Use JWT for inference (no local RBAC)         | `Bearer <jwt>`         | `/<ns>/<model>/...` | 403, SAR fails                      |
 | 6 | Expired JWT                                   | `Bearer <expired-jwt>` | `/<ns>/<model>/...` | 401                                 |
 | 7 | Local k8s token still works (backward compat) | `Bearer <k8s-token>`   | `/<ns>/<model>/...` | 200                                 |
-| 8 | JWT on token endpoint (no escalation)         | `Bearer <jwt>`         | `/api/v1/token`     | 401, JWT auth disabled on this path |
+| 8 | Wristband on token endpoint (no re-minting)   | `Bearer <wristband>`   | `/api/v1/auth/token`     | 401, wristband auth disabled        |
+| 9 | External JWT → wristband exchange             | `Bearer <vault-jwt>`   | `/api/v1/auth/token`     | 200, OAuth 2.0 token response       |
 
 ### Test commands
 
@@ -1404,12 +1445,13 @@ spec:
 GW=http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local
 TEST_USER_TOKEN=$(oc create token test-user -n echo-service)
 
-# Scenario 1: Get JWT via /api/v1/token
+# Scenario 1: Get JWT via /api/v1/auth/token
 RESPONSE=$(oc exec -n default dnsutils -- curl -s \
   -H "Authorization: Bearer $TEST_USER_TOKEN" \
-  $GW/api/v1/token)
-JWT=$(echo "$RESPONSE" | jq -r .token)
+  $GW/api/v1/auth/token)
+JWT=$(echo "$RESPONSE" | jq -r .access_token)
 echo "JWT: ${JWT:0:50}..."
+echo "Expires in: $(echo "$RESPONSE" | jq .expires_in)s"
 
 # Scenario 2: Decode the JWT
 echo "$JWT" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
@@ -1434,8 +1476,8 @@ oc exec -n default dnsutils -- curl -s \
 # Scenario 8: JWT on token endpoint (no escalation)
 oc exec -n default dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
   -H "Authorization: Bearer $JWT" \
-  $GW/api/v1/token
-# Expected: 401 (wristband-user auth is disabled on /api/v1/token via when predicate)
+  $GW/api/v1/auth/token
+# Expected: 401 (wristband-user auth is disabled on /api/v1/auth/token via when predicate)
 ```
 
 ## External JWT issuers
@@ -1487,8 +1529,6 @@ authentication:
 
   # Generated from annotation entry: {"prefix": "vault", "jwksUrl": "https://vault.example.com/..."}
   jwt-vault:
-    when:
-      - predicate: "request.path != '/api/v1/token'"
     jwt:
       jwksUrl: "https://vault.example.com/v1/identity/oidc/.well-known/keys"
     overrides:
@@ -1503,9 +1543,14 @@ authentication:
 
 Key points:
 
-- **Token escalation prevention**: The `when` predicate disables external JWT auth on
-  `/api/v1/token`, same as `wristband-user`. Only `kubernetesTokenReview` can mint
-  wristband tokens.
+- **Token exchange support**: Unlike `wristband-user`, external JWT auth is **enabled**
+  on `/api/v1/auth/token`. A user can authenticate with an external JWT (e.g., Vault) and
+  receive a wristband in return. This provides a unified token exchange flow — users
+  authenticate with whatever credential they have and get a standard wristband that
+  works on any peer cluster. It also allows exchanging short-lived external tokens
+  (e.g., Vault tokens with 5-minute TTL) for longer-lived wristbands, so applications
+  don't need to keep refreshing external tokens. Note: wristband → wristband re-minting
+  is still blocked (`wristband-user` remains disabled on `/api/v1/auth/token`).
 - **Priority**: External issuers use `priority: 2` (after `kubernetes-user` at 0 and
   `wristband-user` at 1). Authorino evaluates lower-priority methods first, so local
   auth is preferred when both could match.
@@ -1672,7 +1717,7 @@ authentication rule per issuer.
 ## Open questions
 
 1. **Token endpoint backend**: The `model-serving-api` server (`server/`, `config/server/`)
-   is the production backend. Add a `/api/v1/token` handler that reads the wristband token
+   is the production backend. Add a `/api/v1/auth/token` handler that reads the wristband token
    from the upstream request header (injected by Authorino) and returns it in the response
    body as JSON.
 

--- a/internal/controller/resources/template/VAULT_INTEGRATION_TEST_PLAN.md
+++ b/internal/controller/resources/template/VAULT_INTEGRATION_TEST_PLAN.md
@@ -1,0 +1,1340 @@
+# Vault OIDC Integration Test Plan
+
+Validate external JWT authentication via the `security.opendatahub.io/authn-jwt-jwks`
+Gateway annotation, using HashiCorp Vault as the OIDC provider.
+
+This document is a companion to the "External JWT issuers" section of
+`MULTI_CLUSTER_AUTH.md`. It covers Vault setup, cluster configuration, and a complete
+set of test scenarios (functional, security, and edge cases) with copy-pasteable
+commands.
+
+**Validated**: All scenarios in this document have been tested on a live OCP cluster
+with RHOAI 3.3, Kuadrant, and Authorino. See "Validated findings" at the end for
+corrections discovered during testing.
+
+## What the annotation does
+
+When the controller sees `security.opendatahub.io/authn-jwt-jwks` on a Gateway, it
+generates one `jwt-<prefix>` authentication rule in the AuthPolicy per issuer entry.
+Each rule:
+
+- Verifies the JWT signature against the configured JWKS URL
+- Prefixes `username` and `groups` with `<prefix>:` to prevent collision with local
+  Kubernetes identities (e.g., Vault user `alice` becomes `vault:alice`)
+- Is disabled on `/api/v1/token` to prevent external JWTs from minting wristband tokens
+- Has `priority: 2` (evaluated after `kubernetes-user` at 0 and `wristband-user` at 1)
+
+## Prerequisites
+
+- RHOAI or ODH installed with Kuadrant and Authorino on the cluster
+- Gateway `openshift-ai-inference` in `openshift-ingress` namespace
+- Controller-generated AuthPolicy active (or manual AuthPolicy with external issuer
+  support)
+- CLIs: `oc` (authenticated as cluster-admin), `jq`
+- Network: Authorino must be able to reach the Vault JWKS endpoint (guaranteed by
+  deploying Vault in-cluster)
+
+## 1. Deploy Vault dev server (in-cluster)
+
+Deploy a Vault instance in dev mode inside the cluster. This avoids external network
+dependencies — Authorino can reach the JWKS URL via cluster DNS.
+
+**OpenShift note**: Vault's default entrypoint requires `CAP_SETFCAP` and memory
+locking (`mlock`), which are blocked by OpenShift's restricted SCC. The deployment
+below uses `VAULT_DISABLE_MLOCK=true`, `SKIP_SETCAP=true`, and an explicit
+`securityContext` to work within OpenShift's security constraints.
+
+```bash
+oc create namespace vault-oidc --dry-run=client -o yaml | oc apply -f -
+```
+
+```yaml
+# vault-dev.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault
+  namespace: vault-oidc
+  labels:
+    app.kubernetes.io/name: vault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault
+    spec:
+      containers:
+        - name: vault
+          image: hashicorp/vault:1.19
+          command: ["vault"]
+          args:
+            - server
+            - -dev
+            - -dev-root-token-id=root
+            - -dev-listen-address=0.0.0.0:8200
+          ports:
+            - containerPort: 8200
+              protocol: TCP
+          env:
+            - name: VAULT_ADDR
+              value: "http://127.0.0.1:8200"
+            - name: VAULT_TOKEN
+              value: "root"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: VAULT_DISABLE_MLOCK
+              value: "true"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            httpGet:
+              path: /v1/sys/health
+              port: 8200
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: vault-oidc
+  labels:
+    app.kubernetes.io/name: vault
+spec:
+  selector:
+    app.kubernetes.io/name: vault
+  ports:
+    - port: 8200
+      targetPort: 8200
+      protocol: TCP
+```
+
+```bash
+oc apply -f vault-dev.yaml
+oc wait -n vault-oidc deployment/vault --for=condition=Available --timeout=60s
+```
+
+Verify Vault is running:
+
+```bash
+oc exec -n vault-oidc deployment/vault -- vault status
+```
+
+## 2. Configure Vault OIDC provider
+
+All commands run inside the Vault pod using `oc exec`. Vault dev mode pre-authenticates
+with the root token.
+
+### 2a. Create a named key for signing OIDC tokens
+
+**Important**: Use `RS256`, not `ES256`. Vault's JWKS endpoint serves all keys
+(including default RS256 keys). Authorino's go-jose library rejects ES256-signed JWTs
+when the JWKS contains RS256 keys first (`unexpected signature algorithm "ES256";
+expected ["RS256"]`). Using RS256 avoids this issue.
+
+```bash
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/oidc/key/inference-key \
+    allowed_client_ids="*" \
+    algorithm="RS256"
+```
+
+### 2b. Create an OIDC role with identity claims
+
+The token template must include a `username` custom claim. Vault's default `sub` claim
+is the entity UUID (e.g., `d875f26f-abb6-d959-...`), not the human-readable entity name.
+The `username` claim provides the entity name for identity prefixing.
+
+```bash
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/oidc/role/inference-role \
+    key="inference-key" \
+    ttl="1h" \
+    template='{"username": {{identity.entity.name}}, "groups": {{identity.entity.groups.names}}}'
+```
+
+The `sub` claim is automatically set to the entity ID (UUID) by Vault. The identity
+normalization expression uses `auth.identity.username` (the custom claim), not
+`auth.identity.sub` (the UUID).
+
+### 2c. Create test entities
+
+Create entities for test scenarios. Each entity represents a user identity in Vault.
+
+```bash
+# Entity: alice (will have individual RBAC)
+ALICE_ID=$(oc exec -n vault-oidc deployment/vault -- \
+  vault write -field=id identity/entity \
+    name="alice" \
+    metadata=role="data-scientist")
+
+# Entity: bob (will have group-based RBAC)
+BOB_ID=$(oc exec -n vault-oidc deployment/vault -- \
+  vault write -field=id identity/entity \
+    name="bob" \
+    metadata=role="ml-engineer")
+
+# Entity: test-user (same name as k8s SA, for collision testing)
+TEST_USER_ID=$(oc exec -n vault-oidc deployment/vault -- \
+  vault write -field=id identity/entity \
+    name="test-user" \
+    metadata=role="collision-test")
+
+# Entity: unauthorized-user (no RBAC anywhere)
+UNAUTH_ID=$(oc exec -n vault-oidc deployment/vault -- \
+  vault write -field=id identity/entity \
+    name="unauthorized-user" \
+    metadata=role="none")
+```
+
+### 2d. Create a group and add members
+
+```bash
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/group \
+    name="ml-engineers" \
+    member_entity_ids="$BOB_ID"
+```
+
+### 2e. Create entity aliases
+
+Vault requires entity aliases linked to an auth method to generate tokens. Enable the
+`userpass` auth method, create an OIDC reader policy, and create aliases:
+
+```bash
+# Enable userpass auth
+oc exec -n vault-oidc deployment/vault -- vault auth enable userpass
+
+# Get the accessor for userpass (jq runs locally, not in the container)
+ACCESSOR=$(oc exec -n vault-oidc deployment/vault -- \
+  vault auth list -format=json | jq -r '.["userpass/"].accessor')
+
+# Create a policy allowing users to read OIDC tokens
+# (the default policy does not grant this — without it, token generation fails with 403)
+oc exec -n vault-oidc deployment/vault -- sh -c '
+cat > /tmp/oidc-reader.hcl <<POLICY
+path "identity/oidc/token/*" {
+  capabilities = ["read"]
+}
+POLICY
+vault policy write oidc-reader /tmp/oidc-reader.hcl'
+
+# Create userpass users with the oidc-reader policy
+for USER in alice bob test-user unauthorized-user; do
+  oc exec -n vault-oidc deployment/vault -- \
+    vault write auth/userpass/users/$USER password="testpassword" policies="oidc-reader"
+done
+
+# Create entity aliases
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/entity-alias name="alice" canonical_id="$ALICE_ID" mount_accessor="$ACCESSOR"
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/entity-alias name="bob" canonical_id="$BOB_ID" mount_accessor="$ACCESSOR"
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/entity-alias name="test-user" canonical_id="$TEST_USER_ID" mount_accessor="$ACCESSOR"
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/entity-alias name="unauthorized-user" canonical_id="$UNAUTH_ID" mount_accessor="$ACCESSOR"
+```
+
+### 2f. Generate test tokens
+
+To generate a token for a specific entity, log in as that user and read the OIDC token.
+
+**Important**: The container has `VAULT_TOKEN=root` set as an environment variable
+(for `vault` CLI admin operations). This root token takes precedence over `vault login`.
+The helper below uses `unset VAULT_TOKEN` before logging in so that the userpass
+token (which carries entity context) is used for the OIDC read.
+
+```bash
+# Helper function: get a Vault JWT for a user
+vault_jwt() {
+  local user=$1
+  oc exec -n vault-oidc deployment/vault -- sh -c "
+    unset VAULT_TOKEN
+    vault login -method=userpass username=$user password=testpassword >/dev/null 2>&1
+    vault read -field=token identity/oidc/token/inference-role
+  "
+}
+
+# Generate tokens
+ALICE_JWT=$(vault_jwt alice)
+BOB_JWT=$(vault_jwt bob)
+TEST_USER_JWT=$(vault_jwt test-user)
+UNAUTH_JWT=$(vault_jwt unauthorized-user)
+```
+
+### 2g. Verify the JWKS endpoint
+
+```bash
+oc exec -n vault-oidc deployment/vault -- \
+  curl -s http://127.0.0.1:8200/v1/identity/oidc/.well-known/keys | jq .
+```
+
+Expected: JSON with `keys` array containing RS256 public keys.
+
+### 2h. Decode a test token
+
+```bash
+echo "$ALICE_JWT" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+```
+
+Expected payload structure:
+
+```json
+{
+  "aud": "...",
+  "exp": 1776677808,
+  "groups": null,
+  "iat": 1776674208,
+  "iss": "http://0.0.0.0:8200/v1/identity/oidc",
+  "namespace": "root",
+  "sub": "d875f26f-abb6-d959-6cf7-dee7e4d52094",
+  "username": "alice"
+}
+```
+
+Key observations:
+- `iss` is `http://0.0.0.0:8200/...` (Vault's listen address), not the cluster DNS name.
+  This is why `jwksUrl` must be used on the consumer side, not `issuerUrl` — issuer URL
+  validation would fail because the `iss` claim doesn't match the cluster-accessible URL.
+- `sub` is the entity UUID, not the entity name. The `username` custom claim carries the
+  human-readable name.
+- `groups` is `null` (not `[]`) when the entity has no group membership. The CEL identity
+  normalization expression must handle null: `has(auth.identity.groups) &&
+  auth.identity.groups != null ? ... : []`.
+
+## 3. Cluster configuration
+
+### 3a. Annotate the Gateway
+
+Add the external issuer annotation to the Gateway. The JWKS URL uses the in-cluster
+Vault Service DNS name:
+
+```bash
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+```
+
+### 3b. Verify the AuthPolicy was updated
+
+The controller should add a `jwt-vault` authentication rule to the AuthPolicy:
+
+```bash
+oc get authpolicy openshift-ai-inference-authn -n openshift-ingress -o yaml | grep -A 20 'jwt-vault'
+```
+
+Expected: a `jwt-vault` authentication section with:
+- `when` predicate excluding `/api/v1/token`
+- `jwt.jwksUrl` pointing to the Vault JWKS endpoint
+- `overrides.user` expression prefixing identities with `vault:`
+- `priority: 2`
+
+If the controller has not yet implemented this feature, apply the AuthPolicy manually
+(see "Manual AuthPolicy" appendix below).
+
+### 3c. Create RBAC for prefixed Vault identities
+
+```yaml
+# vault-rbac.yaml
+
+# User-based: vault:alice can access models in echo-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-alice-inference-access
+  namespace: echo-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: User
+    name: "vault:alice"
+    apiGroup: rbac.authorization.k8s.io
+---
+# Group-based: vault:ml-engineers can access models in echo-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-ml-engineers-inference-access
+  namespace: echo-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: Group
+    name: "vault:ml-engineers"
+    apiGroup: rbac.authorization.k8s.io
+```
+
+```bash
+oc apply -f vault-rbac.yaml
+```
+
+Note: `vault:test-user` and `vault:unauthorized-user` intentionally have **no**
+RoleBindings. This is required for the identity prefix isolation and negative tests.
+
+## 4. Deploy test infrastructure
+
+Reuse the echo-service infrastructure from `BATCH.md`. If it is already deployed, skip
+to step 4c.
+
+### 4a. Echo server
+
+```bash
+oc create namespace echo-service --dry-run=client -o yaml | oc apply -f -
+```
+
+```yaml
+# echo-server.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-server
+  namespace: echo-service
+  labels:
+    app.kubernetes.io/name: echo-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: echo-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: echo-server
+    spec:
+      containers:
+        - name: echo-server
+          image: ealen/echo-server:0.9.2
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8080"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-server
+  namespace: echo-service
+  labels:
+    app.kubernetes.io/name: echo-server
+spec:
+  selector:
+    app.kubernetes.io/name: echo-server
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+```
+
+```bash
+oc apply -f echo-server.yaml
+oc wait -n echo-service deployment/echo-server --for=condition=Available --timeout=60s
+```
+
+### 4b. HTTPRoute, ServiceAccount, and RBAC
+
+```yaml
+# echo-routes-and-rbac.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-inference
+  namespace: echo-service
+spec:
+  parentRefs:
+    - name: openshift-ai-inference
+      namespace: openshift-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /echo-service/echo-server
+      backendRefs:
+        - name: echo-server
+          port: 80
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-user
+  namespace: echo-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llminferenceservices-reader
+rules:
+  - apiGroups: ["serving.kserve.io"]
+    resources: ["llminferenceservices"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-user-inference-access
+  namespace: echo-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llminferenceservices-reader
+subjects:
+  - kind: ServiceAccount
+    name: test-user
+    namespace: echo-service
+```
+
+```bash
+oc apply -f echo-routes-and-rbac.yaml
+```
+
+### 4c. dnsutils pod
+
+```bash
+oc run dnsutils --image=registry.k8s.io/e2e-test-images/agnhost:2.39 \
+  --restart=Never --command -- sleep infinity 2>/dev/null || true
+oc wait pod dnsutils --for=condition=Ready --timeout=60s
+```
+
+### 4d. Set variables
+
+```bash
+GW="http://openshift-ai-inference-openshift-default.openshift-ingress.svc.cluster.local"
+TEST_USER_TOKEN=$(oc create token test-user -n echo-service --audience=https://kubernetes.default.svc)
+```
+
+Refresh the Vault JWTs (they expire after 1 hour):
+
+```bash
+ALICE_JWT=$(vault_jwt alice)
+BOB_JWT=$(vault_jwt bob)
+TEST_USER_JWT=$(vault_jwt test-user)
+UNAUTH_JWT=$(vault_jwt unauthorized-user)
+```
+
+## 5. Functional test scenarios
+
+| # | Scenario                               | Token                | Path                                            | Expected                                       |
+|---|----------------------------------------|----------------------|-------------------------------------------------|------------------------------------------------|
+| 1 | Vault JWT, valid user RBAC             | `$ALICE_JWT`         | `/echo-service/echo-server/v1/chat/completions` | 200, identity = `vault:alice`                  |
+| 2 | Vault JWT, group-based RBAC            | `$BOB_JWT`           | `/echo-service/echo-server/v1/chat/completions` | 200, identity = `vault:bob`                    |
+| 3 | K8s token backward compatibility       | `$TEST_USER_TOKEN`   | `/echo-service/echo-server/v1/chat/completions` | 200, identity = `system:serviceaccount:...`    |
+| 4 | Vault JWT on token endpoint (blocked)  | `$ALICE_JWT`         | `/api/v1/token`                                 | 401 (external JWT disabled on this path)       |
+
+### Scenario 1: Vault JWT with valid user RBAC
+
+`vault:alice` has a RoleBinding in `echo-service`. The Vault JWT should authenticate,
+get prefixed to `vault:alice`, and pass the SubjectAccessReview.
+
+```bash
+oc exec dnsutils -- curl -s \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions" | jq .
+```
+
+Expected: 200. The echo server response should show the request was forwarded
+(Authorino authenticated and authorized the request).
+
+### Scenario 2: Vault JWT with group-based RBAC
+
+`bob` is a member of the `ml-engineers` group in Vault. The JWT includes
+`"groups": ["ml-engineers"]`, which the controller normalizes to
+`["vault:ml-engineers"]`. The group RoleBinding in `echo-service` grants access.
+
+```bash
+oc exec dnsutils -- curl -s \
+  -H "Authorization: Bearer $BOB_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions" | jq .
+```
+
+Expected: 200.
+
+### Scenario 3: Kubernetes token backward compatibility
+
+The existing `kubernetesTokenReview` authentication must continue to work unchanged.
+
+```bash
+oc exec dnsutils -- curl -s \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/echo-service/echo-server/v1/chat/completions" | jq .
+```
+
+Expected: 200.
+
+### Scenario 4: Vault JWT on token endpoint (escalation prevention)
+
+External JWT authentication is disabled on `/api/v1/token` via a `when` predicate.
+Only `kubernetesTokenReview` can access the token endpoint (to prevent external JWTs
+from minting wristband tokens).
+
+```bash
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/api/v1/token"
+```
+
+Expected: `401`.
+
+## 6. Security test scenarios
+
+| # | Scenario                        | Token                | Path                                            | Expected                |
+|---|---------------------------------|----------------------|-------------------------------------------------|-------------------------|
+| 5 | No RBAC for Vault identity      | `$UNAUTH_JWT`        | `/echo-service/echo-server/v1/chat/completions` | 403                     |
+| 6 | Expired Vault JWT               | `$EXPIRED_JWT`       | `/echo-service/echo-server/v1/chat/completions` | 401                     |
+| 7 | Tampered JWT payload            | `$TAMPERED_JWT`      | `/echo-service/echo-server/v1/chat/completions` | 401                     |
+| 8 | Invalid JWT (garbage string)    | `not-a-jwt`          | `/echo-service/echo-server/v1/chat/completions` | 401                     |
+| 9 | Identity prefix isolation       | `$TEST_USER_JWT`     | `/echo-service/echo-server/v1/chat/completions` | 403 (vault:test-user)   |
+
+### Scenario 5: No RBAC for Vault identity
+
+`vault:unauthorized-user` has no RoleBinding anywhere. Authentication passes (valid
+JWT), but the SubjectAccessReview fails.
+
+```bash
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $UNAUTH_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+```
+
+Expected: `403`.
+
+### Scenario 6: Expired Vault JWT
+
+Create a Vault role with a very short TTL to produce an expired token:
+
+```bash
+# Create a short-lived role (2 seconds)
+oc exec -n vault-oidc deployment/vault -- \
+  vault write identity/oidc/role/expired-role \
+    key="inference-key" \
+    ttl="2s" \
+    template='{"username": {{identity.entity.name}}, "groups": {{identity.entity.groups.names}}}'
+
+# Get a token and wait for it to expire
+EXPIRED_JWT=$(vault_jwt_with_role alice expired-role)
+sleep 5
+
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $EXPIRED_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+```
+
+Where `vault_jwt_with_role` is the same as `vault_jwt` but reads from the specified role:
+
+```bash
+vault_jwt_with_role() {
+  local user=$1
+  local role=$2
+  oc exec -n vault-oidc deployment/vault -- sh -c "
+    unset VAULT_TOKEN
+    vault login -method=userpass username=$user password=testpassword >/dev/null 2>&1
+    vault read -field=token identity/oidc/token/$role
+  "
+}
+```
+
+Expected: `401`.
+
+### Scenario 7: Tampered JWT payload
+
+Take a valid JWT and modify the payload to change the identity. The signature becomes
+invalid:
+
+```bash
+# Split the JWT
+HEADER=$(echo "$ALICE_JWT" | cut -d. -f1)
+PAYLOAD=$(echo "$ALICE_JWT" | cut -d. -f2)
+SIGNATURE=$(echo "$ALICE_JWT" | cut -d. -f3)
+
+# Decode, modify, re-encode the payload
+MODIFIED_PAYLOAD=$(echo "$PAYLOAD" | tr '_-' '/+' | base64 -d 2>/dev/null \
+  | jq '.sub = "tampered-identity"' \
+  | base64 | tr '/+' '_-' | tr -d '=')
+
+TAMPERED_JWT="${HEADER}.${MODIFIED_PAYLOAD}.${SIGNATURE}"
+
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TAMPERED_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+```
+
+Expected: `401` (signature verification fails).
+
+### Scenario 8: Invalid JWT (garbage string)
+
+```bash
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer not-a-jwt" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+```
+
+Expected: `401`.
+
+### Scenario 9: Identity prefix isolation
+
+This is the critical security test. A Vault entity named `test-user` is prefixed to
+`vault:test-user` by the identity normalization. The Kubernetes SA
+`system:serviceaccount:echo-service:test-user` has RBAC (via the standard RoleBinding),
+but `vault:test-user` has **no** RoleBinding. This proves the prefix prevents identity
+collision.
+
+```bash
+# Vault JWT for test-user entity -> becomes vault:test-user -> no RBAC -> 403
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TEST_USER_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 403
+
+# K8s token for SA test-user -> system:serviceaccount:echo-service:test-user -> has RBAC -> 200
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+```
+
+This validates that Vault identity `test-user` and Kubernetes SA `test-user` are
+distinct — the prefix mechanism prevents escalation.
+
+## 7. Edge case scenarios
+
+| #  | Scenario                   | Setup                                          | Expected                                     |
+|----|----------------------------|-------------------------------------------------|----------------------------------------------|
+| 10 | Unreachable JWKS URL       | Set jwksUrl to invalid endpoint                 | Vault JWT 401, k8s token 200                 |
+| 11 | Remove annotation          | Remove `authn-jwt-jwks` annotation              | Vault JWT 401, k8s token 200                 |
+| 12 | Re-add annotation          | Re-apply the annotation                         | Vault JWT works again                        |
+| 13 | Multiple external issuers  | Add a second prefix entry                       | Both JWT types authenticate correctly        |
+| 14 | Empty groups in JWT        | Entity with no group membership                 | User-level RBAC only, empty groups in SAR    |
+| 15 | No token at all            | Omit Authorization header                       | 401                                          |
+
+### Scenario 10: Unreachable JWKS URL
+
+Set the JWKS URL to an endpoint that does not exist. Authorino cannot fetch the keys,
+so Vault JWTs fail verification. Kubernetes tokens are unaffected.
+
+```bash
+# Set an invalid JWKS URL
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://does-not-exist.svc:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+
+# Wait for AuthPolicy to reconcile
+sleep 5
+
+# Vault JWT should fail
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 401
+
+# K8s token should still work
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+
+# Restore the correct URL
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+```
+
+### Scenario 11: Remove annotation
+
+Removing the annotation should cause the controller to regenerate the AuthPolicy
+without the `jwt-vault` rule. Vault JWTs become unrecognized.
+
+```bash
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks- \
+
+# Wait for AuthPolicy to reconcile
+sleep 5
+
+# Vault JWT should fail (no jwt-vault auth rule)
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 401
+
+# K8s token should still work
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+```
+
+### Scenario 12: Re-add annotation
+
+```bash
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+
+# Wait for AuthPolicy to reconcile
+sleep 5
+
+# Vault JWT should work again (need a fresh token if the old one expired)
+ALICE_JWT=$(vault_jwt alice)
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+```
+
+### Scenario 13: Multiple external issuers
+
+Add a second external issuer (simulated by a second Vault role with a different prefix):
+
+```bash
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"},{"prefix":"vault2","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+
+# Wait for AuthPolicy to reconcile
+sleep 5
+
+# Verify both jwt-vault and jwt-vault2 auth rules exist
+oc get authpolicy openshift-ai-inference-authn -n openshift-ingress -o yaml | grep -E 'jwt-vault|jwt-vault2'
+```
+
+Create RBAC for the second prefix:
+
+```bash
+oc create rolebinding vault2-alice-inference-access -n echo-service \
+  --clusterrole=llminferenceservices-reader \
+  --user="vault2:alice"
+```
+
+Test that the same Vault JWT authenticates under the second prefix:
+
+```bash
+# vault2:alice should also work
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200 (matches either jwt-vault or jwt-vault2, both have valid JWKS)
+```
+
+Restore single issuer:
+
+```bash
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks='[{"prefix":"vault","jwksUrl":"http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"}]' \
+  --overwrite
+oc delete rolebinding vault2-alice-inference-access -n echo-service
+```
+
+### Scenario 14: Empty groups in JWT
+
+`alice` is not a member of any Vault group. The JWT's `groups` claim is `null` (not
+`[]` — Vault uses null for absent group membership). The CEL expression handles null
+and normalizes it to an empty list. The SAR uses an empty groups list, so only
+user-level RBAC applies.
+
+```bash
+# alice has user-level RBAC (vault:alice RoleBinding exists) -> 200
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+```
+
+### Scenario 15: No token at all
+
+```bash
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 401
+```
+
+## 8. Wristband token coexistence
+
+If wristband token exchange is configured on the same cluster (see
+`MULTI_CLUSTER_AUTH.md`), verify that all three authentication methods coexist.
+
+### Scenario 16: Wristband token still works alongside Vault
+
+```bash
+# Get a wristband (requires token exchange to be configured)
+WRISTBAND=$(oc exec dnsutils -- curl -s \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/api/v1/token" | jq -r '.request.headers["x-wristband-token"]')
+
+# Use the wristband for inference
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $WRISTBAND" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200 (wristband auth is independent of Vault auth)
+```
+
+### Scenario 17: All three auth methods in one session
+
+```bash
+echo "K8s token:"
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TEST_USER_TOKEN" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+
+echo "Vault JWT:"
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $ALICE_JWT" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+
+echo "Wristband:"
+oc exec dnsutils -- curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $WRISTBAND" \
+  "$GW/echo-service/echo-server/v1/chat/completions"
+# Expected: 200
+```
+
+## 9. Automated e2e test design
+
+The manual scenarios above map to Go e2e tests following the patterns in
+`internal/controller/test/e2e/batch_authpolicy_test.go`.
+
+### Proposed file structure
+
+```
+internal/controller/test/e2e/
+  vault_jwt_test.go          # Test functions (//go:build e2e)
+  vault_jwt_test_env.go      # vaultTestEnv struct, setup/teardown helpers
+```
+
+### Test environment
+
+```go
+type vaultTestEnv struct {
+    gatewayURL       string
+    gatewayName      string
+    gatewayNamespace string
+    vaultNamespace   string
+    echoNamespace    string
+    clientset        *kubernetes.Clientset
+    k8sClient        client.Client
+    httpClient       *http.Client
+    portForwardStop  chan struct{}
+}
+```
+
+Key helper methods:
+
+| Method | Purpose |
+|--------|---------|
+| `deployVault(t)` | Deploy Vault dev server pod + service |
+| `configureVaultOIDC(t)` | Create named key, OIDC role, entities, groups, aliases |
+| `getVaultJWT(t, user string) string` | Log in as user, read OIDC token |
+| `annotateGateway(t, issuers string)` | Set `authn-jwt-jwks` annotation |
+| `removeGatewayAnnotation(t)` | Remove `authn-jwt-jwks` annotation |
+| `createVaultRBAC(t, prefix, name, ns string)` | Create RoleBinding for prefixed identity |
+| `waitForAuthPolicyRule(t, ruleName string)` | Poll until the auth rule appears in the AuthPolicy |
+
+### Test function mapping
+
+| Test function | Scenario # | What it validates |
+|---------------|------------|-------------------|
+| `TestVaultJWTUserRBAC` | 1 | Vault JWT + user RoleBinding = 200 |
+| `TestVaultJWTGroupRBAC` | 2 | Vault JWT + group RoleBinding = 200 |
+| `TestKubernetesTokenBackwardCompat` | 3 | K8s token still works = 200 |
+| `TestVaultJWTTokenEndpointBlocked` | 4 | Vault JWT on /api/v1/token = 401 |
+| `TestVaultJWTNoRBAC` | 5 | Vault JWT without RBAC = 403 |
+| `TestVaultJWTExpired` | 6 | Expired JWT = 401 |
+| `TestVaultJWTTampered` | 7 | Modified payload = 401 |
+| `TestVaultJWTInvalid` | 8 | Garbage string = 401 |
+| `TestVaultJWTIdentityPrefixIsolation` | 9 | vault:test-user 403, k8s test-user 200 |
+| `TestVaultJWTUnreachableJWKS` | 10 | Bad URL = vault 401, k8s 200 |
+| `TestVaultJWTAnnotationRemoval` | 11 | Remove annotation = vault 401, k8s 200 |
+| `TestVaultJWTAnnotationRestore` | 12 | Re-add annotation = vault 200 |
+| `TestMultipleExternalIssuers` | 13 | Two prefixes, both authenticate |
+| `TestVaultJWTEmptyGroups` | 14 | No groups = user RBAC only |
+| `TestNoToken` | 15 | Missing auth header = 401 |
+
+### TestMain
+
+```go
+func TestMain(m *testing.M) {
+    env, err := newVaultTestEnv()  // gateway discovery, port-forward
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "setup: %v\n", err)
+        os.Exit(1)
+    }
+    env.deployVault(nil)              // deploy Vault pod + service
+    env.configureVaultOIDC(nil)       // create OIDC provider, entities, groups
+    env.deployEchoServer(nil)         // deploy echo server + HTTPRoute
+    env.annotateGateway(nil, `[...]`) // set the external issuer annotation
+    env.createVaultRBAC(nil, ...)     // create RoleBindings for prefixed identities
+
+    code := m.Run()
+    env.close()
+    os.Exit(code)
+}
+```
+
+### Token generation in Go
+
+Instead of shelling out to `vault`, call the Vault HTTP API directly:
+
+```go
+func (e *vaultTestEnv) getVaultJWT(t *testing.T, user string) string {
+    // POST /v1/auth/userpass/login/<user> -> client_token
+    // GET  /v1/identity/oidc/token/inference-role with X-Vault-Token -> token
+}
+```
+
+### Makefile target
+
+```makefile
+test-e2e-vault:
+	go test -v -tags=e2e -timeout=10m -parallel=8 \
+	  ./internal/controller/test/e2e/ -run TestVault -count=1
+```
+
+## 10. Verification checklist
+
+| # | Check                                                       | Pass |
+|---|-------------------------------------------------------------|------|
+| 1 | Vault JWT authenticates with valid user RBAC (200)          | [ ]  |
+| 2 | Group-based RBAC works with prefixed groups (200)           | [ ]  |
+| 3 | K8s token backward compatibility (200)                      | [ ]  |
+| 4 | Vault JWT blocked on /api/v1/token (401)                    | [ ]  |
+| 5 | No RBAC for Vault identity (403)                            | [ ]  |
+| 6 | Expired Vault JWT (401)                                     | [ ]  |
+| 7 | Tampered JWT rejected (401)                                 | [ ]  |
+| 8 | Invalid token rejected (401)                                | [ ]  |
+| 9 | Identity prefix prevents collision (vault:X != k8s X)       | [ ]  |
+| 10 | Unreachable JWKS: vault 401, k8s 200                       | [ ]  |
+| 11 | Annotation removal: vault 401, k8s 200                     | [ ]  |
+| 12 | Annotation restore: vault works again                      | [ ]  |
+| 13 | Multiple external issuers coexist                          | [ ]  |
+| 14 | Empty groups: user-level RBAC only                         | [ ]  |
+| 15 | Missing auth header (401)                                  | [ ]  |
+| 16 | Wristband token works alongside Vault (200)                | [ ]  |
+| 17 | All three auth methods coexist                             | [ ]  |
+
+## 11. Cleanup
+
+```bash
+# Remove Vault RBAC
+oc delete rolebinding vault-alice-inference-access -n echo-service
+oc delete rolebinding vault-ml-engineers-inference-access -n echo-service
+
+# Remove Gateway annotation
+oc annotate gateway openshift-ai-inference -n openshift-ingress \
+  security.opendatahub.io/authn-jwt-jwks-
+
+# Remove Vault
+oc delete namespace vault-oidc
+
+# Remove echo server (if created for this test)
+oc delete httproute echo-inference -n echo-service
+oc delete deployment echo-server -n echo-service
+oc delete service echo-server -n echo-service
+oc delete rolebinding test-user-inference-access -n echo-service
+oc delete serviceaccount test-user -n echo-service
+
+# Remove dnsutils
+oc delete pod dnsutils
+
+# Remove namespace (if no longer needed)
+oc delete namespace echo-service
+
+# Remove ClusterRole (shared, check if other tests need it)
+# oc delete clusterrole llminferenceservices-reader
+```
+
+## 12. Known limitations
+
+- **Vault dev mode**: Uses HTTP without TLS. Suitable for testing only. The JWKS URL
+  uses `http://` which Authorino accepts. In production, Vault should use TLS and the
+  JWKS URL should use `https://`.
+- **JWKS cache refresh**: Authorino caches JWKS and refreshes periodically. Immediate
+  changes to the JWKS (e.g., key rotation in Vault) may not be reflected for a few
+  seconds. Allow a brief delay in tests after JWKS changes.
+- **`jwksUrl` vs `issuerUrl`**: The annotation uses `jwksUrl`, which means Authorino
+  does **not** validate the `iss` claim in the JWT. This is required because Vault dev
+  mode's `iss` claim uses the internal listen address (`http://0.0.0.0:8200/...`), not
+  the cluster DNS name. Even in production, `jwksUrl` is preferred for flexibility.
+- **Priority ordering**: External issuers use `priority: 2`. Authorino evaluates
+  lower-priority methods first (`kubernetes-user` at 0, `wristband-user` at 1). If a
+  token matches a higher-priority method, the external issuer is not evaluated.
+- **Vault token TTL**: Vault OIDC tokens have a TTL configured on the role (default
+  `1h` in this test plan). Refresh tokens before they expire when running tests
+  manually.
+
+## Validated findings
+
+The following issues were discovered during live cluster validation and are reflected
+in the document above. They are listed here as a reference for the design discussion.
+
+### 1. OIDC key algorithm must be RS256
+
+Vault's OIDC JWKS endpoint serves all named keys alongside default RS256 keys. When
+the inference key uses ES256, the JWKS contains both RS256 and ES256 entries. Authorino's
+go-jose library selects RS256 as the expected algorithm (based on JWKS ordering) and
+rejects the ES256-signed JWT with:
+
+```
+oidc: malformed jwt: go-jose/go-jose: unexpected signature algorithm "ES256"; expected ["RS256"]
+```
+
+**Resolution**: Use `algorithm="RS256"` for the Vault OIDC named key. This aligns with
+the default keys already in the JWKS.
+
+**Impact on MULTI_CLUSTER_AUTH.md**: The design doc's Vault example should note that
+the OIDC key algorithm must match what Authorino expects from the JWKS. If the JWKS
+serves multiple algorithms, Authorino may not handle mixed-algorithm JWKS correctly.
+
+### 2. `sub` claim is entity UUID, not entity name
+
+Vault's OIDC `sub` claim contains the entity ID (UUID, e.g., `d875f26f-abb6-d959-...`),
+not the human-readable entity name. The original design expression
+`'vault:' + auth.identity.sub` would produce `vault:d875f26f-abb6-...`, which is
+unusable for RoleBinding subjects.
+
+**Resolution**: Add a `username` custom claim to the OIDC role template
+(`{{identity.entity.name}}`), and use `auth.identity.username` in the identity
+normalization expression.
+
+**Impact on MULTI_CLUSTER_AUTH.md**: The external issuer section should document that
+Vault requires a custom `username` claim and the identity expression should reference
+`auth.identity.username`, not `auth.identity.sub`.
+
+### 3. `iss` claim uses Vault's listen address
+
+Vault sets the `iss` claim to its internal listen address (`http://0.0.0.0:8200/...`),
+not the externally reachable service URL. This makes `issuerUrl`-based validation
+impossible — Authorino would try to discover OIDC at `http://0.0.0.0:8200/...` which
+is not reachable from the Authorino pod.
+
+**Resolution**: Use `jwksUrl` (not `issuerUrl`) for external issuers. Authorino fetches
+keys from the configured URL and skips `iss` validation.
+
+### 4. `groups` claim is `null` when empty
+
+Vault returns `"groups": null` (not `[]`) when an entity has no group membership. The
+CEL expression must handle both `null` and `[]`:
+
+```
+has(auth.identity.groups) && auth.identity.groups != null
+  ? auth.identity.groups.map(g, 'vault:' + g)
+  : []
+```
+
+### 5. OpenShift SCC requires special container configuration
+
+Vault's default entrypoint calls `setcap` and `mlock`, which OpenShift's restricted SCC
+blocks. The container requires:
+- `VAULT_DISABLE_MLOCK=true` and `SKIP_SETCAP=true` env vars
+- Explicit `command: ["vault"]` (bypasses the default entrypoint)
+- `securityContext.allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]`
+
+### 6. `VAULT_TOKEN` env var overrides `vault login`
+
+The container's `VAULT_TOKEN=root` environment variable takes precedence over
+`vault login`. When generating user-specific OIDC tokens, `VAULT_TOKEN` must be unset
+first — otherwise the root token is used, which has no entity association, and the OIDC
+read fails with "no entity associated with the request's token".
+
+### 7. Vault userpass requires explicit OIDC policy
+
+The default Vault policy does not grant permission to read OIDC tokens. Without an
+explicit policy, users get a 403 when calling
+`vault read identity/oidc/token/<role>`. An `oidc-reader` policy must be created and
+attached to userpass users.
+
+### Test results
+
+All scenarios validated on OCP cluster with RHOAI 3.3, Kuadrant, and Authorino:
+
+| # | Scenario                                    | Expected | Actual | Status    |
+|---|---------------------------------------------|----------|--------|-----------|
+| 1 | Vault JWT alice (user RBAC)                 | 200      | 200    | Validated |
+| 2 | Vault JWT bob (group RBAC)                  | 200      | 200    | Validated |
+| 3 | K8s token backward compatibility            | 200      | 200    | Validated |
+| 4 | Vault JWT on /api/v1/token (blocked)        | 401      | 401    | Validated |
+| 5 | No RBAC for Vault identity                  | 403      | 403    | Validated |
+| 6 | Expired Vault JWT                           | 401      | 401    | Validated |
+| 7 | Tampered JWT payload                        | 401      | 401    | Validated |
+| 8 | Invalid JWT (garbage)                       | 401      | 401    | Validated |
+| 9 | Identity prefix isolation                   | 403/200  | 403/200| Validated |
+| 11| Remove jwt-vault rule                       | 401/200  | 401/200| Validated |
+| 12| Re-add jwt-vault rule                       | 200      | 200    | Validated |
+| 15| No token at all                             | 401      | 401    | Validated |
+| 16| Wristband coexistence                       | 200      | 200    | Validated |
+
+## Appendix: Manual AuthPolicy with external issuer
+
+If the controller has not yet implemented `security.opendatahub.io/authn-jwt-jwks`
+parsing, apply this AuthPolicy manually. It extends the standard
+`authpolicy_llm_isvc_userdefined.yaml` template with a `jwt-vault` authentication
+rule.
+
+Label the existing AuthPolicy as unmanaged first:
+
+```bash
+oc label authpolicy openshift-ai-inference-authn -n openshift-ingress \
+  opendatahub.io/managed=false
+```
+
+Then apply:
+
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: openshift-ai-inference-authn
+  namespace: openshift-ingress
+  labels:
+    app.kubernetes.io/name: llminferenceservice-auth
+    app.kubernetes.io/component: llminferenceservice-policies
+    app.kubernetes.io/part-of: llminferenceservice
+    app.kubernetes.io/managed-by: manual
+    opendatahub.io/managed: "false"
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: openshift-ai-inference
+  rules:
+    authentication:
+      kubernetes-user:
+        kubernetesTokenReview:
+          audiences:
+            - https://kubernetes.default.svc
+        overrides:
+          fairness:
+            value: "https://kubernetes.default.svc"
+          objective:
+            expression: >-
+              auth.identity.user.username.startsWith('system:serviceaccount:')
+                ? auth.identity.user.username.split(':')[2]
+                : 'authenticated'
+
+      jwt-vault:
+        when:
+          - predicate: "request.path != '/api/v1/token'"
+        jwt:
+          jwksUrl: "http://vault.vault-oidc.svc.cluster.local:8200/v1/identity/oidc/.well-known/keys"
+        overrides:
+          user:
+            expression: "{'username': 'vault:' + auth.identity.username, 'groups': has(auth.identity.groups) && auth.identity.groups != null ? auth.identity.groups.map(g, 'vault:' + g) : []}"
+          fairness:
+            expression: auth.identity.iss
+          objective:
+            expression: "'authenticated'"
+        priority: 2
+
+    authorization:
+      inference-access:
+        when:
+          - predicate: >-
+              !(request.path == '/api/v1/token' ||
+                request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+        kubernetesSubjectAccessReview:
+          user:
+            expression: >-
+              'x-maas-user' in request.headers
+                ? request.headers['x-maas-user']
+                : auth.identity.user.username
+          authorizationGroups:
+            expression: >-
+              'x-maas-user' in request.headers
+                ? ('x-maas-groups' in request.headers
+                    ? request.headers['x-maas-groups'].split(',')
+                    : [])
+                : auth.identity.user.groups
+          resourceAttributes:
+            group:
+              value: serving.kserve.io
+            resource:
+              value: llminferenceservices
+            namespace:
+              expression: request.path.split("/")[1]
+            name:
+              expression: request.path.split("/")[2]
+            verb:
+              value: get
+        priority: 1
+      inference-access-delegate:
+        when:
+          - predicate: >-
+              !(request.path == '/api/v1/token' ||
+                request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
+          - predicate: "'x-maas-user' in request.headers"
+        kubernetesSubjectAccessReview:
+          user:
+            expression: "auth.identity.user.username"
+          authorizationGroups:
+            expression: "auth.identity.user.groups"
+          resourceAttributes:
+            group:
+              value: serving.kserve.io
+            resource:
+              value: llminferenceservices/delegate
+            namespace:
+              expression: request.path.split("/")[1]
+            name:
+              expression: request.path.split("/")[2]
+            verb:
+              value: post-delegate
+        priority: 1
+
+    response:
+      success:
+        headers:
+          x-gateway-inference-fairness-id:
+            metrics: false
+            plain:
+              expression: auth.identity.fairness
+            priority: 0
+          x-gateway-inference-objective:
+            metrics: false
+            plain:
+              expression: auth.identity.objective
+            priority: 0
+          x-maas-user:
+            when:
+              - predicate: >-
+                  request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                  request.path == '/v1/batches' || request.path.startsWith('/v1/batches/')
+            plain:
+              expression: auth.identity.user.username
+            priority: 0
+          x-maas-groups:
+            when:
+              - predicate: >-
+                  request.path == '/v1/files' || request.path.startsWith('/v1/files/') ||
+                  request.path == '/v1/batches' || request.path.startsWith('/v1/batches/')
+            plain:
+              expression: "auth.identity.user.groups.join(',')"
+            priority: 0
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Problem

Kubernetes tokens are cluster-scoped. A ServiceAccount token valid on cluster A cannot
authenticate on cluster B. In a multi-cluster topology where inference workloads are
distributed across clusters, users need a portable identity token to access models on
any cluster where they have been granted RBAC.

Additionally, organizations may have existing identity providers (HashiCorp Vault,
Keycloak, Auth0) that issue JWTs to users outside the Kubernetes ecosystem. These
users need to authenticate to inference endpoints without requiring a Kubernetes
identity on every cluster.

## Architecture: peer-to-peer

Every cluster is an equal peer — each can issue JWT tokens and consume tokens
issued by other peers. There is no hub/spoke distinction. The token proves the
user's **identity** (who they are), not their **authorization** (what they can do).
Each cluster enforces its own RBAC independently.

### Component diagram

```text
                                                 Client
                                                   │
                                           External LB / DNS
                                  ┌────────────────┴────────────────┐
                                  ▼                                 ▼
 ┌──────────────────────────────────────────────┐    ┌──────────────────────────────────────────────┐
 │  Cluster A                                   │    │  Cluster B                                   │
 │                                              │    │                                              │
 │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
 │  │ Gateway                                │  │    │  │ Gateway                                │  │
 │  │                                        │  │    │  │                                        │  │
 │  │  Listener ──► Authorino                │  │    │  │  Listener ──► Authorino                │  │
 │  │                  │                     │  │    │  │                  │                     │  │
 │  │                  ├─ authn: k8s token   │  │    │  │                  ├─ authn: k8s token   │  │
 │  │                  ├─ authn: peer JWT    │  │    │  │                  ├─ authn: peer JWT    │  │
 │  │                  ├─ authn: external JWT│  │    │  │                  ├─ authn: external JWT│  │
 │  │                  ├─ authz: SAR (RBAC)  │  │    │  │                  ├─ authz: SAR (RBAC)  │  │
 │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
 │                     │                        │    │                     │                        │
 │       ┌─────────────┴────────────┐           │    │       ┌─────────────┴────────────┐           │
 │       ▼                          ▼           │    │       ▼                          ▼           │
 │  ┌────────────────┐  ┌────────────────┐      │    │  ┌────────────────┐  ┌────────────────┐      │
 │  │model-serving-  │  │ Inference      │      │    │  │model-serving-  │  │ Inference      │      │
 │  │api (system ns) │  │ Backends       │      │    │  │api (system ns) │  │ Backends       │      │
 │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │    │  │ /api/v1/token  │  │ /<ns>/<model>/ │      │
 │  └────────────────┘  └────────────────┘      │    │  └────────────────┘  └────────────────┘      │
 │                                              │    │                                              │
 │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
 │  │ Authorino OIDC (:8083, TLS)            │  │    │  │ Authorino OIDC (:8083, TLS)            │  │
 │  │ JWKS: cluster-a-key + cluster-b-key    │  │    │  │ JWKS: cluster-b-key + cluster-a-key    │  │
 │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
 │                                              │    │                                              │
 │  ┌────────────────────────────────────────┐  │    │  ┌────────────────────────────────────────┐  │
 │  │ Signing Key Secrets (kuadrant-system)  │  │    │  │ Signing Key Secrets (kuadrant-system)  │  │
 │  │ ├─ cluster-a-key (auto, signs)         │◄─┼────┼─►│ ├─ cluster-b-key (auto, signs)         │  │
 │  │ └─ cluster-b-key (peer, verify)        │  │    │  │ └─ cluster-a-key (peer, verify)        │  │
 │  └────────────────────────────────────────┘  │    │  └────────────────────────────────────────┘  │
 └──────────────────────────────────────────────┘    └──────────────────────────────────────────────┘
                                          ▲            ▲
                          Signing keys distributed via GitOps / ACM

                              ┌──────────────────────────────────────┐
                              │ External OIDC Provider               │
                              │ (Vault, Keycloak, Auth0, ...)        │
                              │                                      │
                              │  JWKS endpoint ◄── Authorino fetches │
                              └──────────────────────────────────────┘
```

### Token exchange flow

```text
Cluster A (or B) (issuing)                        Cluster B (or A) (consuming)

User ──► Gateway /api/v1/token                    Client ──► Gateway ──► Authorino ──► Inference Backend
           │                                                │
           ├─ 1. kubernetesTokenReview (authn)              ├─ 1. jwt verification (authn)
           ├─ 2. No authorization (token path)              ├─ 2. SubjectAccessReview (local RBAC)
           └─ 3. Issue signed JWT (response)                └─ 3. Set flow control headers (response)
                    │                                                  ▲
                    │              signed JWT                          │
                    └──────────────────────────────────────────────────┘
```

**Flow**:

1. User authenticates on cluster A with a local Kubernetes token via `GET /api/v1/token`
2. Cluster A skips authorization for the token path (authentication only)
3. Cluster A issues a signed JWT containing the user's identity (username, groups)
4. Client extracts the JWT from the response
5. Client sends the JWT to cluster B's inference endpoint
6. Cluster B verifies the JWT signature via JWKS
7. Cluster B extracts the username and groups from the JWT
8. Cluster B performs a **local** SubjectAccessReview — the user/SA must exist and have
   RBAC on cluster B

**Key property**: the token carries identity, not authorization. A stolen or leaked
token is useless on a cluster where the user has no RBAC. Each cluster is responsible
for its own access control.

### Assumptions and limitations

- **Identity consistency across clusters**: The JWT encodes the user's Kubernetes
  identity (e.g., `system:serviceaccount:ns:name`). For RBAC to succeed on a peer
  cluster, the same user or ServiceAccount (namespace + name) must exist on that cluster.
  The token does not create identities — it only carries them.
- **Kuadrant and Authorino installed on every cluster**: Each peer cluster must have
  Kuadrant with Authorino deployed and configured.
- **Token carries identity only**: The JWT does not encode authorization decisions.
  Each cluster enforces its own RBAC via SubjectAccessReview. A valid token from a
  peer is insufficient without local RoleBindings.
- **Zero-config single cluster**: The controller auto-generates a local signing key
  per Gateway. Token exchange via `/api/v1/token` works without any annotation or
  manual key creation. Multi-cluster requires only adding peer key names to the
  `security.opendatahub.io/token-exchange-signing-keys` annotation.
- **Signing key distribution**: Authorino's `signingKeyRefs` requires private keys —
  it cannot import public-key-only Secrets (rejects with `"invalid signing key
  algorithm"`). The local signing key is auto-generated; peer signing key pairs
  (private key Secrets) must be distributed to every cluster that needs to verify
  their tokens. Authorino publishes all `signingKeyRefs` in a single JWKS endpoint,
  so a single `jwt` authentication entry is sufficient to verify tokens from all
  peers whose keys are configured.

## Workflow overview

### Platform admin: multi-cluster setup

```text
Admin
  │
  ├─ 1. On each cluster: export the auto-generated signing key or generate a new one
  │     ├─ Export: oc get secret <gw>-wristband-signing-key -n kuadrant-system -o yaml
  │     └─ Generate: openssl ecparam -name prime256v1 -genkey -noout | oc create secret
  │        generic peer-key -n kuadrant-system --from-file=key.pem=/dev/stdin
  │
  ├─ 2. Distribute each cluster's signing key to every peer cluster
  │     └─ Via GitOps, RH Advanced Cluster Management (ACM), or manual `oc apply` (on each cluster)
  │
  ├─ 3. Annotate the Gateway on each cluster with peer key names
  │     └─ security.opendatahub.io/token-exchange-signing-keys: "peer-a-key,peer-b-key"
  │
  ├─ 4. Create RoleBindings for remote identities on each cluster
  │     └─ Grant remote SAs/users access to local LLMInferenceServices
  │
  └─ 5. (Optional) Configure token duration
        └─ security.opendatahub.io/token-exchange-duration: "31536000"

Controller (on annotation change)
  │
  └─ Update AuthPolicy signingKeyRefs: [auto-generated, peer-a-key, peer-b-key]
     └─ Authorino publishes all keys in a single JWKS endpoint
```

### Application developer: token exchange flow

```text
Developer / CI pipeline
  │
  ├─ 1. Authenticate on home cluster
  │     GET /api/v1/token
  │     Authorization: Bearer <k8s-token>
  │     └─ Response: {"token": "<jwt>"}
  │
  ├─ 2. Use JWT on any peer cluster
  │     GET /<ns>/<model>/v1/chat/completions
  │     Authorization: Bearer <jwt>
  │     │
  │     ├─ Authorino verifies JWT signature (JWKS)
  │     ├─ Extracts username/groups from claims
  │     ├─ SubjectAccessReview against local RBAC
  │     └─ 200 (authorized) or 403 (no local RBAC)
  │
  └─ 3. Same JWT works on any peer where user has RoleBindings
```

### Incident responder: token revocation

```text
Responder
  │
  ├─ Scope: single identity
  │  ├─ Remove RoleBindings on affected clusters → 403
  │  └─ (Optional) Add patternMatching deny rule → 401
  │
  ├─ Scope: single token
  │  └─ Add patternMatching deny rule on sub claim → 401
  │
  ├─ Scope: signing key compromised
  │  ├─ Rotate the signing key Secret
  │  ├─ Redistribute JWKS to peers
  │  └─ All existing tokens from that key → 401
  │
  └─ Scope: cluster compromised
     ├─ Remove peer's signing key Secret from all clusters
     ├─ Update Gateway annotation to exclude peer
     └─ All tokens from that peer → 401
```

## Backward compatibility

All changes are additive. The existing `kubernetesTokenReview` + `SubjectAccessReview`
flow remains the primary authentication/authorization path for local users.

Additional `jwt` authentication methods (peer wristbands and/or external OIDC providers)
are configured alongside `kubernetesTokenReview`. Authorino evaluates all authentication
configs — at least one must succeed. Local Kubernetes tokens continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive multi-cluster authentication docs covering token-exchange flow, gateway routing/exclusion rules, wristband JWT issuance and verification (response header usage, identity claim normalization), deterministic auth-config naming, JWKS distribution/verification, cross-cluster RBAC, key rotation/revocation workflows, optional external JWT sources, test scenarios and operational guidance.
  * Added a Vault OIDC integration test plan with deployment/setup steps, verification commands, failure scenarios, RBAC examples, automated e2e test design, checklist and cleanup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->