### PR TITLE
chore: switch params.env to Konflux-built images (RHOAIENG-53839)

### DIFF
--- a/.github/workflows/verify-odh-model-controller-img-tag.yaml
+++ b/.github/workflows/verify-odh-model-controller-img-tag.yaml
@@ -20,7 +20,7 @@ jobs:
           if [ "${{ github.base_ref }}" == "incubating" ]; then
             EXPECTED_TAG="fast"
           elif [[ "${{ github.base_ref }}" == "main" ]]; then
-            EXPECTED_TAG="stable"
+            EXPECTED_TAG="odh-stable"
           elif [[ "${GITHUB_REF}" == refs/tags/odh-v* ]]; then
             EXPECTED_TAG="${GITHUB_REF#refs/tags/}"
           else

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,6 +1,5 @@
-odh-model-controller=quay.io/opendatahub/odh-model-controller:stable
-# TODO(RHOAIENG-53839): Temporary hack to workaround the yet to happen Konflux onboarding.
-odh-model-serving-api=quay.io/opendatahub/odh-model-controller:odh-model-serving-api-stable
+odh-model-controller=quay.io/opendatahub/odh-model-controller:odh-stable
+odh-model-serving-api=quay.io/opendatahub/odh-model-serving-api:odh-stable
 ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest
 nim-state=managed
 kserve-state=managed


### PR DESCRIPTION
## Summary

Now that Konflux onboarding is complete for both `odh-model-controller` and `odh-model-serving-api`, this PR switches `params.env` on the `main` branch to use the Konflux-built images directly, removing the temporary GitHub Actions tag-prefix hack.

- `odh-model-controller`: `quay.io/opendatahub/odh-model-controller:stable` -> `:odh-stable`
- `odh-model-serving-api`: `quay.io/opendatahub/odh-model-controller:odh-model-serving-api-stable` -> `quay.io/opendatahub/odh-model-serving-api:odh-stable` (own repo now)
- Removes the `TODO([RHOAIENG-53839](https://redhat.atlassian.net/browse/RHOAIENG-53839))` hack comment
- Updates `verify-odh-model-controller-img-tag` CI to expect `odh-stable` for the `main` branch

Both target images verified to exist via skopeo:
```
skopeo inspect docker://quay.io/opendatahub/odh-model-controller:odh-stable   # OK
skopeo inspect docker://quay.io/opendatahub/odh-model-serving-api:odh-stable  # OK
```

## Test plan

- [ ] Verify CI tag-check workflow passes with the new `odh-stable` expected tag
- [ ] Confirm operator can deploy with the updated image refs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tags for model controller and serving API components to use the `odh-stable` versioning scheme.
  * Updated deployment verification logic to validate the updated image tag references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->