### PR TITLE
fix: when AuthPolicy CRD not exist(Kuadrant not installed) KserveAuthPolicyReconciler should return nil than err

### DIFF
--- a/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler.go
+++ b/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler.go
@@ -23,6 +23,7 @@ import (
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +64,10 @@ func (r *KserveAuthPolicyReconciler) Reconcile(ctx context.Context, log logr.Log
 	log.V(1).Info("Starting AuthPolicy reconciliation for LLMInferenceService")
 
 	if err := r.reconcileHTTPRouteAuthpolicy(ctx, log, llmisvc); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.V(1).Info("AuthPolicy CRD not available, skipping reconciliation")
+			return nil
+		}
 		log.Error(err, "Failed to reconcile HTTPRoute AuthPolicy")
 		return err
 	}
@@ -124,6 +129,10 @@ func (r *KserveAuthPolicyReconciler) Delete(ctx context.Context, log logr.Logger
 	log.V(1).Info("Deleting AuthPolicies for LLMInferenceService")
 
 	if err := r.deleteHTTPRouteAuthPolicies(ctx, log, llmisvc); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.V(1).Info("AuthPolicy CRD not available, nothing to delete")
+			return nil
+		}
 		return err
 	}
 

--- a/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler_test.go
+++ b/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler_test.go
@@ -1,0 +1,192 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/resources"
+)
+
+type fakeAuthPolicyStore struct {
+	getErr    error
+	removeErr error
+	createErr error
+	updateErr error
+}
+
+func (f *fakeAuthPolicyStore) Get(_ context.Context, _ types.NamespacedName) (*kuadrantv1.AuthPolicy, error) {
+	return nil, f.getErr
+}
+
+func (f *fakeAuthPolicyStore) Remove(_ context.Context, _ types.NamespacedName) error {
+	return f.removeErr
+}
+
+func (f *fakeAuthPolicyStore) Create(_ context.Context, _ *kuadrantv1.AuthPolicy) error {
+	return f.createErr
+}
+
+func (f *fakeAuthPolicyStore) Update(_ context.Context, _ *kuadrantv1.AuthPolicy) error {
+	return f.updateErr
+}
+
+type fakeAuthPolicyDetector struct {
+	authType constants.AuthType
+}
+
+func (f *fakeAuthPolicyDetector) Detect(_ context.Context, _ map[string]string) constants.AuthType {
+	return f.authType
+}
+
+type fakeAuthPolicyTemplateLoader struct {
+	policy *kuadrantv1.AuthPolicy
+	err    error
+}
+
+func (f *fakeAuthPolicyTemplateLoader) Load(_ context.Context, target resources.AuthPolicyTarget, _ ...resources.ObjectOption) (*kuadrantv1.AuthPolicy, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.policy != nil {
+		return f.policy, nil
+	}
+	return &kuadrantv1.AuthPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      target.Name + "-auth",
+			Namespace: target.Namespace,
+		},
+	}, nil
+}
+
+func newTestLLMInferenceService(name, namespace string) *kservev1alpha2.LLMInferenceService {
+	return &kservev1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func TestReconcile_AuthDisabled_NoMatchError_Skipped(t *testing.T) {
+	noMatchErr := &meta.NoResourceMatchError{
+		PartialResource: schema.GroupVersionResource{
+			Group:    "kuadrant.io",
+			Version:  "v1",
+			Resource: "authpolicies",
+		},
+	}
+
+	reconciler := &KserveAuthPolicyReconciler{
+		store: &fakeAuthPolicyStore{
+			getErr: fmt.Errorf("could not GET AuthPolicy: %w", noMatchErr),
+		},
+		detector:       &fakeAuthPolicyDetector{authType: constants.Anonymous},
+		templateLoader: &fakeAuthPolicyTemplateLoader{},
+	}
+
+	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
+	if err != nil {
+		t.Errorf("expected nil error when AuthPolicy CRD is not available, got: %v", err)
+	}
+}
+
+func TestReconcile_AuthDisabled_OtherError_Propagated(t *testing.T) {
+	reconciler := &KserveAuthPolicyReconciler{
+		store: &fakeAuthPolicyStore{
+			getErr: fmt.Errorf("connection refused"),
+		},
+		detector:       &fakeAuthPolicyDetector{authType: constants.Anonymous},
+		templateLoader: &fakeAuthPolicyTemplateLoader{},
+	}
+
+	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
+	if err == nil {
+		t.Error("expected error to be propagated, got nil")
+	}
+}
+
+func TestDelete_NoMatchError_Skipped(t *testing.T) {
+	noMatchErr := &meta.NoResourceMatchError{
+		PartialResource: schema.GroupVersionResource{
+			Group:    "kuadrant.io",
+			Version:  "v1",
+			Resource: "authpolicies",
+		},
+	}
+
+	reconciler := &KserveAuthPolicyReconciler{
+		store: &fakeAuthPolicyStore{
+			removeErr: fmt.Errorf("could not DELETE AuthPolicy: %w", noMatchErr),
+		},
+	}
+
+	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	err := reconciler.Delete(context.Background(), logr.Discard(), llmisvc)
+	if err != nil {
+		t.Errorf("expected nil error when AuthPolicy CRD is not available during delete, got: %v", err)
+	}
+}
+
+func TestDelete_OtherError_Propagated(t *testing.T) {
+	reconciler := &KserveAuthPolicyReconciler{
+		store: &fakeAuthPolicyStore{
+			removeErr: fmt.Errorf("connection refused"),
+		},
+	}
+
+	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	err := reconciler.Delete(context.Background(), logr.Discard(), llmisvc)
+	if err == nil {
+		t.Error("expected error to be propagated, got nil")
+	}
+}
+
+func TestReconcile_NoSetEnableAuthAnnotation_NoMatchError_Skipped(t *testing.T) {
+	noMatchErr := &meta.NoResourceMatchError{
+		PartialResource: schema.GroupVersionResource{
+			Group:    "kuadrant.io",
+			Version:  "v1",
+			Resource: "authpolicies",
+		},
+	}
+
+	reconciler := &KserveAuthPolicyReconciler{
+		store: &fakeAuthPolicyStore{
+			getErr: fmt.Errorf("could not GET AuthPolicy: %w", noMatchErr),
+		},
+		detector:       &fakeAuthPolicyDetector{authType: constants.UserDefined},
+		templateLoader: &fakeAuthPolicyTemplateLoader{},
+	}
+
+	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
+	if err != nil {
+		t.Errorf("expected nil error when enable-auth annotation is not set and AuthPolicy CRD is not available, got: %v", err)
+	}
+}

--- a/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler_test.go
+++ b/internal/controller/serving/llm/reconcilers/kserve_authpolicy_reconciler_test.go
@@ -82,11 +82,11 @@ func (f *fakeAuthPolicyTemplateLoader) Load(_ context.Context, target resources.
 	}, nil
 }
 
