### PR TITLE
ci(release): [RHOAIENG-58438] enable tag-push Konflux builds

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -25,6 +25,11 @@ on:
         required: false
         type: boolean
         default: false
+      dry_run:
+        description: 'Dry run: show what would change without writing files, tagging, or creating a release'
+        required: false
+        type: boolean
+        default: false
     #
     # Note: This workflow assumes the release tag and image tags are in sync.
     #       'tag_name' is used to create the release and to rewrite .tekton/ push
@@ -181,15 +186,20 @@ jobs:
 
       - name: Update params.env files (if applicable)
         if: ${{ needs.validate-and-check.outputs.has_params_env == 'true' }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           import json
+          import os
           import re
           
+          dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
           tag_name = "${{ github.event.inputs.tag_name }}"
           repo_name = "${{ needs.validate-and-check.outputs.repo_name }}"
           params_files = json.loads('${{ needs.validate-and-check.outputs.params_env_files }}')
           
-          print(f"Updating params.env files for {repo_name} with tag: {tag_name}\n")
+          prefix_label = "[DRY RUN] " if dry_run else ""
+          print(f"{prefix_label}Updating params.env files for {repo_name} with tag: {tag_name}\n")
           
           # Define patterns based on repository
           if repo_name == "odh-model-controller":
@@ -226,26 +236,30 @@ jobs:
             updated_content, count = image_pattern.subn(rf'\1:\g<2>{tag_name}', content)
 
             if count > 0:
-              with open(params_file, 'w') as f:
-                f.write(updated_content)
-
+              if not dry_run:
+                with open(params_file, 'w') as f:
+                  f.write(updated_content)
               updated_files.append(params_file)
               total_replacements += count
-              print(f"  ✓ Updated {count} image tag(s)")
+              print(f"  ✓ {'Would update' if dry_run else 'Updated'} {count} image tag(s)")
               for image_path, prefix, old_tag in set(matches):
                 print(f"    - {image_path}:{prefix}{old_tag} → {image_path}:{prefix}{tag_name}")
             else:
               print(f"  - No changes needed")
           
-          print(f"\n✓ Updated {total_replacements} image tag(s) across {len(updated_files)} file(s)")
+          print(f"\n✓ {prefix_label}{'Would update' if dry_run else 'Updated'} {total_replacements} image tag(s) across {len(updated_files)} file(s)")
         shell: python
 
       - name: Rewrite .tekton/ push pipelines for tag-push triggering
         if: ${{ needs.validate-and-check.outputs.has_tekton == 'true' }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           import json
+          import os
           import re
 
+          dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
           tag_name = "${{ github.event.inputs.tag_name }}"
           tekton_files = json.loads('${{ needs.validate-and-check.outputs.tekton_files }}')
 
@@ -254,7 +268,8 @@ jobs:
             print("No push pipeline files found, skipping")
             raise SystemExit(0)
 
-          print(f"Rewriting {len(push_files)} push pipeline(s) for tag-push triggering\n")
+          prefix_label = "[DRY RUN] " if dry_run else ""
+          print(f"{prefix_label}Rewriting {len(push_files)} push pipeline(s) for tag-push triggering\n")
 
           cel_pattern = re.compile(
             r'( +)pipelinesascode\.tekton\.dev/on-cel-expression:.*\n(?:\1 +.*\n)*'
@@ -286,26 +301,32 @@ jobs:
                 f'{indent}pipelinesascode.tekton.dev/on-event: "[push]"\n'
               )
               content = cel_pattern.sub(replacement, content)
-              print(f"  ✓ Replaced on-cel-expression with on-target-branch/on-event")
+              print(f"  ✓ {'Would replace' if dry_run else 'Replaced'} on-cel-expression with on-target-branch/on-event")
             else:
               print(f"  - No on-cel-expression found")
 
             matches = image_tag_pattern.findall(content)
             content, count = image_tag_pattern.subn(rf'\1:{tag_name}', content)
             if count > 0:
-              print(f"  ✓ Updated {count} image tag(s)")
+              print(f"  ✓ {'Would update' if dry_run else 'Updated'} {count} image tag(s)")
               for image_path, old_tag in set(matches):
                 print(f"    - {image_path}:{old_tag} → {image_path}:{tag_name}")
 
             if content != original:
-              with open(tekton_file, 'w') as f:
-                f.write(content)
+              if not dry_run:
+                with open(tekton_file, 'w') as f:
+                  f.write(content)
               updated_files.append(tekton_file)
 
-          print(f"\n✓ Rewrote {len(updated_files)} push pipeline(s) for tag {tag_name}")
+          if not updated_files:
+            print("::error::Found push pipeline(s) but no patterns matched -- check .tekton/ format")
+            raise SystemExit(1)
+
+          print(f"\n✓ {prefix_label}{'Would rewrite' if dry_run else 'Rewrote'} {len(updated_files)} push pipeline(s) for tag {tag_name}")
         shell: python
 
       - name: Commit release changes (if any)
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           git add config/**/params.env .tekton/ 2>/dev/null || true
           
@@ -317,6 +338,7 @@ jobs:
           fi
 
       - name: Create and push Tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           FORCE_FLAG=""
           if [[ "${{ github.event.inputs.allow_existing_tag }}" == "true" ]]; then
@@ -327,6 +349,7 @@ jobs:
           echo "✓ Tag created and pushed: ${{ github.event.inputs.tag_name }}"
 
       - name: Create Release
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -345,7 +368,11 @@ jobs:
     steps:
       - name: Print Summary
         run: |
-          echo "# ODH Release Workflow Summary" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "# ODH Release Workflow Summary (DRY RUN)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "# ODH Release Workflow Summary" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Repository:** ${{ needs.validate-and-check.outputs.repo_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Release Tag:** ${{ github.event.inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
@@ -359,7 +386,9 @@ jobs:
           echo "- Create Release: ${{ needs.create-release.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          if [[ "${{ needs.create-release.result }}" == "success" ]]; then
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "ℹ️ **Dry run completed.** No files were written, no tag was created, and no release was published. Review the create-release job logs for details on what would change." >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ needs.create-release.result }}" == "success" ]]; then
             echo "✅ **Release created successfully!**" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ **Some steps may have failed. Please review the logs.**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -260,7 +260,7 @@ jobs:
           tag_name = "${{ github.event.inputs.tag_name }}"
           tekton_files = json.loads('${{ needs.validate-and-check.outputs.tekton_files }}')
 
