### PR TITLE
chore: bump kserve dependency to odh-v3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.7
 
 // Use ODH release branch instead
-replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260409184100-a2efb39e4494
+replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933
 
 // CVE-2025-68156: Update expr-lang/expr to v1.17.7
 replace github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.7

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/open-telemetry/opentelemetry-operator v0.113.0 h1:EoN3SLwF9dP5Ou7gFcf
 github.com/open-telemetry/opentelemetry-operator v0.113.0/go.mod h1:eQ8W+MxP+q5Tewf5Cx1vNXvRynjP9JNgrBbUO7TqjXQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opendatahub-io/kserve v0.0.0-20260409184100-a2efb39e4494 h1:Z2L8eI1RhBqRvD3QYUpU5ejnamA6nTu1t5NvJsEpze0=
-github.com/opendatahub-io/kserve v0.0.0-20260409184100-a2efb39e4494/go.mod h1:wBepkgRTeDeGTyuNsE22q0Z1hma4psyb05ZdV7XaCsM=
+github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933 h1:dCwn+v11R58UxND1RhimSLi4Dub6nuKzJnvsltYuZkI=
+github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933/go.mod h1:wBepkgRTeDeGTyuNsE22q0Z1hma4psyb05ZdV7XaCsM=
 github.com/openshift/api v0.0.0-20260306002634-d3bbdada155c h1:YQYiDzOLJzwQunxCaa5OpyNyMLPz4HJ2CLaKqUQOQjQ=
 github.com/openshift/api v0.0.0-20260306002634-d3bbdada155c/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d h1:T+9HFgEEcnu1TDDfsO5JcJC6N0/Kzob5AtG9IpITHJ8=


### PR DESCRIPTION
## Description

Update the `opendatahub-io/kserve` replace directive in `go.mod` to the commit behind the `odh-v3.5` release tag.

```
-replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260409184100-a2efb39e4494
+replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933
```

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a backend dependency to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->