### PR TITLE
fix: read prometheus.io/path annotation for ServiceMonitor endpoint path

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler.go
@@ -17,11 +17,13 @@ package reconcilers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 
 	"github.com/go-logr/logr"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	kserveconstants "github.com/kserve/kserve/pkg/constants"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +81,22 @@ func (r *KserveRawMetricsServiceMonitorReconciler) createDesiredResource(ctx con
 		return nil, err
 	}
 
+	endpoint := v1.Endpoint{
+		Port:   isvcRuntime.Name + "-metrics",
+		Scheme: "http",
+	}
+	if anns := isvcRuntime.Spec.Annotations; anns != nil {
+		if path, ok := anns[kserveconstants.PrometheusPathAnnotationKey]; ok {
+			path = strings.TrimSpace(path)
+			if path != "" {
+				if !strings.HasPrefix(path, "/") {
+					path = "/" + path
+				}
+				endpoint.Path = path
+			}
+		}
+	}
+
 	desiredServiceMonitor := &v1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getMetricsServiceMonitorName(isvc),
@@ -88,12 +106,7 @@ func (r *KserveRawMetricsServiceMonitorReconciler) createDesiredResource(ctx con
 			},
 		},
 		Spec: v1.ServiceMonitorSpec{
-			Endpoints: []v1.Endpoint{
-				{
-					Port:   isvcRuntime.Name + "-metrics",
-					Scheme: "http",
-				},
-			},
+			Endpoints:         []v1.Endpoint{endpoint},
 			NamespaceSelector: v1.NamespaceSelector{},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler_test.go
@@ -1,0 +1,171 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	kserveconstants "github.com/kserve/kserve/pkg/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	controllerutils "github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+)
+
+var _ = Describe("KserveRawMetricsServiceMonitorReconciler", func() {
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(kservev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(kservev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(monitoringv1.AddToScheme(scheme)).To(Succeed())
+		controllerutils.RegisterSchemes(scheme)
+	})
+
+	Describe("createDesiredResource", func() {
+		const (
+			runtimeName = "test-runtime"
+			isvcName    = "test-isvc"
+			namespace   = "ns"
+		)
+
+		createServingRuntime := func(annotations map[string]string) *kservev1alpha1.ServingRuntime {
+			return &kservev1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      runtimeName,
+					Namespace: namespace,
+				},
+				Spec: kservev1alpha1.ServingRuntimeSpec{
+					ServingRuntimePodSpec: kservev1alpha1.ServingRuntimePodSpec{
+						Annotations: annotations,
+					},
+				},
+			}
+		}
+
+		createInferenceService := func() *kservev1beta1.InferenceService {
+			runtimeRef := runtimeName
+			return &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName,
+					Namespace: namespace,
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							Runtime: ptr.To(runtimeRef),
+						},
+					},
+				},
+			}
+		}
+
+		When("the prometheus.io/path annotation is set on the ServingRuntime", func() {
+			It("should set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(map[string]string{
+					kserveconstants.PrometheusPathAnnotationKey: "/v1/metrics",
+					kserveconstants.PrometheusPortAnnotationKey: "8000",
+				})
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(Equal("/v1/metrics"))
+			})
+		})
+
+		When("the prometheus.io/path annotation is absent from the ServingRuntime", func() {
+			It("should not set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(map[string]string{
+					kserveconstants.PrometheusPortAnnotationKey: "8000",
+				})
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(BeEmpty())
+			})
+		})
+
+		When("the prometheus.io/path annotation is present but empty", func() {
+			It("should not set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(map[string]string{
+					kserveconstants.PrometheusPathAnnotationKey: "",
+					kserveconstants.PrometheusPortAnnotationKey: "8000",
+				})
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(BeEmpty())
+			})
+		})
+
+		When("the ServingRuntime has no annotations", func() {
+			It("should not set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(nil)
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler_test.go
@@ -148,6 +148,52 @@ var _ = Describe("KserveRawMetricsServiceMonitorReconciler", func() {
 			})
 		})
 
+		When("the prometheus.io/path annotation has no leading slash", func() {
+			It("should prepend a slash and set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(map[string]string{
+					kserveconstants.PrometheusPathAnnotationKey: "v1/metrics",
+					kserveconstants.PrometheusPortAnnotationKey: "8000",
+				})
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(Equal("/v1/metrics"))
+			})
+		})
+
+		When("the prometheus.io/path annotation has surrounding whitespace", func() {
+			It("should trim whitespace and set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
+				sr := createServingRuntime(map[string]string{
+					kserveconstants.PrometheusPathAnnotationKey: "  /v1/metrics  ",
+					kserveconstants.PrometheusPortAnnotationKey: "8000",
+				})
+				isvc := createInferenceService()
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sr, isvc).
+					Build()
+
+				reconciler := NewKServeRawMetricsServiceMonitorReconciler(client)
+				sm, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sm).NotTo(BeNil())
+				Expect(sm.Spec.Endpoints).To(HaveLen(1))
+				Expect(sm.Spec.Endpoints[0].Path).To(Equal("/v1/metrics"))
+			})
+		})
+
 		When("the ServingRuntime has no annotations", func() {
 			It("should not set Endpoint.Path on the ServiceMonitor", func(ctx SpecContext) {
 				sr := createServingRuntime(nil)

--- a/internal/controller/serving/reconcilers/suite_test.go
+++ b/internal/controller/serving/reconcilers/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconcilers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconcilers Suite")
+}

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -430,7 +430,7 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 		Spec: v1alpha1.ServingRuntimeSpec{
 			ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
 				Annotations: map[string]string{
-					"prometheus.io/path":                    "/metrics",
+					"prometheus.io/path":                    "/v1/metrics",
 					"prometheus.io/port":                    "8000",
 					"serving.knative.dev/progress-deadline": "30m",
 				},


### PR DESCRIPTION
## Description

Backport of #808 to `stable-2.x`.

NIM changed its metrics endpoint from `/metrics` to `/v1/metrics` starting in version 1.3.x. Since then, all NIM metrics graphs in the RHOAI dashboard have shown no data, because Prometheus was scraping the wrong path on every NIM deployment. This was accidentally uncovered while investigating NIM 2 compatibility.

There are two issues, both fixed in this PR:

1. The `prometheus.io/path` annotation in the NIM ServingRuntime template (`GetNimServingRuntimeTemplate` in `internal/controller/utils/nim.go`) was set to `/metrics`. Updated to `/v1/metrics`.

2. The `KserveRawMetricsServiceMonitorReconciler` never read the `prometheus.io/path` annotation from the ServingRuntime when constructing the ServiceMonitor — it always left `Endpoint.Path` unset, causing Prometheus to default to `/metrics` regardless of the annotation value. Fixed by reading `PrometheusPathAnnotationKey` from the ServingRuntime annotations and propagating it to `Endpoint.Path` when present, trimming whitespace and normalizing the leading slash. If the annotation is absent, `Endpoint.Path` is not set, preserving existing behavior for all other runtimes.

Fixes: [NVPE-433](https://redhat.atlassian.net/browse/NVPE-433)
Target: RHOAI 2.25.6 (code freeze May 18)

## How Has This Been Tested?

Pre-implementation validation was performed in [NVPE-423](https://redhat.atlassian.net/browse/NVPE-423) across multiple NIM versions (RHOAI 2.25, A100 GPUs), manually deploying `llama-3.1-8b-instruct` at each version and curling both `/metrics` and `/v1/metrics` directly on the pod:

- `1.2.2`: `/metrics` → 200, `/v1/metrics` → 404
- `1.3.3`: `/metrics` → 404, `/v1/metrics` → 200
- `1.8.x`, `1.10.x`, `1.12.0`, `1.15.5` (TRT-LLM and vLLM backends): `/metrics` → 404, `/v1/metrics` → 200
- `2.0.2`: `/metrics` → 404, `/v1/metrics` → 200

This confirms the path change was introduced in NIM 1.3.x and is independent of the inference backend. It is not a NIM 2 regression — it was accidentally uncovered while investigating NIM 2 compatibility.

The ServiceMonitor fix was verified by manually patching the `Endpoint.Path` field on an existing ServiceMonitor to `/v1/metrics` (with the controller scaled down to prevent reconciliation from reverting the change), then confirming Prometheus successfully scraped metrics from the NIM pod at the correct path.

Unit tests covering all annotation presence/absence and normalization cases are included.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work