-          push_files = [f for f in tekton_files if f.endswith('-push.yaml')]
+          push_files = [f for f in tekton_files if f.endswith(('-push.yaml', '-push.yml'))]
           if not push_files:
             print("No push pipeline files found, skipping")
             raise SystemExit(0)

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -1,28 +1,25 @@
 # ODH Release Workflow
 #
-# Creates a tagged release for an opendatahub-io repository. Supports two tiers:
+# Creates a tagged release for an opendatahub-io repository. For each repo:
+#   1. Validates inputs and checks for existing tags.
+#   2. Discovers config/**/params.env and .tekton/*-push.yaml files.
+#   3. If params.env files exist: bumps image tags matching a repo-specific regex.
+#   4. If .tekton/ push pipelines exist: rewrites on-cel-expression to
+#      on-target-branch/on-event for the release tag, and updates output-image tags.
+#      This triggers Konflux builds from the tag push (Fix 2).
+#   5. Commits changes locally, creates and pushes an annotated tag, and publishes
+#      a GitHub release. Only the tag is pushed (the branch is not modified).
 #
-# Tag-only repos (llm-d-inference-scheduler, workload-variant-autoscaler, llm-d-kv-cache):
-#   - Validates inputs, creates an annotated tag, and publishes a GitHub release.
-#   - No file modifications. Add new repos to the skip list in the "Discover files" step.
+# Repos without config/**/params.env (e.g. llm-d-inference-scheduler,
+# workload-variant-autoscaler, llm-d-kv-cache) get only the tekton rewrite + tag.
 #
-# Full repos (odh-model-controller, kserve):
-#   - Same as above, plus rewrites files before tagging:
-#     1. params.env: bumps image tags matching the repo-specific regex.
-#     2. .tekton/*-push.yaml: replaces on-cel-expression with on-target-branch/on-event
-#        targeting the release tag, and updates output-image tags.
-#   - Changes are committed locally; only the tag is pushed (the branch is not modified).
-#
-# Repository requirements for full support:
-#   - config/**/params.env with image refs using recognized tags
-#     (fast, odh-stable, v*-latest, release-v*, odh-v*)
+# Repository requirements:
 #   - .tekton/*-push.yaml files with:
 #       pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
 #         == "<branch>"
-#     and output-image using one of the recognized tags above
-#
-# The kserve params.env pattern excludes llm-d-inference-scheduler,
-# llm-d-routing-sidecar, and llm-d-kv-cache images (they have their own release cadence).
+#     and output-image using a recognized tag (fast, odh-stable, v*-latest,
+#     release-v*, odh-v*)
+#   - Optionally config/**/params.env with image refs using the same tag formats
 
 name: ODH Release Workflow
 
@@ -141,39 +138,22 @@ jobs:
           import json
           import glob
           