-func newTestLLMInferenceService(name, namespace string) *kservev1alpha2.LLMInferenceService {
+func newTestLLMInferenceService() *kservev1alpha2.LLMInferenceService {
 	return &kservev1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:      "test-svc",
+			Namespace: "test-ns",
 		},
 	}
 }
@@ -108,7 +108,7 @@ func TestReconcile_AuthDisabled_NoMatchError_Skipped(t *testing.T) {
 		templateLoader: &fakeAuthPolicyTemplateLoader{},
 	}
 
-	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	llmisvc := newTestLLMInferenceService()
 	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
 	if err != nil {
 		t.Errorf("expected nil error when AuthPolicy CRD is not available, got: %v", err)
@@ -124,7 +124,7 @@ func TestReconcile_AuthDisabled_OtherError_Propagated(t *testing.T) {
 		templateLoader: &fakeAuthPolicyTemplateLoader{},
 	}
 
-	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	llmisvc := newTestLLMInferenceService()
 	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
 	if err == nil {
 		t.Error("expected error to be propagated, got nil")
@@ -146,7 +146,7 @@ func TestDelete_NoMatchError_Skipped(t *testing.T) {
 		},
 	}
 
-	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	llmisvc := newTestLLMInferenceService()
 	err := reconciler.Delete(context.Background(), logr.Discard(), llmisvc)
 	if err != nil {
 		t.Errorf("expected nil error when AuthPolicy CRD is not available during delete, got: %v", err)
@@ -160,7 +160,7 @@ func TestDelete_OtherError_Propagated(t *testing.T) {
 		},
 	}
 
-	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	llmisvc := newTestLLMInferenceService()
 	err := reconciler.Delete(context.Background(), logr.Discard(), llmisvc)
 	if err == nil {
 		t.Error("expected error to be propagated, got nil")
@@ -184,7 +184,7 @@ func TestReconcile_NoSetEnableAuthAnnotation_NoMatchError_Skipped(t *testing.T) 
 		templateLoader: &fakeAuthPolicyTemplateLoader{},
 	}
 
-	llmisvc := newTestLLMInferenceService("test-svc", "test-ns")
+	llmisvc := newTestLLMInferenceService()
 	err := reconciler.Reconcile(context.Background(), logr.Discard(), llmisvc)
 	if err != nil {
 		t.Errorf("expected nil error when enable-auth annotation is not set and AuthPolicy CRD is not available, got: %v", err)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


- add a unit test for this, the existing test in llm_inferenceservice_controller_test.go has CRD already in AddToScheme

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the AuthPolicy feature is unavailable, so related actions now skip cleanly instead of failing.
  * Reconcile and delete operations now return successfully when the required capability isn’t present, reducing noisy errors.
  * Non-availability-related errors still surface normally, preserving expected failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->