### PR TITLE
fix(metrics): fix vLLM REQUEST_COUNT metric query for dashboard

### DIFF
--- a/internal/controller/constants/runtime-metrics.go
+++ b/internal/controller/constants/runtime-metrics.go
@@ -187,7 +187,11 @@ const (
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${REQUEST_RATE_INTERVAL}])))"
+						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason!~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
+					},
+					{
+						"title": "Number of failed incoming requests",
+						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason=~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package reconcilers
 
 import (
+	"encoding/json"
 	"strings"
 
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -254,6 +255,73 @@ var _ = Describe("KserveMetricsDashboardReconciler", func() {
 				Expect(configMap.Data["metrics"]).To(ContainSubstring("tgis-model"))
 				Expect(configMap.Data["metrics"]).To(ContainSubstring("test-namespace"))
 			})
+		})
+
+		When("all runtime metrics templates are validated", func() {
+			type metricsQuery struct {
+				Title string `json:"title"`
+				Query string `json:"query"`
+			}
+			type metricsSection struct {
+				Title   string         `json:"title"`
+				Type    string         `json:"type"`
+				Queries []metricsQuery `json:"queries"`
+			}
+			type metricsConfig struct {
+				Config []metricsSection `json:"config"`
+			}
+
+			runtimeData := map[string]string{
+				"Caikit":   constants.CaikitMetricsData,
+				"OVMS":     constants.OvmsMetricsData,
+				"TGIS":     constants.TgisMetricsData,
+				"vLLM":     constants.VllmMetricsData,
+				"NIM":      constants.NIMMetricsData,
+				"MLServer": constants.MLServerMetricsData,
+			}
+
+			for name, data := range runtimeData {
+				It("should have REQUEST_COUNT with success+failed queries for "+name, func() {
+					var cfg metricsConfig
+					Expect(json.Unmarshal([]byte(data), &cfg)).To(Succeed())
+
+					var requestCount *metricsSection
+					for i := range cfg.Config {
+						if cfg.Config[i].Type == "REQUEST_COUNT" {
+							requestCount = &cfg.Config[i]
+							break
+						}
+					}
+					Expect(requestCount).NotTo(BeNil(), name+" must define a REQUEST_COUNT section")
+					Expect(requestCount.Queries).To(HaveLen(2),
+						name+" REQUEST_COUNT must have 2 queries (success + failed)")
+					Expect(strings.ToLower(requestCount.Queries[0].Title)).To(ContainSubstring("successful"),
+						name+" REQUEST_COUNT[0] must be the success query")
+					Expect(strings.ToLower(requestCount.Queries[1].Title)).To(ContainSubstring("failed"),
+						name+" REQUEST_COUNT[1] must be the failed query")
+				})
+
+				It("should not use lowercase variable placeholders for "+name, func() {
+					var cfg metricsConfig
+					Expect(json.Unmarshal([]byte(data), &cfg)).To(Succeed())
+
+					for _, section := range cfg.Config {
+						for _, q := range section.Queries {
+							Expect(q.Query).NotTo(ContainSubstring("${model_name}"),
+								name+" "+section.Type+": must use ${MODEL_NAME}")
+							Expect(q.Query).NotTo(ContainSubstring("${namespace}"),
+								name+" "+section.Type+": must use ${NAMESPACE}")
+						}
+					}
+				})
+
+				It("should have all variables substituted after calling SubstituteVariablesInQueries for "+name, func() {
+					substituted := utils.SubstituteVariablesInQueries(data, "test-ns", "test-model")
+					Expect(substituted).NotTo(ContainSubstring("${"))
+					Expect(substituted).To(ContainSubstring("test-ns"))
+					Expect(substituted).To(ContainSubstring("test-model"))
+				})
+			}
 		})
 
 		When("no valid runtime annotations are set", func() {


### PR DESCRIPTION
The vLLM metrics ConfigMap had two issues causing the "Requests per 5 minutes" metric to not populate in the OpenShift AI dashboard:

1. The success query used ${model_name} (lowercase) which was not substituted by SubstituteVariablesInQueries (expects ${MODEL_NAME}). This caused the Prometheus query to filter by a literal placeholder string, returning no data.

2. The failed requests query was missing entirely. The dashboard expects two queries at index 0 (success) and index 1 (failed) for the REQUEST_COUNT type. The missing query caused the dashboard to send query=undefined to Prometheus.

Fixes: [RHOAIENG-59920](https://redhat.atlassian.net/browse/RHOAIENG-59920)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vLLM successful-requests metric so the model label is populated and error/abort finishes are excluded.

* **Chores**
  * Added a vLLM failed-requests metric that counts error/abort finishes, aggregated over the existing request-rate interval.

* **Tests**
  * Added validation tests for runtime metrics templates and variable substitution to ensure accurate queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->