-          repository = "${{ github.event.inputs.repository }}"
+          params_env_files = glob.glob('config/**/params.env', recursive=True)
+          tekton_files = glob.glob('.tekton/**/*.yaml', recursive=True) + \
+                         glob.glob('.tekton/**/*.yml', recursive=True)
           
-          # Skip file discovery for repos that only need a tag + release (no params.env or tekton rewriting)
-          if repository in ("llm-d-inference-scheduler", "workload-variant-autoscaler", "llm-d-kv-cache"):
-            print(f"Skipping file discovery for {repository}")
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"params_env_files=[]\n")
-              f.write(f"tekton_files=[]\n")
-              f.write(f"has_params_env=false\n")
-              f.write(f"has_tekton=false\n")
-            print("✓ Discovery skipped - no files to update for this repository")
-          else:
-            # Discover params.env files under config/
-            params_env_files = glob.glob('config/**/params.env', recursive=True)
-            
-            # Discover YAML files under .tekton/
-            tekton_files = glob.glob('.tekton/**/*.yaml', recursive=True) + \
-                           glob.glob('.tekton/**/*.yml', recursive=True)
-            
-            # Output results
-            print(f"Found params.env files: {params_env_files}")
-            print(f"Found tekton files: {tekton_files}")
-            
-            # Write outputs
-            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f"params_env_files={json.dumps(params_env_files)}\n")
-              f.write(f"tekton_files={json.dumps(tekton_files)}\n")
-              f.write(f"has_params_env={'true' if params_env_files else 'false'}\n")
-              f.write(f"has_tekton={'true' if tekton_files else 'false'}\n")
-            
-            print(f"\n✓ Discovery complete")
-            print(f"  params.env files: {len(params_env_files)}")
-            print(f"  Tekton files: {len(tekton_files)}")
+          print(f"Found params.env files: {params_env_files}")
+          print(f"Found tekton files: {tekton_files}")
+          
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"params_env_files={json.dumps(params_env_files)}\n")
+            f.write(f"tekton_files={json.dumps(tekton_files)}\n")
+            f.write(f"has_params_env={'true' if params_env_files else 'false'}\n")
+            f.write(f"has_tekton={'true' if tekton_files else 'false'}\n")
+          
+          print(f"\n✓ Discovery complete")
+          print(f"  params.env files: {len(params_env_files)}")
+          print(f"  Tekton files: {len(tekton_files)}")
         shell: python
 
   create-release:
