### PR TITLE
[RHOAIENG-60685] aggregate NIM Account roles to admin, edit, and view…

### DIFF
--- a/config/rbac/account_editor_role.yaml
+++ b/config/rbac/account_editor_role.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: odh-model-controller
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: account-editor-role
 rules:
 - apiGroups:
@@ -22,6 +24,7 @@ rules:
 - apiGroups:
   - nim.opendatahub.io
   resources:
-  - accounts/status
+  - accounts/finalizers
   verbs:
   - get
+  - update

--- a/config/rbac/account_viewer_role.yaml
+++ b/config/rbac/account_viewer_role.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: odh-model-controller
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: account-viewer-role
 rules:
 - apiGroups:
@@ -19,5 +22,7 @@ rules:
   - nim.opendatahub.io
   resources:
   - accounts/status
+  - accounts/finalizers
   verbs:
   - get
+  - update

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,12 +19,11 @@ resources:
 #- metrics_auth_role.yaml
 #- metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
-# default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
-# if you do not want those helpers be installed with your Project.
-#- account_editor_role.yaml
-#- account_viewer_role.yaml
+# The following roles aggregate NIM Account CR permissions to the
+# default admin, edit, and view ClusterRoles, allowing namespace
+# admins and editors to manage Account CRs in their own projects.
+- account_editor_role.yaml
+- account_viewer_role.yaml
 # The following RBAC configurations are need for token
 # TODO: verify if it's needed for kube-rbac-proxy, otherwise remove them
 - auth_proxy_role.yaml


### PR DESCRIPTION
… ClusterRoles

chore:  Project admins and editors could not create NIM Account CRs in their
        namespaces because the account-editor-role and account-viewer-role
        ClusterRoles lacked aggregation labels and were not included in the
        kustomize deployment. Add aggregation labels and enable the roles so
        namespace-scoped users can manage Account CRs in their own projects.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RBAC permissions for account editor and viewer roles to include necessary access to account finalizers, enabling proper lifecycle management.
  * Activated account editor and viewer roles in the RBAC configuration, transitioning them from commented scaffolding to active deployment.
  * Added role aggregation markers to support integration with Kubernetes default admin, edit, and view ClusterRoles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->