### PR TITLE
fix(release): [RHOAIENG-58438] split git add to prevent staging failure

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -335,7 +335,8 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.inputs.tag_name }}
         run: |
-          git add config/**/params.env .tekton/ 2>/dev/null || true
+          git add config/**/params.env 2>/dev/null || true
+          git add .tekton/ 2>/dev/null || true
           
           if [[ -n "$(git status --porcelain)" ]]; then
             git commit -m "Update image refs and .tekton/ pipelines for release ${TAG_NAME}"


### PR DESCRIPTION
## Description

Fixes a bug introduced in #807 where the release workflow fails for repos without `config/**/params.env` (e.g. `llm-d-kv-cache`).

The single `git add config/**/params.env .tekton/` command aborts entirely when the first pathspec matches nothing -- git produces a fatal error and never processes `.tekton/`. Because `2>/dev/null || true` hides this, the subsequent `git commit` fails with exit code 1 since nothing was staged.

Split into two independent `git add` commands so each pathspec is processed independently.

## How Has This Been Tested?

Verified that `llm-d-kv-cache` on `release-v0.7.1` has no `config/` directory, confirming the pathspec mismatch as root cause.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->