@@ -229,9 +209,8 @@ jobs:
               r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver)):((?:odh-model-serving-api-)?)(fast|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           else:
-            # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar|llm-d-kv-cache)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -57,8 +57,7 @@ on:
         default: false
     #
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   REPO_OWNER: opendatahub-io
@@ -90,39 +89,41 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs and check tag
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+          REPOSITORY: ${{ github.event.inputs.repository }}
+          ALLOW_EXISTING_TAG: ${{ github.event.inputs.allow_existing_tag }}
         run: |
+          import os
           import re
           import sys
           import subprocess
           
-          tag_name = "${{ github.event.inputs.tag_name }}"
-          repository = "${{ github.event.inputs.repository }}"
+          tag_name = os.environ["TAG_NAME"]
+          repository = os.environ["REPOSITORY"]
           
           # Expected format: odh-vX.Y or odh-vX.Y.Z with optional -EAn suffix
           tag_pattern = r'^odh-v\d+\.\d+(\.\d+)?(-EA\d)?$'
           
           errors = []
           
-          # Validate tag formats
           if not re.match(tag_pattern, tag_name):
             errors.append(f"Tag '{tag_name}' does not match expected format 'odh-vX.Y' or 'odh-vX.Y.Z'")
           
-          # Fail fast if validation errors exist
           if errors:
             for error in errors:
               print(f"::error::{error}")
             sys.exit(1)
           
-          # Check if tag exists on remote (uses authenticated origin from checkout)
           result = subprocess.run(
             ['git', 'ls-remote', '--tags', 'origin', f'refs/tags/{tag_name}'],
             capture_output=True
           )
           
           if result.stdout.decode().strip():
-            allow_existing = "${{ github.event.inputs.allow_existing_tag }}" == "true"
+            allow_existing = os.environ.get("ALLOW_EXISTING_TAG", "false") == "true"
             if allow_existing:
-              print(f"⚠ Tag '{tag_name}' exists but allow_existing_tag is set — will overwrite")
+              print(f"⚠ Tag '{tag_name}' exists but allow_existing_tag is set -- will overwrite")
             else:
               print(f"::error::Tag '{tag_name}' already exists on remote.")
               sys.exit(1)
@@ -159,6 +160,8 @@ jobs:
   create-release:
     name: Create Tag and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: validate-and-check
     if: needs.validate-and-check.result == 'success'
     steps:
@@ -186,15 +189,18 @@ jobs:
         if: ${{ needs.validate-and-check.outputs.has_params_env == 'true' }}
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+          REPO_NAME: ${{ needs.validate-and-check.outputs.repo_name }}
+          PARAMS_ENV_FILES: ${{ needs.validate-and-check.outputs.params_env_files }}
         run: |
           import json
           import os
           import re
           
           dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
-          tag_name = "${{ github.event.inputs.tag_name }}"
-          repo_name = "${{ needs.validate-and-check.outputs.repo_name }}"
-          params_files = json.loads('${{ needs.validate-and-check.outputs.params_env_files }}')
+          tag_name = os.environ["TAG_NAME"]
+          repo_name = os.environ["REPO_NAME"]
+          params_files = json.loads(os.environ["PARAMS_ENV_FILES"])
           
           prefix_label = "[DRY RUN] " if dry_run else ""
           print(f"{prefix_label}Updating params.env files for {repo_name} with tag: {tag_name}\n")
@@ -251,14 +257,16 @@ jobs:
         if: ${{ needs.validate-and-check.outputs.has_tekton == 'true' }}
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+          TEKTON_FILES: ${{ needs.validate-and-check.outputs.tekton_files }}
         run: |
           import json
           import os
           import re
 
           dry_run = os.environ.get('DRY_RUN', 'false') == 'true'
-          tag_name = "${{ github.event.inputs.tag_name }}"
-          tekton_files = json.loads('${{ needs.validate-and-check.outputs.tekton_files }}')
+          tag_name = os.environ["TAG_NAME"]
+          tekton_files = json.loads(os.environ["TEKTON_FILES"])
 
           push_files = [f for f in tekton_files if f.endswith(('-push.yaml', '-push.yml'))]
           if not push_files:
@@ -324,11 +332,13 @@ jobs:
 
       - name: Commit release changes (if any)
         if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
         run: |
           git add config/**/params.env .tekton/ 2>/dev/null || true
           
           if [[ -n "$(git status --porcelain)" ]]; then
-            git commit -m "Update image refs and .tekton/ pipelines for release ${{ github.event.inputs.tag_name }}"
+            git commit -m "Update image refs and .tekton/ pipelines for release ${TAG_NAME}"
             echo "✓ Changes committed locally"
           else
             echo "No changes to commit"
@@ -336,14 +346,17 @@ jobs:
 
       - name: Create and push Tag
         if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+          ALLOW_EXISTING_TAG: ${{ github.event.inputs.allow_existing_tag }}
         run: |
           FORCE_FLAG=""
-          if [[ "${{ github.event.inputs.allow_existing_tag }}" == "true" ]]; then
+          if [[ "${ALLOW_EXISTING_TAG}" == "true" ]]; then
             FORCE_FLAG="-f"
           fi
-          git tag ${FORCE_FLAG} -a ${{ github.event.inputs.tag_name }} -m "ODH release ${{ github.event.inputs.tag_name }}"
-          git push ${FORCE_FLAG} origin ${{ github.event.inputs.tag_name }}
-          echo "✓ Tag created and pushed: ${{ github.event.inputs.tag_name }}"
+          git tag ${FORCE_FLAG} -a "${TAG_NAME}" -m "ODH release ${TAG_NAME}"
+          git push ${FORCE_FLAG} origin "${TAG_NAME}"
+          echo "✓ Tag created and pushed: ${TAG_NAME}"
 
       - name: Create Release
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -364,28 +377,36 @@ jobs:
     if: always()
     steps:
       - name: Print Summary
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          REPO_NAME: ${{ needs.validate-and-check.outputs.repo_name }}
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+          HAS_PARAMS_ENV: ${{ needs.validate-and-check.outputs.has_params_env }}
+          HAS_TEKTON: ${{ needs.validate-and-check.outputs.has_tekton }}
+          VALIDATE_RESULT: ${{ needs.validate-and-check.result }}
+          RELEASE_RESULT: ${{ needs.create-release.result }}
         run: |
-          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
             echo "# ODH Release Workflow Summary (DRY RUN)" >> $GITHUB_STEP_SUMMARY
           else
             echo "# ODH Release Workflow Summary" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository:** ${{ needs.validate-and-check.outputs.repo_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Release Tag:** ${{ github.event.inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository:** ${REPO_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "**Release Tag:** ${TAG_NAME}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Discovered Files" >> $GITHUB_STEP_SUMMARY
-          echo "- params.env files found: ${{ needs.validate-and-check.outputs.has_params_env }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Tekton files found: ${{ needs.validate-and-check.outputs.has_tekton }}" >> $GITHUB_STEP_SUMMARY
+          echo "- params.env files found: ${HAS_PARAMS_ENV}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tekton files found: ${HAS_TEKTON}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Job Status" >> $GITHUB_STEP_SUMMARY
-          echo "- Validation: ${{ needs.validate-and-check.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Create Release: ${{ needs.create-release.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Validation: ${VALIDATE_RESULT}" >> $GITHUB_STEP_SUMMARY
+          echo "- Create Release: ${RELEASE_RESULT}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+          if [[ "${DRY_RUN}" == "true" ]]; then
             echo "ℹ️ **Dry run completed.** No files were written, no tag was created, and no release was published. Review the create-release job logs for details on what would change." >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.create-release.result }}" == "success" ]]; then
+          elif [[ "${RELEASE_RESULT}" == "success" ]]; then
             echo "✅ **Release created successfully!**" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ **Some steps may have failed. Please review the logs.**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -1,16 +1,44 @@
+# ODH Release Workflow
+#
+# Creates a tagged release for an opendatahub-io repository. Supports two tiers:
+#
+# Tag-only repos (llm-d-inference-scheduler, workload-variant-autoscaler, llm-d-kv-cache):
+#   - Validates inputs, creates an annotated tag, and publishes a GitHub release.
+#   - No file modifications. Add new repos to the skip list in the "Discover files" step.
+#
+# Full repos (odh-model-controller, kserve):
+#   - Same as above, plus rewrites files before tagging:
+#     1. params.env: bumps image tags matching the repo-specific regex.
+#     2. .tekton/*-push.yaml: replaces on-cel-expression with on-target-branch/on-event
+#        targeting the release tag, and updates output-image tags.
+#   - Changes are committed locally; only the tag is pushed (the branch is not modified).
+#
+# Repository requirements for full support:
+#   - config/**/params.env with image refs using recognized tags
+#     (fast, odh-stable, v*-latest, release-v*, odh-v*)
+#   - .tekton/*-push.yaml files with:
+#       pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+#         == "<branch>"
+#     and output-image using one of the recognized tags above
+#
+# The kserve params.env pattern excludes llm-d-inference-scheduler,
+# llm-d-routing-sidecar, and llm-d-kv-cache images (they have their own release cadence).
+
 name: ODH Release Workflow
 
 on:
   workflow_dispatch:
     inputs:
       repository:
-        description: 'Target repository (odh-model-controller, kserve, llm-d-inference-scheduler)'
+        description: 'Target repository (odh-model-controller, kserve, llm-d-inference-scheduler, workload-variant-autoscaler, llm-d-kv-cache)'
         required: true
         type: choice
         options:
           - odh-model-controller
           - llm-d-inference-scheduler
           - kserve
+          - llm-d-kv-cache
+          - workload-variant-autoscaler
       tag_name: # The new release tag to be created and used as the search value.
         description: 'New release tag (e.g., odh-v2.35)'
         required: true
@@ -30,10 +58,6 @@ on:
         required: false
         type: boolean
         default: false
-    #
-    # Note: This workflow assumes the release tag and image tags are in sync.
-    #       'tag_name' is used to create the release and to rewrite .tekton/ push
-    #       pipelines for tag-push triggering.
     #
 
 permissions:
@@ -110,12 +134,6 @@ jobs:
           print(f"  Repository: {repository}")
           print(f"  Release tag: {tag_name}")
         shell: python
-  #
-  # Note: This workflow dynamically discovers and updates:
-  #   - params.env files in config/ directory
-  #   - YAML files in .tekton/ directory
-  #
-
       - name: Discover files to update
         id: discover
         run: |
@@ -125,9 +143,9 @@ jobs:
           
           repository = "${{ github.event.inputs.repository }}"
           
-          # Skip file discovery for llm-d-inference-scheduler
-          if repository == "llm-d-inference-scheduler":
-            print("Skipping file discovery for llm-d-inference-scheduler")
+          # Skip file discovery for repos that only need a tag + release (no params.env or tekton rewriting)
+          if repository in ("llm-d-inference-scheduler", "workload-variant-autoscaler", "llm-d-kv-cache"):
+            print(f"Skipping file discovery for {repository}")
             with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"params_env_files=[]\n")
               f.write(f"tekton_files=[]\n")
@@ -213,7 +231,7 @@ jobs:
           else:
             # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar|llm-d-kv-cache)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -15,10 +15,6 @@ on:
         description: 'New release tag (e.g., odh-v2.35)'
         required: true
         type: string
-      next_tag_name: # The next tag to replace the current one in the Konflux files.
-        description: 'Next development tag (e.g., odh-v2.36) - not required for llm-d-inference-scheduler'
-        required: false
-        type: string
       target_branch:
         description: 'Target branch in the repository (e.g., main, incubating)'
         required: false
@@ -31,14 +27,12 @@ on:
         default: false
     #
     # Note: This workflow assumes the release tag and image tags are in sync.
-    #       'tag_name' is used to create the release and as the value to find in konflux files.
-    #       'next_tag_name' provides the new value to set.
+    #       'tag_name' is used to create the release and to rewrite .tekton/ push
+    #       pipelines for tag-push triggering.
     #
 
 permissions:
   contents: write
-  packages: write
-  pull-requests: write
 
 env:
   REPO_OWNER: opendatahub-io
@@ -76,7 +70,6 @@ jobs:
           import subprocess
           
           tag_name = "${{ github.event.inputs.tag_name }}"
-          next_tag = "${{ github.event.inputs.next_tag_name }}"
           repository = "${{ github.event.inputs.repository }}"
           
           # Expected format: odh-vX.Y or odh-vX.Y.Z with optional -EAn suffix
@@ -87,15 +80,6 @@ jobs:
           # Validate tag formats
           if not re.match(tag_pattern, tag_name):
             errors.append(f"Tag '{tag_name}' does not match expected format 'odh-vX.Y' or 'odh-vX.Y.Z'")
-          
-          # next_tag validation only required for repos that need Tekton bumping
-          if repository != "llm-d-inference-scheduler":
-            if not next_tag:
-              errors.append("next_tag_name is required for this repository")
-            elif not re.match(tag_pattern, next_tag):
-              errors.append(f"Next tag '{next_tag}' does not match expected format 'odh-vX.Y' or 'odh-vX.Y.Z'")
-            elif tag_name == next_tag:
-              errors.append(f"tag_name and next_tag_name must be different (both are '{tag_name}')")
           
           # Fail fast if validation errors exist
           if errors:
@@ -120,7 +104,6 @@ jobs:
           print(f"✓ All validations passed")
           print(f"  Repository: {repository}")
           print(f"  Release tag: {tag_name}")
-          print(f"  Next tag: {next_tag}")
         shell: python
   #
   # Note: This workflow dynamically discovers and updates:
@@ -220,7 +203,7 @@ jobs:
           else:
             # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar)[\w.-]+):()(fast|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-inference-scheduler|llm-d-routing-sidecar)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []
@@ -257,17 +240,80 @@ jobs:
           print(f"\n✓ Updated {total_replacements} image tag(s) across {len(updated_files)} file(s)")
         shell: python
 
-      - name: Commit params.env changes (if any)
-        if: ${{ needs.validate-and-check.outputs.has_params_env == 'true' }}
+      - name: Rewrite .tekton/ push pipelines for tag-push triggering
+        if: ${{ needs.validate-and-check.outputs.has_tekton == 'true' }}
         run: |
-          # Add all params.env files
-          git add config/**/params.env 2>/dev/null || true
+          import json
+          import re
+
+          tag_name = "${{ github.event.inputs.tag_name }}"
+          tekton_files = json.loads('${{ needs.validate-and-check.outputs.tekton_files }}')
+
+          push_files = [f for f in tekton_files if f.endswith('-push.yaml')]
+          if not push_files:
+            print("No push pipeline files found, skipping")
+            raise SystemExit(0)
+
+          print(f"Rewriting {len(push_files)} push pipeline(s) for tag-push triggering\n")
+
+          cel_pattern = re.compile(
+            r'( +)pipelinesascode\.tekton\.dev/on-cel-expression:.*\n(?:\1 +.*\n)*'
+          )
+
+          image_tag_pattern = re.compile(
+            r'([\w.-]+(?:\.[\w.-]+)*(?:/[\w.-]+)+):(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+          )
+
+          updated_files = []
+
+          for tekton_file in push_files:
+            print(f"Processing: {tekton_file}")
+
+            try:
+              with open(tekton_file, 'r') as f:
+                content = f.read()
+            except FileNotFoundError:
+              print(f"  - File not found, skipping")
+              continue
+
+            original = content
+
+            cel_match = cel_pattern.search(content)
+            if cel_match:
+              indent = cel_match.group(1)
+              replacement = (
+                f'{indent}pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/{tag_name}]"\n'
+                f'{indent}pipelinesascode.tekton.dev/on-event: "[push]"\n'
+              )
+              content = cel_pattern.sub(replacement, content)
+              print(f"  ✓ Replaced on-cel-expression with on-target-branch/on-event")
+            else:
+              print(f"  - No on-cel-expression found")
+
+            matches = image_tag_pattern.findall(content)
+            content, count = image_tag_pattern.subn(rf'\1:{tag_name}', content)
+            if count > 0:
+              print(f"  ✓ Updated {count} image tag(s)")
+              for image_path, old_tag in set(matches):
+                print(f"    - {image_path}:{old_tag} → {image_path}:{tag_name}")
+
+            if content != original:
+              with open(tekton_file, 'w') as f:
+                f.write(content)
+              updated_files.append(tekton_file)
+
+          print(f"\n✓ Rewrote {len(updated_files)} push pipeline(s) for tag {tag_name}")
+        shell: python
+
+      - name: Commit release changes (if any)
+        run: |
+          git add config/**/params.env .tekton/ 2>/dev/null || true
           
           if [[ -n "$(git status --porcelain)" ]]; then
-            git commit -m "Update image refs for release ${{ github.event.inputs.tag_name }}"
+            git commit -m "Update image refs and .tekton/ pipelines for release ${{ github.event.inputs.tag_name }}"
             echo "✓ Changes committed locally"
           else
-            echo "No params.env changes to commit"
+            echo "No changes to commit"
           fi
 
       - name: Create and push Tag
@@ -291,149 +337,10 @@ jobs:
           prerelease: false
           draft: false
 
-  bump-tekton-tags:
-    name: Bump Tekton tags for next release
-    runs-on: ubuntu-latest
-    needs: [validate-and-check, create-release]
-    if: always() && needs.create-release.result == 'success' && needs.validate-and-check.outputs.has_tekton == 'true' && !(github.event.inputs.repository == 'llm-d-inference-scheduler' && github.event.inputs.next_tag_name == '')
-    outputs:
-      pr_url: ${{ steps.create_pr.outputs.pr_url }}
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: getsentry/action-github-app-token@v2
-        with:
-          app_id: ${{ secrets.ODH_RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.ODH_RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Checkout target repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.REPO_OWNER }}/${{ needs.validate-and-check.outputs.repo_name }}
-          token: ${{ steps.app-token.outputs.token }}
-          ref: ${{ github.event.inputs.target_branch }}
-          fetch-depth: 1
-
-      - name: Update Tekton files with next tag
-        run: |
-          import os
-          import json
-          import re
-          
-          next_tag = "${{ github.event.inputs.next_tag_name }}"
-          tekton_files = json.loads('${{ needs.validate-and-check.outputs.tekton_files }}')
-          
-          print(f"Updating image tags in Tekton files to: {next_tag}\n")
-          
-          # Pattern to match image references with common tag formats:
-          # - :fast
-          # - :v0.15-latest
-          # - :release-v0.3.2
-          # - :odh-v2.35
-          # Captures the full image path (registry/namespace/repo), replaces only the tag
-          image_pattern = re.compile(
-            r'([\w.-]+(?:\.[\w.-]+)*(?:/[\w.-]+)+):((?:odh-model-serving-api-)?)(fast|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
-          )
-          
-          updated_files = []
-          errors = []
-          total_replacements = 0
-          
-          for tekton_file in tekton_files:
-            print(f"Processing: {tekton_file}")
-            
-            try:
-              with open(tekton_file, 'r') as f:
-                content = f.read()
-            except FileNotFoundError:
-              errors.append(f"File not found: {tekton_file}")
-              continue
-            
-            # Find all matches first to report what we're changing
-            matches = image_pattern.findall(content)
-            if not matches:
-              print(f"  - No matching image tags found, skipping")
-              continue
-            
-            # Replace all image tags while preserving registry/namespace/repo
-            # and any tag prefix (e.g. odh-model-serving-api-)
-            updated_content, count = image_pattern.subn(rf'\1:\g<2>{next_tag}', content)
-
-            if count > 0:
-              with open(tekton_file, 'w') as f:
-                f.write(updated_content)
-
-              updated_files.append(tekton_file)
-              total_replacements += count
-              print(f"  ✓ Updated {count} image tag(s)")
-              for image_path, prefix, old_tag in set(matches):
-                print(f"    - {image_path}:{prefix}{old_tag} → {image_path}:{prefix}{next_tag}")
-          
-          if errors:
-            print(f"\nWarnings:")
-            for error in errors:
-              print(f"  - {error}")
-          
-          print(f"\n✓ Updated {total_replacements} image tag(s) across {len(updated_files)} file(s)")
-        shell: python
-
-      - name: Create PR for Tekton tag bump
-        id: create_pr
-        run: |
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
-          
-          # Add all tekton files
-          git add .tekton/ 2>/dev/null || true
-          
-          if [[ -z "$(git status --porcelain)" ]]; then
-            echo "No changes to commit"
-            exit 0
-          fi
-          
-          # Create a new branch for the PR
-          BRANCH_NAME="chore/bump-odh-tag-${{ github.event.inputs.next_tag_name }}"
-          git checkout -b "$BRANCH_NAME"
-          
-          # Commit changes
-          git commit -m "chore(konflux): Bump ODH tag to ${{ github.event.inputs.next_tag_name }}"
-          
-          # Fetch the remote branch (if it exists) so --force-with-lease has a valid lease
-          git fetch origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" 2>/dev/null || true
-
-          git push --force-with-lease origin "refs/heads/$BRANCH_NAME:refs/heads/$BRANCH_NAME"
-          echo "✓ Branch pushed: $BRANCH_NAME"
-          
-          # Create or reuse PR
-          export GH_TOKEN="${{ steps.app-token.outputs.token }}"
-          REPO="${{ env.REPO_OWNER }}/${{ needs.validate-and-check.outputs.repo_name }}"
-          EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json url -q '.[0].url')
-          if [[ -n "$EXISTING_PR" ]]; then
-            PR_URL="$EXISTING_PR"
-            echo "✓ PR already exists (branch force-pushed): $PR_URL"
-          else
-            PR_URL=$(gh pr create \
-              --repo "$REPO" \
-              --base "${{ github.event.inputs.target_branch }}" \
-              --head "$BRANCH_NAME" \
-              --title "chore(konflux): Bump ODH tag to ${{ github.event.inputs.next_tag_name }}" \
-              --body "## Summary
-          
-          This PR bumps the ODH release tag in Tekton/Konflux files for the next development cycle.
-          
-          - **Previous tag:** \`${{ github.event.inputs.tag_name }}\`
-          - **Next tag:** \`${{ github.event.inputs.next_tag_name }}\`
-          
-          ---
-          *This PR was automatically created by the ODH Release Workflow.*")
-            echo "✓ PR created: $PR_URL"
-          fi
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-
   summary:
     name: Release Summary
     runs-on: ubuntu-latest
-    needs: [validate-and-check, create-release, bump-tekton-tags]
+    needs: [validate-and-check, create-release]
     if: always()
     steps:
       - name: Print Summary
@@ -442,7 +349,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Repository:** ${{ needs.validate-and-check.outputs.repo_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Release Tag:** ${{ github.event.inputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Next Tag:** ${{ github.event.inputs.next_tag_name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Discovered Files" >> $GITHUB_STEP_SUMMARY
           echo "- params.env files found: ${{ needs.validate-and-check.outputs.has_params_env }}" >> $GITHUB_STEP_SUMMARY
@@ -451,17 +357,7 @@ jobs:
           echo "## Job Status" >> $GITHUB_STEP_SUMMARY
           echo "- Validation: ${{ needs.validate-and-check.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Create Release: ${{ needs.create-release.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Bump Tekton Tags: ${{ needs.bump-tekton-tags.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [[ "${{ needs.bump-tekton-tags.result }}" == "success" ]]; then
-            PR_URL="${{ needs.bump-tekton-tags.outputs.pr_url }}"
-            if [[ -n "$PR_URL" ]]; then
-              echo "## Pull Request" >> $GITHUB_STEP_SUMMARY
-              echo "- **Tekton Tag Bump PR:** $PR_URL" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-          fi
           
           if [[ "${{ needs.create-release.result }}" == "success" ]]; then
             echo "✅ **Release created successfully!**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

At release time, rewrite `.tekton/` push pipelines to trigger Konflux builds from the release tag, producing per-release images (e.g. `:odh-v3.5`). This replaces the old `bump-tekton-tags` job and implements Fix 2 from the image-resolution design.

All supported repos now get the same treatment: file discovery runs unconditionally, tekton pipelines are rewritten for tag-push builds, and `params.env` is updated when present. Repos without `params.env` (e.g. `llm-d-inference-scheduler`, `workload-variant-autoscaler`, `llm-d-kv-cache`) get only the tekton rewrite + tag.

Also adds a `dry_run` input that shows what would change without writing files, committing, or creating a release.

Integrates #774 (add `workload-variant-autoscaler` and `llm-d-kv-cache`).

## How Has This Been Tested?

- Regex patterns tested against real `params.env` and `.tekton/` push pipeline content from kserve, odh-model-controller, llm-d-inference-scheduler, workload-variant-autoscaler, and llm-d-kv-cache
- PaC tag-push triggering validated in `open-data-hub-tenant` Konflux tenant (April 2026)
- Dry-run mode verified: side-effect steps skipped, Python scripts report proposed changes only

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow to use a single release-time rewrite driven by the provided tag.
  * Removed prior “next tag” bump flow and related validation.
  * Added unconditional discovery and a dry-run mode that labels output and prevents commits, tag pushes, or releases.
  * Push-pipeline triggers and image tag references are updated to target the release tag.
  * Reduced workflow permissions and removed the bump-PR reporting job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->