### PR TITLE
feat(webhook): migrate ConnectionsAPI injection to odh-model-controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ import (
 	webhookcorev1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/core/v1"
 	webhooknimv1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/nim/v1"
 	webhookservingv1alpha1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1alpha1"
+	webhookservingv1alpha2 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1alpha2"
 	webhookservingv1beta1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
@@ -291,6 +292,7 @@ func setupWebhooks(mgr ctrl.Manager, setupLog logr.Logger) error {
 		{"NIMAccount", webhooknimv1.SetupAccountWebhookWithManager},
 		{"InferenceService", webhookservingv1beta1.SetupInferenceServiceWebhookWithManager},
 		{"InferenceGraph", webhookservingv1alpha1.SetupInferenceGraphWebhookWithManager},
+		{"LLMInferenceService", webhookservingv1alpha2.SetupLLMInferenceServiceWebhookWithManager},
 	}
 
 	for _, webhookSetup := range webhookSetups {

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -44,10 +44,14 @@ patches:
       clientConfig:
         service:
           name: odh-model-controller-webhook-service
+    - name: connection-llmisvc.odh-model-controller.opendatahub.io
+      clientConfig:
+        service:
+          name: odh-model-controller-webhook-service
     - name: mutating.pod.odh-model-controller.opendatahub.io
       clientConfig:
         service:
-          name: odh-model-controller-webhook-service          
+          name: odh-model-controller-webhook-service
       objectSelector:
         matchExpressions:
           - key: serving.kserve.io/inferenceservice

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -44,7 +44,11 @@ patches:
       clientConfig:
         service:
           name: odh-model-controller-webhook-service
-    - name: connection-llmisvc.odh-model-controller.opendatahub.io
+    - name: connection-llmisvc-v1alpha2.odh-model-controller.opendatahub.io
+      clientConfig:
+        service:
+          name: odh-model-controller-webhook-service
+    - name: connection-llmisvc-v1alpha1.odh-model-controller.opendatahub.io
       clientConfig:
         service:
           name: odh-model-controller-webhook-service

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -48,14 +48,33 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-serving-kserve-io-v1alpha2-llminferenceservice
+      path: /mutate-serving-kserve-io-v1alpha1-llminferenceservice
   failurePolicy: Fail
-  name: connection-llmisvc.odh-model-controller.opendatahub.io
+  name: connection-llmisvc-v1alpha1.odh-model-controller.opendatahub.io
   rules:
   - apiGroups:
     - serving.kserve.io
     apiVersions:
     - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - llminferenceservices
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-serving-kserve-io-v1alpha2-llminferenceservice
+  failurePolicy: Fail
+  name: connection-llmisvc-v1alpha2.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
     - v1alpha2
     operations:
     - CREATE

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -48,26 +48,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-serving-kserve-io-v1beta1-inferenceservice
-  failurePolicy: Fail
-  name: minferenceservice-v1beta1.odh-model-controller.opendatahub.io
-  rules:
-  - apiGroups:
-    - serving.kserve.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - inferenceservices
-  sideEffects: NoneOnDryRun
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-serving-kserve-io-v1alpha2-llminferenceservice
   failurePolicy: Fail
   name: connection-llmisvc.odh-model-controller.opendatahub.io
@@ -82,6 +62,26 @@ webhooks:
     - UPDATE
     resources:
     - llminferenceservices
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-serving-kserve-io-v1beta1-inferenceservice
+  failurePolicy: Fail
+  name: minferenceservice-v1beta1.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices
   sideEffects: NoneOnDryRun
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -58,9 +58,31 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - inferenceservices
-  sideEffects: None
+  sideEffects: NoneOnDryRun
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-serving-kserve-io-v1alpha2-llminferenceservice
+  failurePolicy: Fail
+  name: connection-llmisvc.odh-model-controller.opendatahub.io
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - llminferenceservices
+  sideEffects: NoneOnDryRun
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/internal/webhook/connectionapi/annotations.go
+++ b/internal/webhook/connectionapi/annotations.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectionapi
+
+// Annotation constants used by the ConnectionsAPI feature to associate data connections with
+// InferenceService and LLMInferenceService resources.
+const (
+	// AnnotationConnections holds the name of the Secret containing connection credentials.
+	AnnotationConnections = "opendatahub.io/connections"
+
+	// AnnotationConnectionTypeProtocol holds the connection type on the Secret (s3, uri, oci).
+	AnnotationConnectionTypeProtocol = "opendatahub.io/connection-type-protocol"
+
+	// AnnotationConnectionTypeRef is the deprecated equivalent of AnnotationConnectionTypeProtocol
+	// (values: s3, uri-v1, oci-v1). Supported for backward compatibility.
+	AnnotationConnectionTypeRef = "opendatahub.io/connection-type-ref"
+
+	// AnnotationConnectionPath holds the S3 bucket sub-path for the model location.
+	AnnotationConnectionPath = "opendatahub.io/connection-path"
+)

--- a/internal/webhook/connectionapi/utils.go
+++ b/internal/webhook/connectionapi/utils.go
@@ -1,0 +1,395 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectionapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// ConnectionInfo holds connection-related information extracted from resource annotations and the referenced Secret.
+type ConnectionInfo struct {
+	// SecretName is the name of the Secret from the opendatahub.io/connections annotation.
+	SecretName string
+	// Type is the connection type from the connection-type-protocol or connection-type-ref annotation on the Secret.
+	Type string
+	// Path is the S3 sub-path from the opendatahub.io/connection-path annotation on the resource.
+	Path string
+}
+
+// ConnectionAction represents the mutation action to perform on a resource during admission.
+type ConnectionAction string
+
+const (
+	// ConnectionActionInject injects connection credentials into the resource.
+	ConnectionActionInject ConnectionAction = "inject"
+	// ConnectionActionRemove removes previously injected connection credentials.
+	ConnectionActionRemove ConnectionAction = "remove"
+	// ConnectionActionReplace removes old credentials and injects new ones.
+	ConnectionActionReplace ConnectionAction = "replace"
+	// ConnectionActionNone indicates no mutation is needed.
+	ConnectionActionNone ConnectionAction = "none"
+)
+
+// ConnectionType is the canonical identifier for a connection protocol.
+type ConnectionType string
+
+const (
+	// ConnectionTypeProtocolS3 identifies S3-compatible object storage connections.
+	ConnectionTypeProtocolS3 ConnectionType = "s3"
+	// ConnectionTypeProtocolURI identifies generic URI connections.
+	ConnectionTypeProtocolURI ConnectionType = "uri"
+	// ConnectionTypeProtocolOCI identifies OCI container image connections.
+	ConnectionTypeProtocolOCI ConnectionType = "oci"
+
+	// ConnectionTypeRefS3 is the deprecated ref value for S3 connections.
+	ConnectionTypeRefS3 ConnectionType = "s3"
+	// ConnectionTypeRefURI is the deprecated ref value for URI connections.
+	ConnectionTypeRefURI ConnectionType = "uri-v1"
+	// ConnectionTypeRefOCI is the deprecated ref value for OCI connections.
+	ConnectionTypeRefOCI ConnectionType = "oci-v1"
+)
+
+// String returns the string representation of the ConnectionType.
+func (ct ConnectionType) String() string {
+	return string(ct)
+}
+
+// ValidateConnectionAnnotation validates the opendatahub.io/connections annotation on obj.
+//
+// Fetches the referenced Secret once and validates the connection type from its annotations.
+// Returns populated ConnectionInfo and the fetched Secret when a valid connection is found.
+// Returns empty ConnectionInfo and a nil Secret (no error) when no injection should be performed
+// (annotation absent, unknown type, or no type annotation on the Secret).
+// Returns an error when validation fails (e.g., Secret not found, API error).
+//
+// The returned Secret is non-nil only when injection should proceed; callers must pass it to
+// injection helpers (GetURIValue, BuildS3URI) to avoid a second fetch.
+//
+// Parameters:
+//   - ctx: context for logging and API calls
+//   - apiReader: uncached reader for fetching the Secret
+//   - obj: the admitted resource (must implement metav1.Object)
+//   - namespace: namespace of the admitted resource
+//
+// Returns the validated ConnectionInfo, the fetched Secret, and any error encountered.
+func ValidateConnectionAnnotation(ctx context.Context, apiReader client.Reader, obj metav1.Object, namespace string) (ConnectionInfo, *corev1.Secret, error) {
+	log := logf.FromContext(ctx)
+
+	secretName := obj.GetAnnotations()[AnnotationConnections]
+	if secretName == "" {
+		return ConnectionInfo{}, nil, nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := apiReader.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		if k8serr.IsNotFound(err) {
+			return ConnectionInfo{}, nil, fmt.Errorf("connection %q referenced by annotation %q not found in namespace %q",
+				secretName, AnnotationConnections, namespace)
+		}
+		log.Error(err, "failed to get connection", "connection", secretName, "namespace", namespace)
+		return ConnectionInfo{}, nil, fmt.Errorf("failed to validate connection: %w", err)
+	}
+
+	connType, isValid := ValidateConnectionType(secret)
+	if connType == "" {
+		log.Info("connection has no type annotation, skipping injection", "connection", secretName)
+		return ConnectionInfo{}, nil, nil
+	}
+	if !isValid {
+		log.Info("unknown connection type, skipping injection", "connectionType", connType, "connection", secretName)
+		return ConnectionInfo{}, nil, nil
+	}
+
+	connPath := obj.GetAnnotations()[AnnotationConnectionPath]
+	return ConnectionInfo{
+		SecretName: secret.Name,
+		Type:       connType,
+		Path:       connPath,
+	}, secret, nil
+}
+
+// ValidateConnectionType checks connection type annotations on obj.
+//
+// Prefers connection-type-protocol over the deprecated connection-type-ref. Returns the type
+// string and a flag indicating whether the type is a known, supported connection type.
+//
+// Parameters:
+//   - obj: any object whose annotations carry the connection type (e.g., *corev1.Secret)
+//
+// Returns the connection type string (empty if no annotation) and whether it is a valid known type.
+func ValidateConnectionType(obj metav1.Object) (string, bool) {
+	allowedProtocol := []string{
+		ConnectionTypeProtocolS3.String(),
+		ConnectionTypeProtocolURI.String(),
+		ConnectionTypeProtocolOCI.String(),
+	}
+	allowedRef := []string{
+		ConnectionTypeRefS3.String(),
+		ConnectionTypeRefURI.String(),
+		ConnectionTypeRefOCI.String(),
+	}
+
+	annotations := obj.GetAnnotations()
+	if connType, ok := annotations[AnnotationConnectionTypeProtocol]; ok && connType != "" {
+		return connType, slices.Contains(allowedProtocol, connType)
+	}
+	if connType, ok := annotations[AnnotationConnectionTypeRef]; ok && connType != "" {
+		return connType, slices.Contains(allowedRef, connType)
+	}
+	return "", false
+}
+
+// DetermineAction compares old and new ConnectionInfo to decide what mutation to perform on UPDATE.
+//
+// The decision table:
+//   - old present, new absent → remove
+//   - both absent → none
+//   - old absent, new present → inject
+//   - type or secret name changed → replace
+//   - S3 with changed path → replace
+//   - identical → none
+//
+// Parameters:
+//   - oldConn: connection info from the previous object version
+//   - newConn: connection info from the incoming object version
+//
+// Returns the ConnectionAction to perform.
+func DetermineAction(oldConn, newConn ConnectionInfo) ConnectionAction {
+	if oldConn.SecretName != "" && newConn.SecretName == "" {
+		return ConnectionActionRemove
+	}
+	if oldConn.SecretName == "" && newConn.SecretName == "" {
+		return ConnectionActionNone
+	}
+	if oldConn.SecretName == "" && newConn.SecretName != "" {
+		return ConnectionActionInject
+	}
+	if oldConn.Type != newConn.Type || oldConn.SecretName != newConn.SecretName {
+		return ConnectionActionReplace
+	}
+	isS3 := newConn.Type == ConnectionTypeProtocolS3.String() || newConn.Type == ConnectionTypeRefS3.String()
+	if isS3 && oldConn.Path != newConn.Path {
+		return ConnectionActionReplace
+	}
+	return ConnectionActionNone
+}
+
+// ServiceAccountCreation creates a ServiceAccount for S3 connections. No-op for non-S3 types or dry-run requests.
+//
+// Parameters:
+//   - ctx: context for API calls and logging
+//   - cli: write-capable client for ServiceAccount creation
+//   - secretName: name of the connection Secret (SA will be named secretName+"-sa")
+//   - connType: connection type string
+//   - namespace: namespace for the ServiceAccount
+//   - isDryRun: when true, skips actual SA creation
+//
+// Returns any error from ServiceAccount creation.
+func ServiceAccountCreation(ctx context.Context, cli client.Client, secretName, connType, namespace string, isDryRun bool) error {
+	log := logf.FromContext(ctx)
+
+	isS3 := connType == ConnectionTypeProtocolS3.String() || connType == ConnectionTypeRefS3.String()
+	if !isS3 {
+		log.V(1).Info("skipping SA creation for non-S3 connection type", "connectionType", connType)
+		return nil
+	}
+	if isDryRun {
+		log.V(1).Info("skipping SA creation in dry-run mode", "connection", secretName)
+		return nil
+	}
+	return createSA(ctx, cli, secretName, namespace)
+}
+
+// createSA creates a ServiceAccount linking the given secret. AlreadyExists is treated as success.
+func createSA(ctx context.Context, cli client.Client, secretName, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName + "-sa",
+			Namespace: namespace,
+		},
+		Secrets: []corev1.ObjectReference{{Name: secretName}},
+	}
+	if err := cli.Create(ctx, sa); err != nil && !k8serr.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create ServiceAccount: %w", err)
+	}
+	return nil
+}
+
+// GetURIValue reads the URI value from the pre-fetched Secret's "https-host" or "URI" data key.
+//
+// Parameters:
+//   - secret: the pre-fetched connection Secret
+//
+// Returns the URI string or an error if neither key is present.
+func GetURIValue(secret *corev1.Secret) (string, error) {
+	if v, ok := secret.Data["https-host"]; ok {
+		return string(v), nil
+	}
+	if v, ok := secret.Data["URI"]; ok {
+		return string(v), nil
+	}
+	return "", errors.New("connection does not contain 'https-host' or 'URI' data key")
+}
+
+// BuildS3URI constructs an S3 URI (s3://{bucket}/{path}) from the pre-fetched Secret's AWS_S3_BUCKET
+// key and the connection path.
+//
+// Parameters:
+//   - secret: the pre-fetched connection Secret
+//   - connInfo: connection info containing the path
+//
+// Returns the S3 URI string or an error if the bucket key is missing or the path is empty.
+func BuildS3URI(secret *corev1.Secret, connInfo ConnectionInfo) (string, error) {
+	bucket, ok := secret.Data["AWS_S3_BUCKET"]
+	if !ok {
+		return "", errors.New("connection does not contain 'AWS_S3_BUCKET' data key")
+	}
+	if len(bucket) == 0 {
+		return "", errors.New("connection 'AWS_S3_BUCKET' data key is empty")
+	}
+	if connInfo.Path == "" {
+		return "", errors.New("connection info does not have a path")
+	}
+	return fmt.Sprintf("s3://%s/%s", string(bucket), connInfo.Path), nil
+}
+
+// GetOldConnectionInfo decodes req.OldObject.Raw and extracts the connection annotation and type.
+//
+// It reads the opendatahub.io/connections annotation and fetches the referenced Secret metadata
+// to determine the old connection type. When the Secret has been deleted, Type is left empty so
+// callers perform a full cleanup. Returns empty ConnectionInfo when no old connection annotation
+// is present.
+//
+// Parameters:
+//   - ctx: context for logging and API calls
+//   - req: the admission request containing the old object raw bytes
+//   - apiReader: uncached reader for fetching Secret metadata
+//
+// Returns the old ConnectionInfo and any API error encountered.
+func GetOldConnectionInfo(ctx context.Context, req admission.Request, apiReader client.Reader) (ConnectionInfo, error) {
+	log := logf.FromContext(ctx)
+
+	if req.OldObject.Raw == nil {
+		return ConnectionInfo{}, nil
+	}
+
+	oldObj := &metav1.PartialObjectMetadata{}
+	if err := json.Unmarshal(req.OldObject.Raw, oldObj); err != nil {
+		return ConnectionInfo{}, fmt.Errorf("failed to decode old object: %w", err)
+	}
+
+	secretName := oldObj.GetAnnotations()[AnnotationConnections]
+	if secretName == "" {
+		return ConnectionInfo{}, nil
+	}
+
+	secretMeta := &metav1.PartialObjectMetadata{}
+	secretMeta.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+	if err := apiReader.Get(ctx, types.NamespacedName{Name: secretName, Namespace: req.Namespace}, secretMeta); err != nil {
+		if k8serr.IsNotFound(err) {
+			log.V(1).Info("old connection not found, type unknown — full cleanup will be performed", "connection", secretName)
+			return ConnectionInfo{
+				SecretName: secretName,
+				Type:       "",
+				Path:       oldObj.GetAnnotations()[AnnotationConnectionPath],
+			}, nil
+		}
+		return ConnectionInfo{}, fmt.Errorf("failed to get old secret metadata: %w", err)
+	}
+
+	connType := secretMeta.GetAnnotations()[AnnotationConnectionTypeProtocol]
+	if connType == "" {
+		connType = secretMeta.GetAnnotations()[AnnotationConnectionTypeRef]
+	}
+
+	return ConnectionInfo{
+		SecretName: secretName,
+		Type:       connType,
+		Path:       oldObj.GetAnnotations()[AnnotationConnectionPath],
+	}, nil
+}
+
+// InjectServiceAccountName sets serviceAccountName to saName only when it is currently empty.
+// Existing user-set values are preserved.
+//
+// Parameters:
+//   - serviceAccountName: pointer to the ServiceAccountName field to conditionally set
+//   - saName: the value to inject
+func InjectServiceAccountName(serviceAccountName *string, saName string) {
+	if *serviceAccountName == "" {
+		*serviceAccountName = saName
+	}
+}
+
+// RemoveServiceAccountName clears serviceAccountName only when its current value matches injectedSAName.
+// User-set values that differ from injectedSAName are preserved.
+//
+// Parameters:
+//   - serviceAccountName: pointer to the ServiceAccountName field to conditionally clear
+//   - injectedSAName: the value that was previously injected and should be removed
+func RemoveServiceAccountName(serviceAccountName *string, injectedSAName string) {
+	if *serviceAccountName == injectedSAName {
+		*serviceAccountName = ""
+	}
+}
+
+// InjectOCIImagePullSecrets appends a LocalObjectReference for secretName to imagePullSecrets
+// if it is not already present (idempotent).
+//
+// Parameters:
+//   - imagePullSecrets: pointer to the ImagePullSecrets slice to update
+//   - secretName: name of the Secret to add
+func InjectOCIImagePullSecrets(imagePullSecrets *[]corev1.LocalObjectReference, secretName string) {
+	for _, ref := range *imagePullSecrets {
+		if ref.Name == secretName {
+			return
+		}
+	}
+	*imagePullSecrets = append(*imagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+}
+
+// CleanupOCIImagePullSecrets removes the LocalObjectReference for secretName from imagePullSecrets.
+// No-op when secretName is empty.
+//
+// Parameters:
+//   - imagePullSecrets: pointer to the ImagePullSecrets slice to update
+//   - secretName: name of the Secret to remove
+func CleanupOCIImagePullSecrets(imagePullSecrets *[]corev1.LocalObjectReference, secretName string) {
+	if secretName == "" {
+		return
+	}
+	result := make([]corev1.LocalObjectReference, 0, len(*imagePullSecrets))
+	for _, ref := range *imagePullSecrets {
+		if ref.Name != secretName {
+			result = append(result, ref)
+		}
+	}
+	*imagePullSecrets = result
+}

--- a/internal/webhook/connectionapi/utils.go
+++ b/internal/webhook/connectionapi/utils.go
@@ -201,7 +201,7 @@ func DetermineAction(oldConn, newConn ConnectionInfo) ConnectionAction {
 	return ConnectionActionNone
 }
 
-// ServiceAccountCreation creates a ServiceAccount for S3 connections. No-op for non-S3 types or dry-run requests.
+// CreateServiceAccountIfNeeded creates a ServiceAccount for S3 connections. No-op for non-S3 types or dry-run requests.
 //
 // Parameters:
 //   - ctx: context for API calls and logging
@@ -212,7 +212,7 @@ func DetermineAction(oldConn, newConn ConnectionInfo) ConnectionAction {
 //   - isDryRun: when true, skips actual SA creation
 //
 // Returns any error from ServiceAccount creation.
-func ServiceAccountCreation(ctx context.Context, cli client.Client, secretName, connType, namespace string, isDryRun bool) error {
+func CreateServiceAccountIfNeeded(ctx context.Context, cli client.Client, secretName, connType, namespace string, isDryRun bool) error {
 	log := logf.FromContext(ctx)
 
 	isS3 := connType == ConnectionTypeProtocolS3.String() || connType == ConnectionTypeRefS3.String()

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
@@ -18,12 +18,11 @@ package v1alpha2
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"knative.dev/pkg/apis"
 
@@ -40,7 +40,8 @@ import (
 // nolint:unused
 var llmisvclog = logf.Log.WithName("llminferenceservice-resource")
 
-// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1alpha2-llminferenceservice,mutating=true,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1;v1alpha2,name=connection-llmisvc.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1alpha2-llminferenceservice,mutating=true,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha2,name=connection-llmisvc-v1alpha2.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1alpha1-llminferenceservice,mutating=true,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1,name=connection-llmisvc-v1alpha1.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create
@@ -53,39 +54,70 @@ type LLMInferenceServiceCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &LLMInferenceServiceCustomDefaulter{}
 
-// SetupLLMInferenceServiceWebhookWithManager registers the LLMInferenceService mutating webhook with the manager.
+// SetupLLMInferenceServiceWebhookWithManager registers the LLMInferenceService mutating webhook for both
+// v1alpha1 and v1alpha2 API versions using a single shared defaulter instance.
 //
 // Parameters:
 //   - mgr: the controller-runtime manager
 //
 // Returns any registration error.
 func SetupLLMInferenceServiceWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+	defaulter := &LLMInferenceServiceCustomDefaulter{
+		client:    mgr.GetClient(),
+		apiReader: mgr.GetAPIReader(),
+	}
+	if err := ctrl.NewWebhookManagedBy(mgr).
 		For(&kservev1alpha2.LLMInferenceService{}).
-		WithDefaulter(&LLMInferenceServiceCustomDefaulter{
-			client:    mgr.GetClient(),
-			apiReader: mgr.GetAPIReader(),
-		}).
+		WithDefaulter(defaulter).
+		Complete(); err != nil {
+		return err
+	}
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&kservev1alpha1.LLMInferenceService{}).
+		WithDefaulter(defaulter).
 		Complete()
 }
 
-// Default implements webhook.CustomDefaulter. It applies ConnectionsAPI injection or cleanup to the
-// LLMInferenceService based on the opendatahub.io/connections annotation.
+// Default implements webhook.CustomDefaulter. It applies ConnectionsAPI injection or cleanup to
+// LLMInferenceService resources of both v1alpha1 and v1alpha2 API versions.
 //
 // Parameters:
 //   - ctx: context carrying the admission request (via admission.RequestFromContext)
-//   - obj: the LLMInferenceService object to mutate
+//   - obj: the LLMInferenceService object to mutate (either v1alpha1 or v1alpha2)
 //
 // Returns any error that should block admission.
 func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	llmisvc, ok := obj.(*kservev1alpha2.LLMInferenceService)
-	if !ok {
+	switch typedObj := obj.(type) {
+	case *kservev1alpha2.LLMInferenceService:
+		return d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template)
+	case *kservev1alpha1.LLMInferenceService:
+		return d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template)
+	default:
 		return fmt.Errorf("expected a LLMInferenceService object but got %T", obj)
 	}
-	logger := llmisvclog.WithValues("name", llmisvc.GetName())
+}
+
+// applyLLMISVCDefaults is the version-agnostic core of the LLMInferenceService webhook. It determines
+// the ConnectionsAPI action and applies injection or cleanup via field pointers that are compatible
+// with both v1alpha1 and v1alpha2.
+//
+// Parameters:
+//   - ctx: context carrying the admission request
+//   - obj: the admitted resource as metav1.Object (for metadata access)
+//   - modelURI: pointer to the spec.model.uri field
+//   - template: pointer to the spec.template field pointer
+//
+// Returns any error that should block admission.
+func (d *LLMInferenceServiceCustomDefaulter) applyLLMISVCDefaults(
+	ctx context.Context,
+	obj metav1.Object,
+	modelURI *apis.URL,
+	template **corev1.PodSpec,
+) error {
+	logger := llmisvclog.WithValues("name", obj.GetName())
 	logger.Info("Defaulting for LLMInferenceService")
 
-	if llmisvc.DeletionTimestamp != nil {
+	if obj.GetDeletionTimestamp() != nil {
 		return nil
 	}
 
@@ -94,7 +126,7 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 		return fmt.Errorf("failed to get admission request from context: %w", err)
 	}
 
-	newConn, secret, err := connectionapi.ValidateConnectionAnnotation(ctx, d.apiReader, llmisvc, req.Namespace)
+	newConn, secret, err := connectionapi.ValidateConnectionAnnotation(ctx, d.apiReader, obj, req.Namespace)
 	if err != nil {
 		return err
 	}
@@ -121,33 +153,27 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 	switch action {
 	case connectionapi.ConnectionActionInject:
 		isDryRun := req.DryRun != nil && *req.DryRun
-		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+		if err := connectionapi.CreateServiceAccountIfNeeded(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
-		if err := performLLMISVCInjection(ctx, llmisvc, newConn, secret); err != nil {
+		if err := performLLMISVCInjection(ctx, modelURI, template, newConn, secret); err != nil {
 			log.Error(err, "failed to inject connection")
 			return err
 		}
 
 	case connectionapi.ConnectionActionRemove:
-		if err := performLLMISVCCleanup(llmisvc, oldConn); err != nil {
-			log.Error(err, "failed to cleanup connection")
-			return err
-		}
+		performLLMISVCCleanup(modelURI, template, oldConn)
 
 	case connectionapi.ConnectionActionReplace:
 		log.V(1).Info("connection changed, performing replacement",
 			"oldType", oldConn.Type, "newType", newConn.Type,
 			"oldSecret", oldConn.SecretName, "newSecret", newConn.SecretName)
-		if err := performLLMISVCCleanup(llmisvc, oldConn); err != nil {
-			log.Error(err, "failed to cleanup old connection")
-			return err
-		}
+		performLLMISVCCleanup(modelURI, template, oldConn)
 		isDryRun := req.DryRun != nil && *req.DryRun
-		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+		if err := connectionapi.CreateServiceAccountIfNeeded(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
-		if err := performLLMISVCInjection(ctx, llmisvc, newConn, secret); err != nil {
+		if err := performLLMISVCInjection(ctx, modelURI, template, newConn, secret); err != nil {
 			log.Error(err, "failed to inject new connection")
 			return err
 		}
@@ -159,7 +185,8 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 	return nil
 }
 
-// performLLMISVCInjection injects connection credentials into the LLMInferenceService using typed field access.
+// performLLMISVCInjection injects connection credentials into an LLMInferenceService using field
+// pointers, making it compatible with both v1alpha1 and v1alpha2.
 //
 // S3 injects serviceAccountName and sets spec.model.uri to s3://{bucket}/{path}.
 // URI sets spec.model.uri from the Secret's https-host or URI key.
@@ -167,14 +194,16 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 //
 // Parameters:
 //   - ctx: context for logging
-//   - llmisvc: the LLMInferenceService to mutate
+//   - modelURI: pointer to the spec.model.uri field
+//   - template: pointer to the spec.template field pointer
 //   - connInfo: validated connection info
 //   - secret: the pre-fetched connection Secret (returned by ValidateConnectionAnnotation)
 //
 // Returns any error from injection.
 func performLLMISVCInjection(
 	ctx context.Context,
-	llmisvc *kservev1alpha2.LLMInferenceService,
+	modelURI *apis.URL,
+	template **corev1.PodSpec,
 	connInfo connectionapi.ConnectionInfo,
 	secret *corev1.Secret,
 ) error {
@@ -182,10 +211,10 @@ func performLLMISVCInjection(
 
 	switch connInfo.Type {
 	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
-		if llmisvc.Spec.Template == nil {
-			llmisvc.Spec.Template = &corev1.PodSpec{}
+		if *template == nil {
+			*template = &corev1.PodSpec{}
 		}
-		connectionapi.InjectOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, connInfo.SecretName)
+		connectionapi.InjectOCIImagePullSecrets(&(*template).ImagePullSecrets, connInfo.SecretName)
 		log.V(1).Info("injected OCI imagePullSecrets", "connection", connInfo.SecretName)
 		// TODO: inject spec.model.uri for OCI
 		return nil
@@ -199,15 +228,15 @@ func performLLMISVCInjection(
 		if err != nil {
 			return fmt.Errorf("invalid URI %q from secret %s: %w", uriValue, connInfo.SecretName, err)
 		}
-		llmisvc.Spec.Model.URI = *parsed
+		*modelURI = *parsed
 		log.V(1).Info("injected URI spec.model.uri", "connection", connInfo.SecretName)
 		return nil
 
 	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
-		if llmisvc.Spec.Template == nil {
-			llmisvc.Spec.Template = &corev1.PodSpec{}
+		if *template == nil {
+			*template = &corev1.PodSpec{}
 		}
-		connectionapi.InjectServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, connInfo.SecretName+"-sa")
+		connectionapi.InjectServiceAccountName(&(*template).ServiceAccountName, connInfo.SecretName+"-sa")
 		log.V(1).Info("injected serviceAccountName", "saName", connInfo.SecretName+"-sa")
 
 		s3URI, err := connectionapi.BuildS3URI(secret, connInfo)
@@ -218,7 +247,7 @@ func performLLMISVCInjection(
 		if err != nil {
 			return fmt.Errorf("invalid S3 URI %q: %w", s3URI, err)
 		}
-		llmisvc.Spec.Model.URI = *parsed
+		*modelURI = *parsed
 		log.V(1).Info("injected S3 spec.model.uri", "connection", connInfo.SecretName)
 		return nil
 
@@ -228,35 +257,34 @@ func performLLMISVCInjection(
 	}
 }
 
-// performLLMISVCCleanup removes previously injected connection credentials from the LLMInferenceService.
+// performLLMISVCCleanup removes previously injected connection credentials using field pointers,
+// making it compatible with both v1alpha1 and v1alpha2.
 //
-// Phase 1: type-specific cleanup of serviceAccountName and imagePullSecrets (typed field access).
-// Phase 2: unconditional removal of spec.model if spec.model.uri is set, using the hybrid
-// unstructured approach required because LLMInferenceServiceSpec.Model is a non-pointer,
-// non-omitempty field whose URI sub-field has type apis.URL (not a plain string).
+// Phase 1: type-specific cleanup of serviceAccountName and imagePullSecrets.
+// Phase 2: zeros spec.model.uri if it was previously set.
 //
 // Parameters:
-//   - llmisvc: the LLMInferenceService to clean up
+//   - modelURI: pointer to the spec.model.uri field
+//   - template: pointer to the spec.template field pointer
 //   - oldConn: connection info from the previous object version
-//
-// Returns any error from cleanup.
 func performLLMISVCCleanup(
-	llmisvc *kservev1alpha2.LLMInferenceService,
+	modelURI *apis.URL,
+	template **corev1.PodSpec,
 	oldConn connectionapi.ConnectionInfo,
-) error {
+) {
 	// Phase 1: type-specific cleanup of typed fields.
 	switch oldConn.Type {
 	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
-		if llmisvc.Spec.Template != nil {
-			connectionapi.RemoveServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, oldConn.SecretName+"-sa")
+		if *template != nil {
+			connectionapi.RemoveServiceAccountName(&(*template).ServiceAccountName, oldConn.SecretName+"-sa")
 		}
 
 	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
-		if llmisvc.Spec.Template != nil {
+		if *template != nil {
 			if oldConn.SecretName != "" {
-				connectionapi.CleanupOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, oldConn.SecretName)
+				connectionapi.CleanupOCIImagePullSecrets(&(*template).ImagePullSecrets, oldConn.SecretName)
 			} else {
-				llmisvc.Spec.Template.ImagePullSecrets = nil
+				(*template).ImagePullSecrets = nil
 			}
 		}
 
@@ -265,65 +293,18 @@ func performLLMISVCCleanup(
 
 	case "":
 		// Unknown type: perform full cleanup of all possible injected typed fields.
-		if llmisvc.Spec.Template != nil {
-			connectionapi.RemoveServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, oldConn.SecretName+"-sa")
+		if *template != nil {
+			connectionapi.RemoveServiceAccountName(&(*template).ServiceAccountName, oldConn.SecretName+"-sa")
 			if oldConn.SecretName != "" {
-				connectionapi.CleanupOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, oldConn.SecretName)
+				connectionapi.CleanupOCIImagePullSecrets(&(*template).ImagePullSecrets, oldConn.SecretName)
 			} else {
-				llmisvc.Spec.Template.ImagePullSecrets = nil
+				(*template).ImagePullSecrets = nil
 			}
 		}
 	}
 
-	// Phase 2: remove spec.model when spec.model.uri is set.
-	// Uses the hybrid unstructured approach because Model is a non-pointer non-omitempty struct
-	// and its URI field type (apis.URL) cannot be zeroed without failing CRD validation.
-	if llmisvc.Spec.Model.URI.String() != "" {
-		if err := removeModelSpec(llmisvc); err != nil {
-			return fmt.Errorf("failed to remove spec.model: %w", err)
-		}
+	// Phase 2: zero spec.model.uri if it was previously set.
+	if modelURI.String() != "" {
+		*modelURI = apis.URL{}
 	}
-
-	return nil
-}
-
-// removeModelSpec removes the entire spec.model field from the LLMInferenceService using a hybrid
-// unstructured approach.
-//
-// This is necessary because LLMInferenceServiceSpec.Model is a non-pointer non-omitempty struct
-// and its URI field has type apis.URL whose zero value fails CRD validation. The approach:
-//  1. Marshals the object to JSON.
-//  2. Unmarshals into an Unstructured map and removes the "spec.model" field.
-//  3. Unmarshals the cleaned JSON back into the typed struct.
-//  4. Replaces the content of llmisvc with the cleaned version.
-//
-// Parameters:
-//   - llmisvc: pointer to the LLMInferenceService whose spec.model should be removed
-//
-// Returns any marshaling/unmarshaling error.
-func removeModelSpec(llmisvc *kservev1alpha2.LLMInferenceService) error {
-	jsonBytes, err := json.Marshal(llmisvc)
-	if err != nil {
-		return fmt.Errorf("failed to marshal LLMInferenceService: %w", err)
-	}
-
-	u := &unstructured.Unstructured{}
-	if err := json.Unmarshal(jsonBytes, &u.Object); err != nil {
-		return fmt.Errorf("failed to unmarshal to unstructured: %w", err)
-	}
-
-	unstructured.RemoveNestedField(u.Object, "spec", "model")
-
-	cleanedJSON, err := json.Marshal(u.Object)
-	if err != nil {
-		return fmt.Errorf("failed to marshal cleaned object: %w", err)
-	}
-
-	cleaned := &kservev1alpha2.LLMInferenceService{}
-	if err := json.Unmarshal(cleanedJSON, cleaned); err != nil {
-		return fmt.Errorf("failed to unmarshal cleaned object back to typed struct: %w", err)
-	}
-
-	*llmisvc = *cleaned
-	return nil
 }

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
@@ -124,13 +124,13 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
-		if err := performLLMISVCInjection(ctx, req, llmisvc, newConn, secret); err != nil {
+		if err := performLLMISVCInjection(ctx, llmisvc, newConn, secret); err != nil {
 			log.Error(err, "failed to inject connection")
 			return err
 		}
 
 	case connectionapi.ConnectionActionRemove:
-		if err := performLLMISVCCleanup(req, llmisvc, oldConn); err != nil {
+		if err := performLLMISVCCleanup(llmisvc, oldConn); err != nil {
 			log.Error(err, "failed to cleanup connection")
 			return err
 		}
@@ -139,7 +139,7 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 		log.V(1).Info("connection changed, performing replacement",
 			"oldType", oldConn.Type, "newType", newConn.Type,
 			"oldSecret", oldConn.SecretName, "newSecret", newConn.SecretName)
-		if err := performLLMISVCCleanup(req, llmisvc, oldConn); err != nil {
+		if err := performLLMISVCCleanup(llmisvc, oldConn); err != nil {
 			log.Error(err, "failed to cleanup old connection")
 			return err
 		}
@@ -147,7 +147,7 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
-		if err := performLLMISVCInjection(ctx, req, llmisvc, newConn, secret); err != nil {
+		if err := performLLMISVCInjection(ctx, llmisvc, newConn, secret); err != nil {
 			log.Error(err, "failed to inject new connection")
 			return err
 		}
@@ -167,7 +167,6 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 //
 // Parameters:
 //   - ctx: context for logging
-//   - req: the admission request (carries namespace)
 //   - llmisvc: the LLMInferenceService to mutate
 //   - connInfo: validated connection info
 //   - secret: the pre-fetched connection Secret (returned by ValidateConnectionAnnotation)
@@ -175,7 +174,6 @@ func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj ru
 // Returns any error from injection.
 func performLLMISVCInjection(
 	ctx context.Context,
-	req admission.Request,
 	llmisvc *kservev1alpha2.LLMInferenceService,
 	connInfo connectionapi.ConnectionInfo,
 	secret *corev1.Secret,
@@ -238,13 +236,11 @@ func performLLMISVCInjection(
 // non-omitempty field whose URI sub-field has type apis.URL (not a plain string).
 //
 // Parameters:
-//   - req: the admission request (used for namespace in log messages)
 //   - llmisvc: the LLMInferenceService to clean up
 //   - oldConn: connection info from the previous object version
 //
 // Returns any error from cleanup.
 func performLLMISVCCleanup(
-	req admission.Request,
 	llmisvc *kservev1alpha2.LLMInferenceService,
 	oldConn connectionapi.ConnectionInfo,
 ) error {

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"knative.dev/pkg/apis"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+)
+
+// nolint:unused
+var llmisvclog = logf.Log.WithName("llminferenceservice-resource")
+
+// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1alpha2-llminferenceservice,mutating=true,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1;v1alpha2,name=connection-llmisvc.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
+
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create
+
+// LLMInferenceServiceCustomDefaulter injects ConnectionsAPI credentials into LLMInferenceService resources.
+type LLMInferenceServiceCustomDefaulter struct {
+	client    client.Client
+	apiReader client.Reader
+}
+
+var _ webhook.CustomDefaulter = &LLMInferenceServiceCustomDefaulter{}
+
+// SetupLLMInferenceServiceWebhookWithManager registers the LLMInferenceService mutating webhook with the manager.
+//
+// Parameters:
+//   - mgr: the controller-runtime manager
+//
+// Returns any registration error.
+func SetupLLMInferenceServiceWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&kservev1alpha2.LLMInferenceService{}).
+		WithDefaulter(&LLMInferenceServiceCustomDefaulter{
+			client:    mgr.GetClient(),
+			apiReader: mgr.GetAPIReader(),
+		}).
+		Complete()
+}
+
+// Default implements webhook.CustomDefaulter. It applies ConnectionsAPI injection or cleanup to the
+// LLMInferenceService based on the opendatahub.io/connections annotation.
+//
+// Parameters:
+//   - ctx: context carrying the admission request (via admission.RequestFromContext)
+//   - obj: the LLMInferenceService object to mutate
+//
+// Returns any error that should block admission.
+func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	llmisvc, ok := obj.(*kservev1alpha2.LLMInferenceService)
+	if !ok {
+		return fmt.Errorf("expected a LLMInferenceService object but got %T", obj)
+	}
+	logger := llmisvclog.WithValues("name", llmisvc.GetName())
+	logger.Info("Defaulting for LLMInferenceService")
+
+	if llmisvc.DeletionTimestamp != nil {
+		return nil
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get admission request from context: %w", err)
+	}
+
+	newConn, secret, err := connectionapi.ValidateConnectionAnnotation(ctx, d.apiReader, llmisvc, req.Namespace)
+	if err != nil {
+		return err
+	}
+
+	var oldConn connectionapi.ConnectionInfo
+	var action connectionapi.ConnectionAction
+
+	if req.Operation == admissionv1.Update {
+		oldConn, err = connectionapi.GetOldConnectionInfo(ctx, req, d.apiReader)
+		if err != nil {
+			return err
+		}
+		action = connectionapi.DetermineAction(oldConn, newConn)
+	} else {
+		if newConn.SecretName == "" {
+			action = connectionapi.ConnectionActionNone
+		} else {
+			action = connectionapi.ConnectionActionInject
+		}
+	}
+
+	log := logf.FromContext(ctx)
+
+	switch action {
+	case connectionapi.ConnectionActionInject:
+		isDryRun := req.DryRun != nil && *req.DryRun
+		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+			return err
+		}
+		if err := performLLMISVCInjection(ctx, req, llmisvc, newConn, secret); err != nil {
+			log.Error(err, "failed to inject connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionRemove:
+		if err := performLLMISVCCleanup(req, llmisvc, oldConn); err != nil {
+			log.Error(err, "failed to cleanup connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionReplace:
+		log.V(1).Info("connection changed, performing replacement",
+			"oldType", oldConn.Type, "newType", newConn.Type,
+			"oldSecret", oldConn.SecretName, "newSecret", newConn.SecretName)
+		if err := performLLMISVCCleanup(req, llmisvc, oldConn); err != nil {
+			log.Error(err, "failed to cleanup old connection")
+			return err
+		}
+		isDryRun := req.DryRun != nil && *req.DryRun
+		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+			return err
+		}
+		if err := performLLMISVCInjection(ctx, req, llmisvc, newConn, secret); err != nil {
+			log.Error(err, "failed to inject new connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionNone:
+		// no-op
+	}
+
+	return nil
+}
+
+// performLLMISVCInjection injects connection credentials into the LLMInferenceService using typed field access.
+//
+// S3 injects serviceAccountName and sets spec.model.uri to s3://{bucket}/{path}.
+// URI sets spec.model.uri from the Secret's https-host or URI key.
+// OCI appends to spec.template.imagePullSecrets.
+//
+// Parameters:
+//   - ctx: context for logging
+//   - req: the admission request (carries namespace)
+//   - llmisvc: the LLMInferenceService to mutate
+//   - connInfo: validated connection info
+//   - secret: the pre-fetched connection Secret (returned by ValidateConnectionAnnotation)
+//
+// Returns any error from injection.
+func performLLMISVCInjection(
+	ctx context.Context,
+	req admission.Request,
+	llmisvc *kservev1alpha2.LLMInferenceService,
+	connInfo connectionapi.ConnectionInfo,
+	secret *corev1.Secret,
+) error {
+	log := logf.FromContext(ctx)
+
+	switch connInfo.Type {
+	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
+		if llmisvc.Spec.Template == nil {
+			llmisvc.Spec.Template = &corev1.PodSpec{}
+		}
+		connectionapi.InjectOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, connInfo.SecretName)
+		log.V(1).Info("injected OCI imagePullSecrets", "connection", connInfo.SecretName)
+		// TODO: inject spec.model.uri for OCI
+		return nil
+
+	case connectionapi.ConnectionTypeProtocolURI.String(), connectionapi.ConnectionTypeRefURI.String():
+		uriValue, err := connectionapi.GetURIValue(secret)
+		if err != nil {
+			return fmt.Errorf("failed to get URI value: %w", err)
+		}
+		parsed, err := apis.ParseURL(uriValue)
+		if err != nil {
+			return fmt.Errorf("invalid URI %q from secret %s: %w", uriValue, connInfo.SecretName, err)
+		}
+		llmisvc.Spec.Model.URI = *parsed
+		log.V(1).Info("injected URI spec.model.uri", "connection", connInfo.SecretName)
+		return nil
+
+	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
+		if llmisvc.Spec.Template == nil {
+			llmisvc.Spec.Template = &corev1.PodSpec{}
+		}
+		connectionapi.InjectServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, connInfo.SecretName+"-sa")
+		log.V(1).Info("injected serviceAccountName", "saName", connInfo.SecretName+"-sa")
+
+		s3URI, err := connectionapi.BuildS3URI(secret, connInfo)
+		if err != nil {
+			return fmt.Errorf("failed to build S3 URI: %w", err)
+		}
+		parsed, err := apis.ParseURL(s3URI)
+		if err != nil {
+			return fmt.Errorf("invalid S3 URI %q: %w", s3URI, err)
+		}
+		llmisvc.Spec.Model.URI = *parsed
+		log.V(1).Info("injected S3 spec.model.uri", "connection", connInfo.SecretName)
+		return nil
+
+	default:
+		log.V(1).Info("unknown connection type, skipping injection", "connectionType", connInfo.Type)
+		return nil
+	}
+}
+
+// performLLMISVCCleanup removes previously injected connection credentials from the LLMInferenceService.
+//
+// Phase 1: type-specific cleanup of serviceAccountName and imagePullSecrets (typed field access).
+// Phase 2: unconditional removal of spec.model if spec.model.uri is set, using the hybrid
+// unstructured approach required because LLMInferenceServiceSpec.Model is a non-pointer,
+// non-omitempty field whose URI sub-field has type apis.URL (not a plain string).
+//
+// Parameters:
+//   - req: the admission request (used for namespace in log messages)
+//   - llmisvc: the LLMInferenceService to clean up
+//   - oldConn: connection info from the previous object version
+//
+// Returns any error from cleanup.
+func performLLMISVCCleanup(
+	req admission.Request,
+	llmisvc *kservev1alpha2.LLMInferenceService,
+	oldConn connectionapi.ConnectionInfo,
+) error {
+	// Phase 1: type-specific cleanup of typed fields.
+	switch oldConn.Type {
+	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
+		if llmisvc.Spec.Template != nil {
+			connectionapi.RemoveServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, oldConn.SecretName+"-sa")
+		}
+
+	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
+		if llmisvc.Spec.Template != nil {
+			if oldConn.SecretName != "" {
+				connectionapi.CleanupOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, oldConn.SecretName)
+			} else {
+				llmisvc.Spec.Template.ImagePullSecrets = nil
+			}
+		}
+
+	case connectionapi.ConnectionTypeProtocolURI.String(), connectionapi.ConnectionTypeRefURI.String():
+		// URI type only uses spec.model.uri, handled in Phase 2.
+
+	case "":
+		// Unknown type: perform full cleanup of all possible injected typed fields.
+		if llmisvc.Spec.Template != nil {
+			connectionapi.RemoveServiceAccountName(&llmisvc.Spec.Template.ServiceAccountName, oldConn.SecretName+"-sa")
+			if oldConn.SecretName != "" {
+				connectionapi.CleanupOCIImagePullSecrets(&llmisvc.Spec.Template.ImagePullSecrets, oldConn.SecretName)
+			} else {
+				llmisvc.Spec.Template.ImagePullSecrets = nil
+			}
+		}
+	}
+
+	// Phase 2: remove spec.model when spec.model.uri is set.
+	// Uses the hybrid unstructured approach because Model is a non-pointer non-omitempty struct
+	// and its URI field type (apis.URL) cannot be zeroed without failing CRD validation.
+	if llmisvc.Spec.Model.URI.String() != "" {
+		if err := removeModelSpec(llmisvc); err != nil {
+			return fmt.Errorf("failed to remove spec.model: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// removeModelSpec removes the entire spec.model field from the LLMInferenceService using a hybrid
+// unstructured approach.
+//
+// This is necessary because LLMInferenceServiceSpec.Model is a non-pointer non-omitempty struct
+// and its URI field has type apis.URL whose zero value fails CRD validation. The approach:
+//  1. Marshals the object to JSON.
+//  2. Unmarshals into an Unstructured map and removes the "spec.model" field.
+//  3. Unmarshals the cleaned JSON back into the typed struct.
+//  4. Replaces the content of llmisvc with the cleaned version.
+//
+// Parameters:
+//   - llmisvc: pointer to the LLMInferenceService whose spec.model should be removed
+//
+// Returns any marshaling/unmarshaling error.
+func removeModelSpec(llmisvc *kservev1alpha2.LLMInferenceService) error {
+	jsonBytes, err := json.Marshal(llmisvc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal LLMInferenceService: %w", err)
+	}
+
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(jsonBytes, &u.Object); err != nil {
+		return fmt.Errorf("failed to unmarshal to unstructured: %w", err)
+	}
+
+	unstructured.RemoveNestedField(u.Object, "spec", "model")
+
+	cleanedJSON, err := json.Marshal(u.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cleaned object: %w", err)
+	}
+
+	cleaned := &kservev1alpha2.LLMInferenceService{}
+	if err := json.Unmarshal(cleanedJSON, cleaned); err != nil {
+		return fmt.Errorf("failed to unmarshal cleaned object back to typed struct: %w", err)
+	}
+
+	*llmisvc = *cleaned
+	return nil
+}

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
@@ -71,11 +71,11 @@ func newLLMDefaulter(cli client.Client) *LLMInferenceServiceCustomDefaulter {
 }
 
 // llmAdmissionCtx returns a context carrying an admission request.
-func llmAdmissionCtx(op admissionv1.Operation, ns string, oldObj runtime.Object, dryRun bool) context.Context {
+func llmAdmissionCtx(op admissionv1.Operation, oldObj runtime.Object, dryRun bool) context.Context {
 	req := admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			Operation: op,
-			Namespace: ns,
+			Namespace: llmNS,
 		},
 	}
 	if dryRun {
@@ -90,22 +90,22 @@ func llmAdmissionCtx(op admissionv1.Operation, ns string, oldObj runtime.Object,
 }
 
 // buildLLMISVC creates a typed LLMInferenceService for testing.
-func buildLLMISVC(name, ns string, annotations map[string]string) *kservev1alpha2.LLMInferenceService {
+func buildLLMISVC(annotations map[string]string) *kservev1alpha2.LLMInferenceService {
 	return &kservev1alpha2.LLMInferenceService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   ns,
+			Name:        llmISVCName,
+			Namespace:   llmNS,
 			Annotations: annotations,
 		},
 	}
 }
 
 // buildLLMSecret creates a Secret with connection-type-protocol annotation.
-func buildLLMSecret(name, ns, connType string, data map[string][]byte) *corev1.Secret {
+func buildLLMSecret(name, connType string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: ns,
+			Namespace: llmNS,
 			Annotations: map[string]string{
 				connectionapi.AnnotationConnectionTypeProtocol: connType,
 			},
@@ -146,8 +146,8 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		It("skips injection when no connection annotation is set", func() {
 			cli := newLLMFakeClient()
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			llmisvc := buildLLMISVC(nil)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
@@ -160,10 +160,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			}
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: "secret1",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
@@ -181,10 +181,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			}
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: "secret1",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
@@ -193,10 +193,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		It("returns error when referenced secret does not exist", func() {
 			cli := newLLMFakeClient()
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: "missing-secret",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			err := d.Default(admCtx, llmisvc)
 			Expect(err).To(HaveOccurred())
@@ -204,16 +204,16 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("skips injection when resource is marked for deletion", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmS3SecretName,
 			})
 			now := metav1.Now()
 			llmisvc.DeletionTimestamp = &now
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template).To(BeNil())
@@ -222,15 +222,15 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("S3 connection type", func() {
 
 			It("creates SA and injects spec.model.uri", func() {
-				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				secret := buildLLMSecret(llmS3SecretName, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections:    llmS3SecretName,
 					connectionapi.AnnotationConnectionPath: "models/llama",
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Template).ToNot(BeNil())
@@ -245,16 +245,16 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("initializes Template when nil before S3 inject", func() {
-				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				secret := buildLLMSecret(llmS3SecretName, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections:    llmS3SecretName,
 					connectionapi.AnnotationConnectionPath: "models/llama",
 				})
 				Expect(llmisvc.Spec.Template).To(BeNil())
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Template).ToNot(BeNil())
@@ -262,15 +262,15 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("injects URI but does not create SA on dry-run", func() {
-				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				secret := buildLLMSecret(llmS3SecretName, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections:    llmS3SecretName,
 					connectionapi.AnnotationConnectionPath: "models/llama",
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, true) // dryRun=true
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, true) // dryRun=true
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://my-bucket/models/llama"))
@@ -284,14 +284,14 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("returns error when bucket key is missing", func() {
-				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3", map[string][]byte{})
+				secret := buildLLMSecret(llmS3SecretName, "s3", map[string][]byte{})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections:    llmS3SecretName,
 					connectionapi.AnnotationConnectionPath: "models/v1",
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				err := d.Default(admCtx, llmisvc)
 				Expect(err).To(HaveOccurred())
@@ -299,15 +299,15 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("returns error when connection-path annotation is missing", func() {
-				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				secret := buildLLMSecret(llmS3SecretName, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmS3SecretName,
 					// no AnnotationConnectionPath
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				err := d.Default(admCtx, llmisvc)
 				Expect(err).To(HaveOccurred())
@@ -318,41 +318,41 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("URI connection type", func() {
 
 			It("injects spec.model.uri from https-host key", func() {
-				secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				secret := buildLLMSecret(llmURISecretName, "uri",
 					map[string][]byte{"https-host": []byte("https://hf.co/model")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmURISecretName,
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://hf.co/model"))
 			})
 
 			It("injects spec.model.uri from URI key", func() {
-				secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				secret := buildLLMSecret(llmURISecretName, "uri",
 					map[string][]byte{"URI": []byte("hf://facebook/model")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmURISecretName,
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("hf://facebook/model"))
 			})
 
 			It("returns error when secret has neither URI key", func() {
-				secret := buildLLMSecret(llmURISecretName, llmNS, "uri", map[string][]byte{})
+				secret := buildLLMSecret(llmURISecretName, "uri", map[string][]byte{})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmURISecretName,
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				err := d.Default(admCtx, llmisvc)
 				Expect(err).To(HaveOccurred())
@@ -363,13 +363,13 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("OCI connection type", func() {
 
 			It("injects imagePullSecrets", func() {
-				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmOCISecretName,
 				})
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Template).ToNot(BeNil())
@@ -379,30 +379,30 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("initializes Template when nil before OCI inject", func() {
-				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmOCISecretName,
 				})
 				Expect(llmisvc.Spec.Template).To(BeNil())
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Template).ToNot(BeNil())
 			})
 
 			It("does not duplicate imagePullSecrets when already present", func() {
-				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
-				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				llmisvc := buildLLMISVC(map[string]string{
 					connectionapi.AnnotationConnections: llmOCISecretName,
 				})
 				llmisvc.Spec.Template = &corev1.PodSpec{
 					ImagePullSecrets: []corev1.LocalObjectReference{{Name: llmOCISecretName}},
 				}
-				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+				admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 				Expect(llmisvc.Spec.Template.ImagePullSecrets).To(HaveLen(1))
@@ -413,17 +413,17 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("UPDATE operations — removal (annotation removed)", func() {
 
 		It("clears SA and removes spec.model on S3 removal", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmS3SecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
 			// Model.URI will be removed by cleanup
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ServiceAccountName).To(BeEmpty())
@@ -432,32 +432,32 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("removes spec.model on URI removal", func() {
-			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+			secret := buildLLMSecret(llmURISecretName, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			newLLM := buildLLMISVC(nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
 		})
 
 		It("cleans up imagePullSecrets on OCI removal", func() {
-			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmOCISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: llmOCISecretName}},
 			}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ImagePullSecrets).To(BeEmpty())
@@ -465,11 +465,11 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 
 		It("clears entire imagePullSecrets when old SecretName is empty on OCI cleanup", func() {
 			// Direct call: corner case not reachable through the normal webhook flow
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			llmisvc := buildLLMISVC(nil)
 			llmisvc.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
 			}
-			err := performLLMISVCCleanup(admission.Request{}, llmisvc, connectionapi.ConnectionInfo{
+			err := performLLMISVCCleanup(llmisvc, connectionapi.ConnectionInfo{
 				SecretName: "",
 				Type:       connectionapi.ConnectionTypeProtocolOCI.String(),
 			})
@@ -480,15 +480,15 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		It("performs full cleanup when old secret has been deleted", func() {
 			cli := newLLMFakeClient()
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: "deleted-secret",
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{
 				ServiceAccountName: "deleted-secret-sa",
 				ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "deleted-secret"}},
 			}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ServiceAccountName).To(BeEmpty())
@@ -496,16 +496,16 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves user-set SA name when removing S3 connection", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmS3SecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: "user-custom-sa"}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal("user-custom-sa"))
@@ -515,20 +515,20 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("UPDATE operations — replacement", func() {
 
 		It("replaces URI with S3 when connection type changes", func() {
-			uriSecret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+			uriSecret := buildLLMSecret(llmURISecretName, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
-			s3Secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			s3Secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(uriSecret, s3Secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			newLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template).ToNot(BeNil())
@@ -537,19 +537,19 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("replaces S3 fields when connection path changes", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "old",
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			newLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "new",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Model.URI.String()).To(Equal("s3://b/new"))
@@ -560,15 +560,15 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 
 		It("zeros spec.model.uri after removal", func() {
 			// Trigger cleanup via Update removal
-			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+			secret := buildLLMSecret(llmURISecretName, "uri",
 				map[string][]byte{"URI": []byte("https://hf.co/model")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			newLLM := buildLLMISVC(nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			// After removeModelSpec, Model.URI is zero-valued
@@ -576,16 +576,16 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves other spec fields after model removal", func() {
-			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+			secret := buildLLMSecret(llmURISecretName, "uri",
 				map[string][]byte{"URI": []byte("https://hf.co/model")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: "some-sa"}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			// Model URI cleared but Template preserved
@@ -602,11 +602,11 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "m",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
@@ -618,10 +618,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://x"))
@@ -631,10 +631,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			secret := buildLLMSecretWithRef(llmOCISecretName, llmNS, "oci-v1", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmOCISecretName,
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(ConsistOf(
@@ -646,31 +646,31 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Utility edge cases exercised through the webhook", func() {
 
 		It("prefers https-host over URI key when both present", func() {
-			secret := buildLLMSecret(llmURISecretName, llmNS, "uri", map[string][]byte{
+			secret := buildLLMSecret(llmURISecretName, "uri", map[string][]byte{
 				"https-host": []byte("https://preferred.com"),
 				"URI":        []byte("https://fallback.com"),
 			})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://preferred.com"))
 		})
 
 		It("returns error when bucket value is empty", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			err := d.Default(admCtx, llmisvc)
 			Expect(err).To(HaveOccurred())
@@ -678,19 +678,19 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("does not trigger replacement when URI path annotation changes", func() {
-			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+			secret := buildLLMSecret(llmURISecretName, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmURISecretName,
 				connectionapi.AnnotationConnectionPath: "old",
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			newLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmURISecretName,
 				connectionapi.AnnotationConnectionPath: "new",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			// action=none for URI when only path annotation changes
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
@@ -701,17 +701,17 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		It("cleans up imagePullSecrets by name when old secret is deleted", func() {
 			cli := newLLMFakeClient()
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: "deleted-secret",
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{Name: "deleted-secret"},
 					{Name: "other"},
 				},
 			}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			// Unknown type: cleanup by name removes "deleted-secret", preserves "other"
@@ -722,11 +722,11 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 
 		It("clears entire imagePullSecrets when old SecretName is empty", func() {
 			// Direct call: corner case unreachable through normal webhook flow
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			llmisvc := buildLLMISVC(nil)
 			llmisvc.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
 			}
-			err := performLLMISVCCleanup(admission.Request{}, llmisvc, connectionapi.ConnectionInfo{
+			err := performLLMISVCCleanup(llmisvc, connectionapi.ConnectionInfo{
 				SecretName: "",
 				Type:       "",
 			})
@@ -748,11 +748,11 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			}
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    "secret1",
 				connectionapi.AnnotationConnectionPath: "m",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			// S3 injection applied (not OCI)
@@ -762,7 +762,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("succeeds when SA already exists (idempotent creation)", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			existingSA := &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
@@ -772,27 +772,27 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			}
 			cli := newLLMFakeClient(secret, existingSA)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
 		})
 
 		It("does not overwrite user-set SA name on S3 CREATE", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
 			llmisvc.Spec.Template = &corev1.PodSpec{ServiceAccountName: "user-custom-sa"}
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal("user-custom-sa"))
@@ -800,16 +800,16 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
-			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			llmisvc := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmOCISecretName,
 			})
 			llmisvc.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "existing-secret"}},
 			}
-			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
 			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
 			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(ConsistOf(
@@ -819,20 +819,20 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves other imagePullSecrets entries on OCI removal", func() {
-			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections: llmOCISecretName,
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{
 					{Name: "other"},
 					{Name: llmOCISecretName},
 				},
 			}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ImagePullSecrets).To(ConsistOf(
@@ -843,9 +843,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		It("produces no mutation when neither old nor new has annotation", func() {
 			cli := newLLMFakeClient()
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, nil)
-			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			oldLLM := buildLLMISVC(nil)
+			newLLM := buildLLMISVC(nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template).To(BeNil())
@@ -853,22 +853,22 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("triggers replacement when same S3 type but different secret name", func() {
-			oldSecret := buildLLMSecret(llmOldSecretName, llmNS, "s3",
+			oldSecret := buildLLMSecret(llmOldSecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
-			newSecret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			newSecret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(oldSecret, newSecret)
 			d := newLLMDefaulter(cli)
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			oldLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmOldSecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+			newLLM := buildLLMISVC(map[string]string{
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmOldSecretName + "-sa"}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
@@ -876,7 +876,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("produces no mutation for identical S3 connection", func() {
-			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+			secret := buildLLMSecret(llmS3SecretName, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -884,11 +884,11 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 				connectionapi.AnnotationConnections:    llmS3SecretName,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			}
-			oldLLM := buildLLMISVC(llmISVCName, llmNS, annots)
+			oldLLM := buildLLMISVC(annots)
 			oldLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
-			newLLM := buildLLMISVC(llmISVCName, llmNS, annots)
+			newLLM := buildLLMISVC(annots)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
-			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			// action=none: no change
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
@@ -897,7 +897,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 
 		// Ensure marshalSpec helper works to prevent regressions
 		It("marshalSpec helper returns a usable spec map", func() {
-			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			llmisvc := buildLLMISVC(nil)
 			spec := marshalSpec(llmisvc)
 			Expect(spec).ToNot(BeNil())
 		})

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
@@ -33,7 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"knative.dev/pkg/apis"
+
 	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
 const (
@@ -97,34 +100,6 @@ func buildLLMISVC(annotations map[string]string) *kservev1alpha2.LLMInferenceSer
 			Namespace:   llmNS,
 			Annotations: annotations,
 		},
-	}
-}
-
-// buildLLMSecret creates a Secret with connection-type-protocol annotation.
-func buildLLMSecret(name, connType string, data map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: llmNS,
-			Annotations: map[string]string{
-				connectionapi.AnnotationConnectionTypeProtocol: connType,
-			},
-		},
-		Data: data,
-	}
-}
-
-// buildLLMSecretWithRef creates a Secret with the deprecated connection-type-ref annotation.
-func buildLLMSecretWithRef(name, ns, refType string, data map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-			Annotations: map[string]string{
-				connectionapi.AnnotationConnectionTypeRef: refType,
-			},
-		},
-		Data: data,
 	}
 }
 
@@ -204,7 +179,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("skips injection when resource is marked for deletion", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -222,7 +197,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("S3 connection type", func() {
 
 			It("creates SA and injects spec.model.uri", func() {
-				secret := buildLLMSecret(llmS3SecretName, "s3",
+				secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -245,7 +220,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("initializes Template when nil before S3 inject", func() {
-				secret := buildLLMSecret(llmS3SecretName, "s3",
+				secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -262,7 +237,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("injects URI but does not create SA on dry-run", func() {
-				secret := buildLLMSecret(llmS3SecretName, "s3",
+				secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -284,7 +259,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("returns error when bucket key is missing", func() {
-				secret := buildLLMSecret(llmS3SecretName, "s3", map[string][]byte{})
+				secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3", map[string][]byte{})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
 				llmisvc := buildLLMISVC(map[string]string{
@@ -299,7 +274,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("returns error when connection-path annotation is missing", func() {
-				secret := buildLLMSecret(llmS3SecretName, "s3",
+				secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 					map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -318,7 +293,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("URI connection type", func() {
 
 			It("injects spec.model.uri from https-host key", func() {
-				secret := buildLLMSecret(llmURISecretName, "uri",
+				secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 					map[string][]byte{"https-host": []byte("https://hf.co/model")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -332,7 +307,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("injects spec.model.uri from URI key", func() {
-				secret := buildLLMSecret(llmURISecretName, "uri",
+				secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 					map[string][]byte{"URI": []byte("hf://facebook/model")})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
@@ -346,7 +321,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("returns error when secret has neither URI key", func() {
-				secret := buildLLMSecret(llmURISecretName, "uri", map[string][]byte{})
+				secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri", map[string][]byte{})
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
 				llmisvc := buildLLMISVC(map[string]string{
@@ -363,7 +338,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		Context("OCI connection type", func() {
 
 			It("injects imagePullSecrets", func() {
-				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+				secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
 				llmisvc := buildLLMISVC(map[string]string{
@@ -379,7 +354,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("initializes Template when nil before OCI inject", func() {
-				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+				secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
 				llmisvc := buildLLMISVC(map[string]string{
@@ -393,7 +368,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("does not duplicate imagePullSecrets when already present", func() {
-				secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+				secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 				cli := newLLMFakeClient(secret)
 				d := newLLMDefaulter(cli)
 				llmisvc := buildLLMISVC(map[string]string{
@@ -413,7 +388,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("UPDATE operations — removal (annotation removed)", func() {
 
 		It("clears SA and removes spec.model on S3 removal", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -422,7 +397,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
-			// Model.URI will be removed by cleanup
+			s3URI, parseErr := apis.ParseURL("s3://my-bucket/models")
+			Expect(parseErr).ToNot(HaveOccurred())
+			newLLM.Spec.Model.URI = *s3URI
 			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
@@ -432,7 +409,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("removes spec.model on URI removal", func() {
-			secret := buildLLMSecret(llmURISecretName, "uri",
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -440,6 +417,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
 			newLLM := buildLLMISVC(nil)
+			preURI, parseErr := apis.ParseURL("https://x")
+			Expect(parseErr).ToNot(HaveOccurred())
+			newLLM.Spec.Model.URI = *preURI
 			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
@@ -447,7 +427,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("cleans up imagePullSecrets on OCI removal", func() {
-			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+			secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
 			oldLLM := buildLLMISVC(map[string]string{
@@ -469,11 +449,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			llmisvc.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
 			}
-			err := performLLMISVCCleanup(llmisvc, connectionapi.ConnectionInfo{
+			performLLMISVCCleanup(&llmisvc.Spec.Model.URI, &llmisvc.Spec.Template, connectionapi.ConnectionInfo{
 				SecretName: "",
 				Type:       connectionapi.ConnectionTypeProtocolOCI.String(),
 			})
-			Expect(err).ToNot(HaveOccurred())
 			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(BeNil())
 		})
 
@@ -496,7 +475,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves user-set SA name when removing S3 connection", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -515,9 +494,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("UPDATE operations — replacement", func() {
 
 		It("replaces URI with S3 when connection type changes", func() {
-			uriSecret := buildLLMSecret(llmURISecretName, "uri",
+			uriSecret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
-			s3Secret := buildLLMSecret(llmS3SecretName, "s3",
+			s3Secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(uriSecret, s3Secret)
 			d := newLLMDefaulter(cli)
@@ -537,7 +516,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("replaces S3 fields when connection path changes", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -560,7 +539,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 
 		It("zeros spec.model.uri after removal", func() {
 			// Trigger cleanup via Update removal
-			secret := buildLLMSecret(llmURISecretName, "uri",
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 				map[string][]byte{"URI": []byte("https://hf.co/model")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -568,15 +547,18 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 				connectionapi.AnnotationConnections: llmURISecretName,
 			})
 			newLLM := buildLLMISVC(nil)
+			preURI, parseErr := apis.ParseURL("https://hf.co/model")
+			Expect(parseErr).ToNot(HaveOccurred())
+			newLLM.Spec.Model.URI = *preURI
 			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
-			// After removeModelSpec, Model.URI is zero-valued
+			// After cleanup, Model.URI is zero-valued
 			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
 		})
 
 		It("preserves other spec fields after model removal", func() {
-			secret := buildLLMSecret(llmURISecretName, "uri",
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 				map[string][]byte{"URI": []byte("https://hf.co/model")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -585,6 +567,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 			newLLM := buildLLMISVC(nil)
 			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: "some-sa"}
+			preURI, parseErr := apis.ParseURL("https://hf.co/model")
+			Expect(parseErr).ToNot(HaveOccurred())
+			newLLM.Spec.Model.URI = *preURI
 			admCtx := llmAdmissionCtx(admissionv1.Update, oldLLM, false)
 
 			Expect(d.Default(admCtx, newLLM)).To(Succeed())
@@ -598,7 +583,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Backward compatibility (deprecated connection-type-ref)", func() {
 
 		It("injects S3 fields using connection-type-ref: s3", func() {
-			secret := buildLLMSecretWithRef(llmS3SecretName, llmNS, "s3",
+			secret := testutils.BuildSecretWithRef(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -614,7 +599,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("injects spec.model.uri using connection-type-ref: uri-v1", func() {
-			secret := buildLLMSecretWithRef(llmURISecretName, llmNS, "uri-v1",
+			secret := testutils.BuildSecretWithRef(llmURISecretName, llmNS, "uri-v1",
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -628,7 +613,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("injects imagePullSecrets using connection-type-ref: oci-v1", func() {
-			secret := buildLLMSecretWithRef(llmOCISecretName, llmNS, "oci-v1", nil)
+			secret := testutils.BuildSecretWithRef(llmOCISecretName, llmNS, "oci-v1", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
 			llmisvc := buildLLMISVC(map[string]string{
@@ -646,7 +631,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Utility edge cases exercised through the webhook", func() {
 
 		It("prefers https-host over URI key when both present", func() {
-			secret := buildLLMSecret(llmURISecretName, "uri", map[string][]byte{
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri", map[string][]byte{
 				"https-host": []byte("https://preferred.com"),
 				"URI":        []byte("https://fallback.com"),
 			})
@@ -662,7 +647,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("returns error when bucket value is empty", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -678,7 +663,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("does not trigger replacement when URI path annotation changes", func() {
-			secret := buildLLMSecret(llmURISecretName, "uri",
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
 				map[string][]byte{"URI": []byte("https://x")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -726,11 +711,10 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			llmisvc.Spec.Template = &corev1.PodSpec{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
 			}
-			err := performLLMISVCCleanup(llmisvc, connectionapi.ConnectionInfo{
+			performLLMISVCCleanup(&llmisvc.Spec.Model.URI, &llmisvc.Spec.Template, connectionapi.ConnectionInfo{
 				SecretName: "",
 				Type:       "",
 			})
-			Expect(err).ToNot(HaveOccurred())
 			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(BeNil())
 		})
 
@@ -762,7 +746,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("succeeds when SA already exists (idempotent creation)", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			existingSA := &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
@@ -783,7 +767,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("does not overwrite user-set SA name on S3 CREATE", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
@@ -800,7 +784,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
-			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+			secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
 			llmisvc := buildLLMISVC(map[string]string{
@@ -819,7 +803,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves other imagePullSecrets entries on OCI removal", func() {
-			secret := buildLLMSecret(llmOCISecretName, "oci", nil)
+			secret := testutils.BuildSecret(llmOCISecretName, llmNS, "oci", nil)
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)
 			oldLLM := buildLLMISVC(map[string]string{
@@ -853,9 +837,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("triggers replacement when same S3 type but different secret name", func() {
-			oldSecret := buildLLMSecret(llmOldSecretName, "s3",
+			oldSecret := testutils.BuildSecret(llmOldSecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
-			newSecret := buildLLMSecret(llmS3SecretName, "s3",
+			newSecret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(oldSecret, newSecret)
 			d := newLLMDefaulter(cli)
@@ -876,7 +860,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("produces no mutation for identical S3 connection", func() {
-			secret := buildLLMSecret(llmS3SecretName, "s3",
+			secret := testutils.BuildSecret(llmS3SecretName, llmNS, "s3",
 				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
 			cli := newLLMFakeClient(secret)
 			d := newLLMDefaulter(cli)

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -884,6 +885,29 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			llmisvc := buildLLMISVC(nil)
 			spec := marshalSpec(llmisvc)
 			Expect(spec).ToNot(BeNil())
+		})
+	})
+
+	Describe("v1alpha1 API version", func() {
+
+		It("injects URI connection into a v1alpha1 LLMInferenceService", func() {
+			secret := testutils.BuildSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("hf://meta-llama/Llama-4")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := &kservev1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      llmISVCName,
+					Namespace: llmNS,
+					Annotations: map[string]string{
+						connectionapi.AnnotationConnections: llmURISecretName,
+					},
+				},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("hf://meta-llama/Llama-4"))
 		})
 	})
 })

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
@@ -1,0 +1,905 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"encoding/json"
+
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+)
+
+const (
+	llmNS            = "test-ns"
+	llmISVCName      = "test-llmisvc"
+	llmS3SecretName  = "s3-secret"
+	llmURISecretName = "uri-secret"
+	llmOCISecretName = "oci-secret"
+	llmOldSecretName = "old-secret"
+)
+
+// newLLMScheme returns a scheme with core types needed by the fake client.
+func newLLMScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+// newLLMFakeClient creates a fake client pre-loaded with objects.
+func newLLMFakeClient(objs ...client.Object) client.Client {
+	s := newLLMScheme()
+	b := fake.NewClientBuilder().WithScheme(s)
+	if len(objs) > 0 {
+		b = b.WithObjects(objs...)
+	}
+	return b.Build()
+}
+
+// newLLMDefaulter instantiates LLMInferenceServiceCustomDefaulter with a fake client.
+func newLLMDefaulter(cli client.Client) *LLMInferenceServiceCustomDefaulter {
+	return &LLMInferenceServiceCustomDefaulter{
+		client:    cli,
+		apiReader: cli,
+	}
+}
+
+// llmAdmissionCtx returns a context carrying an admission request.
+func llmAdmissionCtx(op admissionv1.Operation, ns string, oldObj runtime.Object, dryRun bool) context.Context {
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: op,
+			Namespace: ns,
+		},
+	}
+	if dryRun {
+		t := true
+		req.DryRun = &t
+	}
+	if oldObj != nil {
+		raw, _ := json.Marshal(oldObj)
+		req.OldObject = runtime.RawExtension{Raw: raw}
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// buildLLMISVC creates a typed LLMInferenceService for testing.
+func buildLLMISVC(name, ns string, annotations map[string]string) *kservev1alpha2.LLMInferenceService {
+	return &kservev1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Annotations: annotations,
+		},
+	}
+}
+
+// buildLLMSecret creates a Secret with connection-type-protocol annotation.
+func buildLLMSecret(name, ns, connType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				connectionapi.AnnotationConnectionTypeProtocol: connType,
+			},
+		},
+		Data: data,
+	}
+}
+
+// buildLLMSecretWithRef creates a Secret with the deprecated connection-type-ref annotation.
+func buildLLMSecretWithRef(name, ns, refType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Annotations: map[string]string{
+				connectionapi.AnnotationConnectionTypeRef: refType,
+			},
+		},
+		Data: data,
+	}
+}
+
+// marshalSpec marshals the LLMInferenceService and returns spec as map[string]any.
+func marshalSpec(llmisvc *kservev1alpha2.LLMInferenceService) map[string]any {
+	raw, err := json.Marshal(llmisvc)
+	Expect(err).ToNot(HaveOccurred())
+	var m map[string]any
+	Expect(json.Unmarshal(raw, &m)).To(Succeed())
+	spec, ok := m["spec"].(map[string]any)
+	Expect(ok).To(BeTrue(), "spec should be a map")
+	return spec
+}
+
+var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
+
+	Describe("CREATE operations", func() {
+
+		It("skips injection when no connection annotation is set", func() {
+			cli := newLLMFakeClient()
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
+			Expect(llmisvc.Spec.Template).To(BeNil())
+		})
+
+		It("skips injection when secret has no connection type annotation", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: llmNS},
+			}
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: "secret1",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("skips injection when secret has an unknown connection type", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: llmNS,
+					Annotations: map[string]string{
+						connectionapi.AnnotationConnectionTypeProtocol: "exotic",
+					},
+				},
+			}
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: "secret1",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("returns error when referenced secret does not exist", func() {
+			cli := newLLMFakeClient()
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: "missing-secret",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			err := d.Default(admCtx, llmisvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("skips injection when resource is marked for deletion", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmS3SecretName,
+			})
+			now := metav1.Now()
+			llmisvc.DeletionTimestamp = &now
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template).To(BeNil())
+		})
+
+		Context("S3 connection type", func() {
+
+			It("creates SA and injects spec.model.uri", func() {
+				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections:    llmS3SecretName,
+					connectionapi.AnnotationConnectionPath: "models/llama",
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Template).ToNot(BeNil())
+				Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://my-bucket/models/llama"))
+
+				sa := &corev1.ServiceAccount{}
+				Expect(cli.Get(context.Background(), types.NamespacedName{
+					Name:      llmS3SecretName + "-sa",
+					Namespace: llmNS,
+				}, sa)).To(Succeed())
+			})
+
+			It("initializes Template when nil before S3 inject", func() {
+				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections:    llmS3SecretName,
+					connectionapi.AnnotationConnectionPath: "models/llama",
+				})
+				Expect(llmisvc.Spec.Template).To(BeNil())
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Template).ToNot(BeNil())
+				Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+			})
+
+			It("injects URI but does not create SA on dry-run", func() {
+				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+					map[string][]byte{"AWS_S3_BUCKET": []byte("my-bucket")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections:    llmS3SecretName,
+					connectionapi.AnnotationConnectionPath: "models/llama",
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, true) // dryRun=true
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://my-bucket/models/llama"))
+
+				sa := &corev1.ServiceAccount{}
+				err := cli.Get(context.Background(), types.NamespacedName{
+					Name:      llmS3SecretName + "-sa",
+					Namespace: llmNS,
+				}, sa)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("returns error when bucket key is missing", func() {
+				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3", map[string][]byte{})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections:    llmS3SecretName,
+					connectionapi.AnnotationConnectionPath: "models/v1",
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				err := d.Default(admCtx, llmisvc)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("AWS_S3_BUCKET"))
+			})
+
+			It("returns error when connection-path annotation is missing", func() {
+				secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+					map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmS3SecretName,
+					// no AnnotationConnectionPath
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				err := d.Default(admCtx, llmisvc)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("path"))
+			})
+		})
+
+		Context("URI connection type", func() {
+
+			It("injects spec.model.uri from https-host key", func() {
+				secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+					map[string][]byte{"https-host": []byte("https://hf.co/model")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmURISecretName,
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://hf.co/model"))
+			})
+
+			It("injects spec.model.uri from URI key", func() {
+				secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+					map[string][]byte{"URI": []byte("hf://facebook/model")})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmURISecretName,
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Model.URI.String()).To(Equal("hf://facebook/model"))
+			})
+
+			It("returns error when secret has neither URI key", func() {
+				secret := buildLLMSecret(llmURISecretName, llmNS, "uri", map[string][]byte{})
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmURISecretName,
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				err := d.Default(admCtx, llmisvc)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("URI"))
+			})
+		})
+
+		Context("OCI connection type", func() {
+
+			It("injects imagePullSecrets", func() {
+				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmOCISecretName,
+				})
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Template).ToNot(BeNil())
+				Expect(llmisvc.Spec.Template.ImagePullSecrets).To(ConsistOf(
+					corev1.LocalObjectReference{Name: llmOCISecretName},
+				))
+			})
+
+			It("initializes Template when nil before OCI inject", func() {
+				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmOCISecretName,
+				})
+				Expect(llmisvc.Spec.Template).To(BeNil())
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Template).ToNot(BeNil())
+			})
+
+			It("does not duplicate imagePullSecrets when already present", func() {
+				secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+				cli := newLLMFakeClient(secret)
+				d := newLLMDefaulter(cli)
+				llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+					connectionapi.AnnotationConnections: llmOCISecretName,
+				})
+				llmisvc.Spec.Template = &corev1.PodSpec{
+					ImagePullSecrets: []corev1.LocalObjectReference{{Name: llmOCISecretName}},
+				}
+				admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+				Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+				Expect(llmisvc.Spec.Template.ImagePullSecrets).To(HaveLen(1))
+			})
+		})
+	})
+
+	Describe("UPDATE operations — removal (annotation removed)", func() {
+
+		It("clears SA and removes spec.model on S3 removal", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmS3SecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
+			// Model.URI will be removed by cleanup
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(BeEmpty())
+			// After cleanup, Model.URI is zero
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("removes spec.model on URI removal", func() {
+			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("https://x")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("cleans up imagePullSecrets on OCI removal", func() {
+			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmOCISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: llmOCISecretName}},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ImagePullSecrets).To(BeEmpty())
+		})
+
+		It("clears entire imagePullSecrets when old SecretName is empty on OCI cleanup", func() {
+			// Direct call: corner case not reachable through the normal webhook flow
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			llmisvc.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
+			}
+			err := performLLMISVCCleanup(admission.Request{}, llmisvc, connectionapi.ConnectionInfo{
+				SecretName: "",
+				Type:       connectionapi.ConnectionTypeProtocolOCI.String(),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(BeNil())
+		})
+
+		It("performs full cleanup when old secret has been deleted", func() {
+			cli := newLLMFakeClient()
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: "deleted-secret",
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				ServiceAccountName: "deleted-secret-sa",
+				ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "deleted-secret"}},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(BeEmpty())
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("preserves user-set SA name when removing S3 connection", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmS3SecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: "user-custom-sa"}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal("user-custom-sa"))
+		})
+	})
+
+	Describe("UPDATE operations — replacement", func() {
+
+		It("replaces URI with S3 when connection type changes", func() {
+			uriSecret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("https://x")})
+			s3Secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(uriSecret, s3Secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template).ToNot(BeNil())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+			Expect(newLLM.Spec.Model.URI.String()).To(Equal("s3://b/models/v1"))
+		})
+
+		It("replaces S3 fields when connection path changes", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "old",
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "new",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Model.URI.String()).To(Equal("s3://b/new"))
+		})
+	})
+
+	Describe("removeModelSpec verification", func() {
+
+		It("zeros spec.model.uri after removal", func() {
+			// Trigger cleanup via Update removal
+			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("https://hf.co/model")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			// After removeModelSpec, Model.URI is zero-valued
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("preserves other spec fields after model removal", func() {
+			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("https://hf.co/model")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: "some-sa"}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			// Model URI cleared but Template preserved
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+			Expect(newLLM.Spec.Template).ToNot(BeNil())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal("some-sa"))
+		})
+	})
+
+	Describe("Backward compatibility (deprecated connection-type-ref)", func() {
+
+		It("injects S3 fields using connection-type-ref: s3", func() {
+			secret := buildLLMSecretWithRef(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "m",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://b/m"))
+		})
+
+		It("injects spec.model.uri using connection-type-ref: uri-v1", func() {
+			secret := buildLLMSecretWithRef(llmURISecretName, llmNS, "uri-v1",
+				map[string][]byte{"URI": []byte("https://x")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://x"))
+		})
+
+		It("injects imagePullSecrets using connection-type-ref: oci-v1", func() {
+			secret := buildLLMSecretWithRef(llmOCISecretName, llmNS, "oci-v1", nil)
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmOCISecretName,
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: llmOCISecretName},
+			))
+		})
+	})
+
+	Describe("Utility edge cases exercised through the webhook", func() {
+
+		It("prefers https-host over URI key when both present", func() {
+			secret := buildLLMSecret(llmURISecretName, llmNS, "uri", map[string][]byte{
+				"https-host": []byte("https://preferred.com"),
+				"URI":        []byte("https://fallback.com"),
+			})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmURISecretName,
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("https://preferred.com"))
+		})
+
+		It("returns error when bucket value is empty", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			err := d.Default(admCtx, llmisvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty"))
+		})
+
+		It("does not trigger replacement when URI path annotation changes", func() {
+			secret := buildLLMSecret(llmURISecretName, llmNS, "uri",
+				map[string][]byte{"URI": []byte("https://x")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmURISecretName,
+				connectionapi.AnnotationConnectionPath: "old",
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmURISecretName,
+				connectionapi.AnnotationConnectionPath: "new",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			// action=none for URI when only path annotation changes
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			// No injection triggered; Model.URI unchanged (stays zero since no inject)
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("cleans up imagePullSecrets by name when old secret is deleted", func() {
+			cli := newLLMFakeClient()
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: "deleted-secret",
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "deleted-secret"},
+					{Name: "other"},
+				},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			// Unknown type: cleanup by name removes "deleted-secret", preserves "other"
+			Expect(newLLM.Spec.Template.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "other"},
+			))
+		})
+
+		It("clears entire imagePullSecrets when old SecretName is empty", func() {
+			// Direct call: corner case unreachable through normal webhook flow
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			llmisvc.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "a"}},
+			}
+			err := performLLMISVCCleanup(admission.Request{}, llmisvc, connectionapi.ConnectionInfo{
+				SecretName: "",
+				Type:       "",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(BeNil())
+		})
+
+		It("prefers protocol annotation over deprecated ref on Secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: llmNS,
+					Annotations: map[string]string{
+						connectionapi.AnnotationConnectionTypeProtocol: "s3",
+						connectionapi.AnnotationConnectionTypeRef:      "oci-v1",
+					},
+				},
+				Data: map[string][]byte{"AWS_S3_BUCKET": []byte("b")},
+			}
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    "secret1",
+				connectionapi.AnnotationConnectionPath: "m",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			// S3 injection applied (not OCI)
+			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal("secret1-sa"))
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://b/m"))
+			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(BeEmpty())
+		})
+
+		It("succeeds when SA already exists (idempotent creation)", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			existingSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      llmS3SecretName + "-sa",
+					Namespace: llmNS,
+				},
+			}
+			cli := newLLMFakeClient(secret, existingSA)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+		})
+
+		It("does not overwrite user-set SA name on S3 CREATE", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			llmisvc.Spec.Template = &corev1.PodSpec{ServiceAccountName: "user-custom-sa"}
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template.ServiceAccountName).To(Equal("user-custom-sa"))
+			Expect(llmisvc.Spec.Model.URI.String()).To(Equal("s3://b/models/v1"))
+		})
+
+		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
+			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmOCISecretName,
+			})
+			llmisvc.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "existing-secret"}},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Create, llmNS, nil, false)
+
+			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
+			Expect(llmisvc.Spec.Template.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "existing-secret"},
+				corev1.LocalObjectReference{Name: llmOCISecretName},
+			))
+		})
+
+		It("preserves other imagePullSecrets entries on OCI removal", func() {
+			secret := buildLLMSecret(llmOCISecretName, llmNS, "oci", nil)
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections: llmOCISecretName,
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: "other"},
+					{Name: llmOCISecretName},
+				},
+			}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "other"},
+			))
+		})
+
+		It("produces no mutation when neither old nor new has annotation", func() {
+			cli := newLLMFakeClient()
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			newLLM := buildLLMISVC(llmISVCName, llmNS, nil)
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template).To(BeNil())
+			Expect(newLLM.Spec.Model.URI.String()).To(BeEmpty())
+		})
+
+		It("triggers replacement when same S3 type but different secret name", func() {
+			oldSecret := buildLLMSecret(llmOldSecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			newSecret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(oldSecret, newSecret)
+			d := newLLMDefaulter(cli)
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmOldSecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			newLLM := buildLLMISVC(llmISVCName, llmNS, map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmOldSecretName + "-sa"}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+			Expect(newLLM.Spec.Model.URI.String()).To(Equal("s3://b/models/v1"))
+		})
+
+		It("produces no mutation for identical S3 connection", func() {
+			secret := buildLLMSecret(llmS3SecretName, llmNS, "s3",
+				map[string][]byte{"AWS_S3_BUCKET": []byte("b")})
+			cli := newLLMFakeClient(secret)
+			d := newLLMDefaulter(cli)
+			annots := map[string]string{
+				connectionapi.AnnotationConnections:    llmS3SecretName,
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			}
+			oldLLM := buildLLMISVC(llmISVCName, llmNS, annots)
+			oldLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
+			newLLM := buildLLMISVC(llmISVCName, llmNS, annots)
+			newLLM.Spec.Template = &corev1.PodSpec{ServiceAccountName: llmS3SecretName + "-sa"}
+			admCtx := llmAdmissionCtx(admissionv1.Update, llmNS, oldLLM, false)
+
+			// action=none: no change
+			Expect(d.Default(admCtx, newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.ServiceAccountName).To(Equal(llmS3SecretName + "-sa"))
+		})
+
+		// Ensure marshalSpec helper works to prevent regressions
+		It("marshalSpec helper returns a usable spec map", func() {
+			llmisvc := buildLLMISVC(llmISVCName, llmNS, nil)
+			spec := marshalSpec(llmisvc)
+			Expect(spec).ToNot(BeNil())
+		})
+	})
+})

--- a/internal/webhook/serving/v1alpha2/webhook_suite_test.go
+++ b/internal/webhook/serving/v1alpha2/webhook_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LLMInferenceService Webhook Suite")
+}

--- a/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
@@ -56,10 +56,10 @@ func newISVCDefaulter(cli client.Client) *InferenceServiceCustomDefaulter {
 	return &InferenceServiceCustomDefaulter{client: cli, apiReader: cli}
 }
 
-// dftCtx creates a context carrying an admission request for Default() calls.
-func dftCtx(op admissionv1.Operation, ns string, oldObj runtime.Object, dryRun bool) context.Context {
+// defaultCtx creates a context carrying an admission request for Default() calls.
+func defaultCtx(op admissionv1.Operation, oldObj runtime.Object, dryRun bool) context.Context {
 	req := admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{Operation: op, Namespace: ns},
+		AdmissionRequest: admissionv1.AdmissionRequest{Operation: op, Namespace: defaultNS},
 	}
 	if dryRun {
 		t := true
@@ -73,18 +73,18 @@ func dftCtx(op admissionv1.Operation, ns string, oldObj runtime.Object, dryRun b
 }
 
 // buildISVC creates a typed InferenceService for testing.
-func buildISVC(name, ns string, annotations map[string]string) *kservev1beta1.InferenceService {
+func buildISVC(annotations map[string]string) *kservev1beta1.InferenceService {
 	return &kservev1beta1.InferenceService{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNS, Annotations: annotations},
 		Spec:       kservev1beta1.InferenceServiceSpec{Predictor: kservev1beta1.PredictorSpec{}},
 	}
 }
 
 // buildSecret creates a Secret with a connection-type-protocol annotation.
-func buildSecret(name, ns, connType string, data map[string][]byte) *corev1.Secret {
+func buildSecret(name, connType string, data map[string][]byte) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
+			Name: name, Namespace: defaultNS,
 			Annotations: map[string]string{connectionapi.AnnotationConnectionTypeProtocol: connType},
 		},
 		Data: data,
@@ -102,7 +102,11 @@ func buildSecretWithRef(name, ns, refType string, data map[string][]byte) *corev
 	}
 }
 
-const dftNS = "test-ns"
+const (
+	defaultNS       = "test-ns"
+	defaultS3Secret = "s3-secret"
+	defaultS3SA     = "s3-secret-sa"
+)
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
@@ -111,104 +115,104 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("CREATE operations", func() {
 
 		It("skips injection when no connection annotation is set", func() {
-			isvc := buildISVC("test", dftNS, nil)
-			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			isvc := buildISVC(nil)
+			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ServiceAccountName).To(BeEmpty())
 			Expect(isvc.Spec.Predictor.Model).To(BeNil())
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
 		})
 
 		It("skips injection when secret has no connection type annotation", func() {
-			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: dftNS}}
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: defaultNS}}
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model).To(BeNil())
 		})
 
 		It("skips injection when secret has an unknown connection type", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "s", Namespace: dftNS,
+					Name: "s", Namespace: defaultNS,
 					Annotations: map[string]string{connectionapi.AnnotationConnectionTypeProtocol: "exotic"},
 				},
 			}
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model).To(BeNil())
 		})
 
 		It("returns error when referenced secret does not exist", func() {
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "missing"})
-			err := newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "missing"})
+			err := newISVCDefaulter(newDefaulterFakeClient()).Default(defaultCtx(admissionv1.Create, nil, false), isvc)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 		})
 
 		It("skips injection when resource is marked for deletion", func() {
-			secret := buildSecret("s", dftNS, "s3", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
+			secret := buildSecret("s", "s3", nil)
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
 			now := metav1.Now()
 			isvc.DeletionTimestamp = &now
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ServiceAccountName).To(BeEmpty())
 		})
 
 		Context("S3 connection type", func() {
 
 			It("creates SA and injects storage key and path", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				secret := buildSecret(defaultS3Secret, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
-				isvc := buildISVC("test", dftNS, map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+				isvc := buildISVC(map[string]string{
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "models/v1",
 				})
 				isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 
-				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
-				Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+				Expect(newISVCDefaulter(cli).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
 				Expect(isvc.Spec.Predictor.Model.Storage).ToNot(BeNil())
-				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 				Expect(isvc.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
 				sa := &corev1.ServiceAccount{}
-				Expect(cli.Get(context.Background(), types.NamespacedName{Name: "s3-secret-sa", Namespace: dftNS}, sa)).To(Succeed())
+				Expect(cli.Get(context.Background(), types.NamespacedName{Name: defaultS3SA, Namespace: defaultNS}, sa)).To(Succeed())
 			})
 
 			It("injects storage fields but does not create SA on dry-run", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				secret := buildSecret(defaultS3Secret, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
-				isvc := buildISVC("test", dftNS, map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+				isvc := buildISVC(map[string]string{
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "models/v1",
 				})
 				isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 
-				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Create, dftNS, nil, true), isvc)).To(Succeed())
-				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				Expect(newISVCDefaulter(cli).Default(defaultCtx(admissionv1.Create, nil, true), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 				sa := &corev1.ServiceAccount{}
-				Expect(cli.Get(context.Background(), types.NamespacedName{Name: "s3-secret-sa", Namespace: dftNS}, sa)).To(HaveOccurred())
+				Expect(cli.Get(context.Background(), types.NamespacedName{Name: defaultS3SA, Namespace: defaultNS}, sa)).To(HaveOccurred())
 			})
 		})
 
 		Context("URI connection type", func() {
 
 			It("injects storageUri from secret https-host key", func() {
-				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"https-host": []byte("https://example.com/model")})
-				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				secret := buildSecret("uri-s", "uri", map[string][]byte{"https-host": []byte("https://example.com/model")})
+				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://example.com/model")))
 			})
 
 			It("injects storageUri from secret URI key", func() {
-				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("s3://bucket/model")})
-				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				secret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("s3://bucket/model")})
+				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("s3://bucket/model")))
 			})
 
 			It("returns error when secret has neither URI key", func() {
-				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{})
-				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-				err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)
+				secret := buildSecret("uri-s", "uri", map[string][]byte{})
+				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("URI"))
 			})
@@ -217,17 +221,17 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("OCI connection type", func() {
 
 			It("injects imagePullSecrets", func() {
-				secret := buildSecret("oci-s", dftNS, "oci", nil)
-				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				secret := buildSecret("oci-s", "oci", nil)
+				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
 			})
 
 			It("does not duplicate imagePullSecrets when already present", func() {
-				secret := buildSecret("oci-s", dftNS, "oci", nil)
-				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				secret := buildSecret("oci-s", "oci", nil)
+				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 				isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.ImagePullSecrets).To(HaveLen(1))
 			})
 		})
@@ -238,18 +242,18 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("inject (annotation added)", func() {
 
 			It("creates SA and injects S3 fields when annotation is added", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				secret := buildSecret(defaultS3Secret, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
-				oldISVC := buildISVC("test", dftNS, nil)
-				newISVC := buildISVC("test", dftNS, map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+				oldISVC := buildISVC(nil)
+				newISVC := buildISVC(map[string]string{
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "models/v1",
 				})
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 
-				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
-				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
-				Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				Expect(newISVCDefaulter(cli).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
+				Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
 			})
 		})
@@ -257,55 +261,55 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("remove (annotation removed)", func() {
 
 			It("clears SA and storage when S3 annotation is removed", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
-				path, key := "models/v1", "s3-secret"
-				newISVC := buildISVC("test", dftNS, nil)
-				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				secret := buildSecret(defaultS3Secret, "s3", nil)
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
+				path, key := "models/v1", defaultS3Secret
+				newISVC := buildISVC(nil)
+				newISVC.Spec.Predictor.ServiceAccountName = defaultS3SA
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
 				newISVC.Spec.Predictor.Model.Storage.Path = &path
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
 				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
 			})
 
 			It("clears storageUri when URI annotation is removed", func() {
-				secret := buildSecret("uri-s", dftNS, "uri", nil)
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				secret := buildSecret("uri-s", "uri", nil)
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 				uri := "https://example.com"
-				newISVC := buildISVC("test", dftNS, nil)
+				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.StorageURI = &uri
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(BeNil())
 			})
 
 			It("removes OCI secret from imagePullSecrets when annotation is removed", func() {
-				secret := buildSecret("oci-s", dftNS, "oci", nil)
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
-				newISVC := buildISVC("test", dftNS, nil)
+				secret := buildSecret("oci-s", "oci", nil)
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
 			})
 
 			It("performs full cleanup when old secret has been deleted", func() {
 				// deleted-secret is intentionally absent from the fake client
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
 				uri := "https://example.com"
-				newISVC := buildISVC("test", dftNS, nil)
+				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.ServiceAccountName = "deleted-secret-sa"
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.StorageURI = &uri
 				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 				newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "deleted-secret"}}
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
 				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(BeNil())
 				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
@@ -313,12 +317,12 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("preserves user-set SA name when removing S3 connection", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
-				newISVC := buildISVC("test", dftNS, nil)
+				secret := buildSecret(defaultS3Secret, "s3", nil)
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
+				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.ServiceAccountName = "user-custom-sa"
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("user-custom-sa"))
 			})
 		})
@@ -326,35 +330,35 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("replace (type or secret changed)", func() {
 
 			It("cleans up S3 and injects URI when connection type changes", func() {
-				s3Secret := buildSecret("s3-secret", dftNS, "s3", nil)
-				uriSecret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("https://x")})
+				s3Secret := buildSecret(defaultS3Secret, "s3", nil)
+				uriSecret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("https://x")})
 				cli := newDefaulterFakeClient(s3Secret, uriSecret)
-				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
-				key := "s3-secret"
-				newISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
+				key := defaultS3Secret
+				newISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				newISVC.Spec.Predictor.ServiceAccountName = defaultS3SA
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
 
-				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(cli).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
 				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
 				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
 			})
 
 			It("replaces S3 fields when connection path changes", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
-				oldISVC := buildISVC("test", dftNS, map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+				secret := buildSecret(defaultS3Secret, "s3", nil)
+				oldISVC := buildISVC(map[string]string{
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "old-path",
 				})
-				newISVC := buildISVC("test", dftNS, map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+				newISVC := buildISVC(map[string]string{
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "new-path",
 				})
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("new-path")))
 			})
 		})
@@ -362,54 +366,54 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("none (no change)", func() {
 
 			It("produces no mutation when neither old nor new has annotation", func() {
-				oldISVC := buildISVC("test", dftNS, nil)
-				newISVC := buildISVC("test", dftNS, nil)
-				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				oldISVC := buildISVC(nil)
+				newISVC := buildISVC(nil)
+				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.Model).To(BeNil())
 			})
 
 			It("produces no mutation for identical S3 connection", func() {
-				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				secret := buildSecret(defaultS3Secret, "s3", nil)
 				annots := map[string]string{
-					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "models/v1",
 				}
-				path, key := "models/v1", "s3-secret"
-				oldISVC := buildISVC("test", dftNS, annots)
-				oldISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				path, key := "models/v1", defaultS3Secret
+				oldISVC := buildISVC(annots)
+				oldISVC.Spec.Predictor.ServiceAccountName = defaultS3SA
 				oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				oldISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 				oldISVC.Spec.Predictor.Model.Storage.StorageKey = &key
 				oldISVC.Spec.Predictor.Model.Storage.Path = &path
-				newISVC := buildISVC("test", dftNS, annots)
-				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				newISVC := buildISVC(annots)
+				newISVC.Spec.Predictor.ServiceAccountName = defaultS3SA
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
 				newISVC.Spec.Predictor.Model.Storage.Path = &path
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
-				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
 				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
 			})
 
 			It("does not trigger replacement when URI path annotation changes", func() {
-				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("https://x")})
+				secret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("https://x")})
 				uri := "https://x"
-				oldISVC := buildISVC("test", dftNS, map[string]string{
+				oldISVC := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    "uri-s",
 					connectionapi.AnnotationConnectionPath: "old",
 				})
 				oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				oldISVC.Spec.Predictor.Model.StorageURI = &uri
-				newISVC := buildISVC("test", dftNS, map[string]string{
+				newISVC := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    "uri-s",
 					connectionapi.AnnotationConnectionPath: "new",
 				})
 				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 				newISVC.Spec.Predictor.Model.StorageURI = &uri
 
-				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
 			})
 		})
@@ -418,9 +422,9 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("S3 path priority", func() {
 
 		It("prefers user-set path over annotation path", func() {
-			secret := buildSecret("s3-secret", dftNS, "s3", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			secret := buildSecret(defaultS3Secret, "s3", nil)
+			isvc := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "ann-path",
 			})
 			userPath := "user-path"
@@ -428,40 +432,40 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			isvc.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 			isvc.Spec.Predictor.Model.Storage.Path = &userPath
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("user-path")))
 		})
 
 		It("uses annotation path over old spec path on UPDATE replace", func() {
-			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			secret := buildSecret(defaultS3Secret, "s3", nil)
 			// Same secret but different path annotation forces replace action
-			oldISVC := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			oldISVC := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "different-old-path",
 			})
-			newISVC := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			newISVC := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "ann-path",
 			})
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 			Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("ann-path")))
 		})
 
 		It("falls back to old spec path when no annotation is set on UPDATE inject", func() {
-			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			secret := buildSecret(defaultS3Secret, "s3", nil)
 			// Old ISVC has no connection annotation (inject action on update)
 			oldPath := "old-spec-path"
-			oldISVC := buildISVC("test", dftNS, nil)
+			oldISVC := buildISVC(nil)
 			oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 			oldISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
 			oldISVC.Spec.Predictor.Model.Storage.Path = &oldPath
 			// New ISVC adds connection but no path annotation
-			newISVC := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections: "s3-secret",
+			newISVC := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections: defaultS3Secret,
 			})
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 			Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("old-spec-path")))
 		})
 	})
@@ -469,26 +473,26 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Backward compatibility (deprecated connection-type-ref)", func() {
 
 		It("injects S3 fields using connection-type-ref: s3", func() {
-			secret := buildSecretWithRef("s3-secret", dftNS, "s3", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			secret := buildSecretWithRef(defaultS3Secret, defaultNS, "s3", nil)
+			isvc := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
-			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
 		})
 
 		It("injects storageUri using connection-type-ref: uri-v1", func() {
-			secret := buildSecretWithRef("uri-s", dftNS, "uri-v1", map[string][]byte{"URI": []byte("https://x")})
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			secret := buildSecretWithRef("uri-s", defaultNS, "uri-v1", map[string][]byte{"URI": []byte("https://x")})
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
 		})
 
 		It("injects imagePullSecrets using connection-type-ref: oci-v1", func() {
-			secret := buildSecretWithRef("oci-s", dftNS, "oci-v1", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			secret := buildSecretWithRef("oci-s", defaultNS, "oci-v1", nil)
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
 		})
 	})
@@ -496,25 +500,25 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Utility edge cases exercised through the webhook", func() {
 
 		It("does not overwrite user-set SA name on S3 CREATE", func() {
-			secret := buildSecret("s3-secret", dftNS, "s3", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			secret := buildSecret(defaultS3Secret, "s3", nil)
+			isvc := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
 			isvc.Spec.Predictor.ServiceAccountName = "user-custom-sa"
 			isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("user-custom-sa"))
-			Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+			Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 		})
 
 		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
-			secret := buildSecret("oci-s", dftNS, "oci", nil)
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			secret := buildSecret("oci-s", "oci", nil)
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 			isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(
 				corev1.LocalObjectReference{Name: "existing"},
 				corev1.LocalObjectReference{Name: "oci-s"},
@@ -522,50 +526,50 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves other imagePullSecrets entries on OCI removal", func() {
-			secret := buildSecret("oci-s", dftNS, "oci", nil)
-			oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
-			newISVC := buildISVC("test", dftNS, nil)
+			secret := buildSecret("oci-s", "oci", nil)
+			oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			newISVC := buildISVC(nil)
 			newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "other"}, {Name: "oci-s"}}
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 			Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "other"}))
 		})
 
 		It("triggers replacement when same S3 type but different secret name", func() {
-			oldSec := buildSecret("old-secret", dftNS, "s3", nil)
-			newSec := buildSecret("s3-secret", dftNS, "s3", nil)
-			oldISVC := buildISVC("test", dftNS, map[string]string{
+			oldSec := buildSecret("old-secret", "s3", nil)
+			newSec := buildSecret(defaultS3Secret, "s3", nil)
+			oldISVC := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    "old-secret",
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
-			newISVC := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			newISVC := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
 			newISVC.Spec.Predictor.ServiceAccountName = "old-secret-sa"
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient(oldSec, newSec)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
-			Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
-			Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+			Expect(newISVCDefaulter(newDefaulterFakeClient(oldSec, newSec)).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
+			Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 		})
 
 		It("prefers https-host over URI key when both present", func() {
-			secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{
+			secret := buildSecret("uri-s", "uri", map[string][]byte{
 				"https-host": []byte("https://preferred.com"),
 				"URI":        []byte("https://fallback.com"),
 			})
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://preferred.com")))
 		})
 
 		It("filters imagePullSecrets by name on unknown type removal", func() {
 			// deleted-secret absent from cluster; GetOldConnectionInfo returns Type=""
-			oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
-			newISVC := buildISVC("test", dftNS, nil)
+			oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
+			newISVC := buildISVC(nil)
 			newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "a"}, {Name: "b"}}
 
-			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(defaultCtx(admissionv1.Update, oldISVC, false), newISVC)).To(Succeed())
 			// CleanupOCIImagePullSecrets("deleted-secret") is a no-op since neither "a" nor "b" match
 			Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(ConsistOf(
 				corev1.LocalObjectReference{Name: "a"},
@@ -577,16 +581,16 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			// Corner case unreachable through the normal webhook flow: DetermineAction
 			// requires oldConn.SecretName != "" to produce Remove. Call performISVCCleanup
 			// directly since it is in the same package.
-			isvc := buildISVC("test", dftNS, nil)
+			isvc := buildISVC(nil)
 			isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "a"}}
-			Expect(performISVCCleanup(admission.Request{}, isvc, connectionapi.ConnectionInfo{SecretName: "", Type: ""})).To(Succeed())
+			Expect(performISVCCleanup(isvc, connectionapi.ConnectionInfo{SecretName: "", Type: ""})).To(Succeed())
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeNil())
 		})
 
 		It("prefers protocol annotation over deprecated ref on Secret", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "s", Namespace: dftNS,
+					Name: "s", Namespace: defaultNS,
 					Annotations: map[string]string{
 						connectionapi.AnnotationConnectionTypeProtocol: "uri",
 						connectionapi.AnnotationConnectionTypeRef:      "oci-v1",
@@ -594,24 +598,24 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 				},
 				Data: map[string][]byte{"URI": []byte("https://x")},
 			}
-			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
 		})
 
 		It("succeeds when SA already exists (idempotent creation)", func() {
-			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			secret := buildSecret(defaultS3Secret, "s3", nil)
 			existingSA := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{Name: "s3-secret-sa", Namespace: dftNS},
+				ObjectMeta: metav1.ObjectMeta{Name: defaultS3SA, Namespace: defaultNS},
 			}
-			isvc := buildISVC("test", dftNS, map[string]string{
-				connectionapi.AnnotationConnections:    "s3-secret",
+			isvc := buildISVC(map[string]string{
+				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
 			})
 			isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret, existingSA)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
-			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret, existingSA)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
 		})
 	})
 })

--- a/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -77,28 +78,6 @@ func buildISVC(annotations map[string]string) *kservev1beta1.InferenceService {
 	return &kservev1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNS, Annotations: annotations},
 		Spec:       kservev1beta1.InferenceServiceSpec{Predictor: kservev1beta1.PredictorSpec{}},
-	}
-}
-
-// buildSecret creates a Secret with a connection-type-protocol annotation.
-func buildSecret(name, connType string, data map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: defaultNS,
-			Annotations: map[string]string{connectionapi.AnnotationConnectionTypeProtocol: connType},
-		},
-		Data: data,
-	}
-}
-
-// buildSecretWithRef creates a Secret with the deprecated connection-type-ref annotation.
-func buildSecretWithRef(name, ns, refType string, data map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name, Namespace: ns,
-			Annotations: map[string]string{connectionapi.AnnotationConnectionTypeRef: refType},
-		},
-		Data: data,
 	}
 }
 
@@ -149,7 +128,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("skips injection when resource is marked for deletion", func() {
-			secret := buildSecret("s", "s3", nil)
+			secret := testutils.BuildSecret("s", defaultNS, "s3", nil)
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
 			now := metav1.Now()
 			isvc.DeletionTimestamp = &now
@@ -160,7 +139,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("S3 connection type", func() {
 
 			It("creates SA and injects storage key and path", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
 				isvc := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    defaultS3Secret,
@@ -178,7 +157,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("injects storage fields but does not create SA on dry-run", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
 				isvc := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    defaultS3Secret,
@@ -196,21 +175,21 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("URI connection type", func() {
 
 			It("injects storageUri from secret https-host key", func() {
-				secret := buildSecret("uri-s", "uri", map[string][]byte{"https-host": []byte("https://example.com/model")})
+				secret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{"https-host": []byte("https://example.com/model")})
 				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://example.com/model")))
 			})
 
 			It("injects storageUri from secret URI key", func() {
-				secret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("s3://bucket/model")})
+				secret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{"URI": []byte("s3://bucket/model")})
 				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("s3://bucket/model")))
 			})
 
 			It("returns error when secret has neither URI key", func() {
-				secret := buildSecret("uri-s", "uri", map[string][]byte{})
+				secret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{})
 				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 				err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)
 				Expect(err).To(HaveOccurred())
@@ -221,14 +200,14 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("OCI connection type", func() {
 
 			It("injects imagePullSecrets", func() {
-				secret := buildSecret("oci-s", "oci", nil)
+				secret := testutils.BuildSecret("oci-s", defaultNS, "oci", nil)
 				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 				Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
 			})
 
 			It("does not duplicate imagePullSecrets when already present", func() {
-				secret := buildSecret("oci-s", "oci", nil)
+				secret := testutils.BuildSecret("oci-s", defaultNS, "oci", nil)
 				isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 				isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
 				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
@@ -242,7 +221,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("inject (annotation added)", func() {
 
 			It("creates SA and injects S3 fields when annotation is added", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				cli := newDefaulterFakeClient(secret)
 				oldISVC := buildISVC(nil)
 				newISVC := buildISVC(map[string]string{
@@ -255,13 +234,15 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal(defaultS3SA))
 				Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal(defaultS3Secret)))
 				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
+				sa := &corev1.ServiceAccount{}
+				Expect(cli.Get(context.Background(), types.NamespacedName{Name: defaultS3SA, Namespace: defaultNS}, sa)).To(Succeed())
 			})
 		})
 
 		Context("remove (annotation removed)", func() {
 
 			It("clears SA and storage when S3 annotation is removed", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
 				path, key := "models/v1", defaultS3Secret
 				newISVC := buildISVC(nil)
@@ -277,7 +258,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("clears storageUri when URI annotation is removed", func() {
-				secret := buildSecret("uri-s", "uri", nil)
+				secret := testutils.BuildSecret("uri-s", defaultNS, "uri", nil)
 				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 				uri := "https://example.com"
 				newISVC := buildISVC(nil)
@@ -289,7 +270,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("removes OCI secret from imagePullSecrets when annotation is removed", func() {
-				secret := buildSecret("oci-s", "oci", nil)
+				secret := testutils.BuildSecret("oci-s", defaultNS, "oci", nil)
 				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
@@ -317,7 +298,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("preserves user-set SA name when removing S3 connection", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
 				newISVC := buildISVC(nil)
 				newISVC.Spec.Predictor.ServiceAccountName = "user-custom-sa"
@@ -330,8 +311,8 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		Context("replace (type or secret changed)", func() {
 
 			It("cleans up S3 and injects URI when connection type changes", func() {
-				s3Secret := buildSecret(defaultS3Secret, "s3", nil)
-				uriSecret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("https://x")})
+				s3Secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
+				uriSecret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{"URI": []byte("https://x")})
 				cli := newDefaulterFakeClient(s3Secret, uriSecret)
 				oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: defaultS3Secret})
 				key := defaultS3Secret
@@ -348,7 +329,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("replaces S3 fields when connection path changes", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				oldISVC := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "old-path",
@@ -373,7 +354,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("produces no mutation for identical S3 connection", func() {
-				secret := buildSecret(defaultS3Secret, "s3", nil)
+				secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 				annots := map[string]string{
 					connectionapi.AnnotationConnections:    defaultS3Secret,
 					connectionapi.AnnotationConnectionPath: "models/v1",
@@ -398,7 +379,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			})
 
 			It("does not trigger replacement when URI path annotation changes", func() {
-				secret := buildSecret("uri-s", "uri", map[string][]byte{"URI": []byte("https://x")})
+				secret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{"URI": []byte("https://x")})
 				uri := "https://x"
 				oldISVC := buildISVC(map[string]string{
 					connectionapi.AnnotationConnections:    "uri-s",
@@ -422,7 +403,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("S3 path priority", func() {
 
 		It("prefers user-set path over annotation path", func() {
-			secret := buildSecret(defaultS3Secret, "s3", nil)
+			secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			isvc := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "ann-path",
@@ -437,7 +418,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("uses annotation path over old spec path on UPDATE replace", func() {
-			secret := buildSecret(defaultS3Secret, "s3", nil)
+			secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			// Same secret but different path annotation forces replace action
 			oldISVC := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    defaultS3Secret,
@@ -453,7 +434,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("falls back to old spec path when no annotation is set on UPDATE inject", func() {
-			secret := buildSecret(defaultS3Secret, "s3", nil)
+			secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			// Old ISVC has no connection annotation (inject action on update)
 			oldPath := "old-spec-path"
 			oldISVC := buildISVC(nil)
@@ -473,7 +454,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Backward compatibility (deprecated connection-type-ref)", func() {
 
 		It("injects S3 fields using connection-type-ref: s3", func() {
-			secret := buildSecretWithRef(defaultS3Secret, defaultNS, "s3", nil)
+			secret := testutils.BuildSecretWithRef(defaultS3Secret, defaultNS, "s3", nil)
 			isvc := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
@@ -483,14 +464,14 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("injects storageUri using connection-type-ref: uri-v1", func() {
-			secret := buildSecretWithRef("uri-s", defaultNS, "uri-v1", map[string][]byte{"URI": []byte("https://x")})
+			secret := testutils.BuildSecretWithRef("uri-s", defaultNS, "uri-v1", map[string][]byte{"URI": []byte("https://x")})
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "uri-s"})
 			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
 		})
 
 		It("injects imagePullSecrets using connection-type-ref: oci-v1", func() {
-			secret := buildSecretWithRef("oci-s", defaultNS, "oci-v1", nil)
+			secret := testutils.BuildSecretWithRef("oci-s", defaultNS, "oci-v1", nil)
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
@@ -500,7 +481,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 	Describe("Utility edge cases exercised through the webhook", func() {
 
 		It("does not overwrite user-set SA name on S3 CREATE", func() {
-			secret := buildSecret(defaultS3Secret, "s3", nil)
+			secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			isvc := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    defaultS3Secret,
 				connectionapi.AnnotationConnectionPath: "models/v1",
@@ -514,7 +495,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
-			secret := buildSecret("oci-s", "oci", nil)
+			secret := testutils.BuildSecret("oci-s", defaultNS, "oci", nil)
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 			isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
 
@@ -526,7 +507,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("preserves other imagePullSecrets entries on OCI removal", func() {
-			secret := buildSecret("oci-s", "oci", nil)
+			secret := testutils.BuildSecret("oci-s", defaultNS, "oci", nil)
 			oldISVC := buildISVC(map[string]string{connectionapi.AnnotationConnections: "oci-s"})
 			newISVC := buildISVC(nil)
 			newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "other"}, {Name: "oci-s"}}
@@ -536,8 +517,8 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("triggers replacement when same S3 type but different secret name", func() {
-			oldSec := buildSecret("old-secret", "s3", nil)
-			newSec := buildSecret(defaultS3Secret, "s3", nil)
+			oldSec := testutils.BuildSecret("old-secret", defaultNS, "s3", nil)
+			newSec := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			oldISVC := buildISVC(map[string]string{
 				connectionapi.AnnotationConnections:    "old-secret",
 				connectionapi.AnnotationConnectionPath: "models/v1",
@@ -554,7 +535,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("prefers https-host over URI key when both present", func() {
-			secret := buildSecret("uri-s", "uri", map[string][]byte{
+			secret := testutils.BuildSecret("uri-s", defaultNS, "uri", map[string][]byte{
 				"https-host": []byte("https://preferred.com"),
 				"URI":        []byte("https://fallback.com"),
 			})
@@ -605,7 +586,7 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 		})
 
 		It("succeeds when SA already exists (idempotent creation)", func() {
-			secret := buildSecret(defaultS3Secret, "s3", nil)
+			secret := testutils.BuildSecret(defaultS3Secret, defaultNS, "s3", nil)
 			existingSA := &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Name: defaultS3SA, Namespace: defaultNS},
 			}

--- a/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
@@ -1,0 +1,617 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"encoding/json"
+
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func newDefaulterScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(s))
+	return s
+}
+
+func newDefaulterFakeClient(objs ...client.Object) client.Client {
+	b := fake.NewClientBuilder().WithScheme(newDefaulterScheme())
+	if len(objs) > 0 {
+		b = b.WithObjects(objs...)
+	}
+	return b.Build()
+}
+
+func newISVCDefaulter(cli client.Client) *InferenceServiceCustomDefaulter {
+	return &InferenceServiceCustomDefaulter{client: cli, apiReader: cli}
+}
+
+// dftCtx creates a context carrying an admission request for Default() calls.
+func dftCtx(op admissionv1.Operation, ns string, oldObj runtime.Object, dryRun bool) context.Context {
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Operation: op, Namespace: ns},
+	}
+	if dryRun {
+		t := true
+		req.DryRun = &t
+	}
+	if oldObj != nil {
+		raw, _ := json.Marshal(oldObj)
+		req.OldObject = runtime.RawExtension{Raw: raw}
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// buildISVC creates a typed InferenceService for testing.
+func buildISVC(name, ns string, annotations map[string]string) *kservev1beta1.InferenceService {
+	return &kservev1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Annotations: annotations},
+		Spec:       kservev1beta1.InferenceServiceSpec{Predictor: kservev1beta1.PredictorSpec{}},
+	}
+}
+
+// buildSecret creates a Secret with a connection-type-protocol annotation.
+func buildSecret(name, ns, connType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			Annotations: map[string]string{connectionapi.AnnotationConnectionTypeProtocol: connType},
+		},
+		Data: data,
+	}
+}
+
+// buildSecretWithRef creates a Secret with the deprecated connection-type-ref annotation.
+func buildSecretWithRef(name, ns, refType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: ns,
+			Annotations: map[string]string{connectionapi.AnnotationConnectionTypeRef: refType},
+		},
+		Data: data,
+	}
+}
+
+const dftNS = "test-ns"
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
+
+	Describe("CREATE operations", func() {
+
+		It("skips injection when no connection annotation is set", func() {
+			isvc := buildISVC("test", dftNS, nil)
+			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(BeEmpty())
+			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
+		})
+
+		It("skips injection when secret has no connection type annotation", func() {
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: dftNS}}
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+		})
+
+		It("skips injection when secret has an unknown connection type", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s", Namespace: dftNS,
+					Annotations: map[string]string{connectionapi.AnnotationConnectionTypeProtocol: "exotic"},
+				},
+			}
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+		})
+
+		It("returns error when referenced secret does not exist", func() {
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "missing"})
+			err := newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("skips injection when resource is marked for deletion", func() {
+			secret := buildSecret("s", dftNS, "s3", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
+			now := metav1.Now()
+			isvc.DeletionTimestamp = &now
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(BeEmpty())
+		})
+
+		Context("S3 connection type", func() {
+
+			It("creates SA and injects storage key and path", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				cli := newDefaulterFakeClient(secret)
+				isvc := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "models/v1",
+				})
+				isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+
+				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+				Expect(isvc.Spec.Predictor.Model.Storage).ToNot(BeNil())
+				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				Expect(isvc.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
+				sa := &corev1.ServiceAccount{}
+				Expect(cli.Get(context.Background(), types.NamespacedName{Name: "s3-secret-sa", Namespace: dftNS}, sa)).To(Succeed())
+			})
+
+			It("injects storage fields but does not create SA on dry-run", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				cli := newDefaulterFakeClient(secret)
+				isvc := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "models/v1",
+				})
+				isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+
+				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Create, dftNS, nil, true), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				sa := &corev1.ServiceAccount{}
+				Expect(cli.Get(context.Background(), types.NamespacedName{Name: "s3-secret-sa", Namespace: dftNS}, sa)).To(HaveOccurred())
+			})
+		})
+
+		Context("URI connection type", func() {
+
+			It("injects storageUri from secret https-host key", func() {
+				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"https-host": []byte("https://example.com/model")})
+				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://example.com/model")))
+			})
+
+			It("injects storageUri from secret URI key", func() {
+				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("s3://bucket/model")})
+				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("s3://bucket/model")))
+			})
+
+			It("returns error when secret has neither URI key", func() {
+				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{})
+				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("URI"))
+			})
+		})
+
+		Context("OCI connection type", func() {
+
+			It("injects imagePullSecrets", func() {
+				secret := buildSecret("oci-s", dftNS, "oci", nil)
+				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
+			})
+
+			It("does not duplicate imagePullSecrets when already present", func() {
+				secret := buildSecret("oci-s", dftNS, "oci", nil)
+				isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+				Expect(isvc.Spec.Predictor.ImagePullSecrets).To(HaveLen(1))
+			})
+		})
+	})
+
+	Describe("UPDATE operations", func() {
+
+		Context("inject (annotation added)", func() {
+
+			It("creates SA and injects S3 fields when annotation is added", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				cli := newDefaulterFakeClient(secret)
+				oldISVC := buildISVC("test", dftNS, nil)
+				newISVC := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "models/v1",
+				})
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+
+				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+				Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
+			})
+		})
+
+		Context("remove (annotation removed)", func() {
+
+			It("clears SA and storage when S3 annotation is removed", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
+				path, key := "models/v1", "s3-secret"
+				newISVC := buildISVC("test", dftNS, nil)
+				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
+				newISVC.Spec.Predictor.Model.Storage.Path = &path
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
+				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
+			})
+
+			It("clears storageUri when URI annotation is removed", func() {
+				secret := buildSecret("uri-s", dftNS, "uri", nil)
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				uri := "https://example.com"
+				newISVC := buildISVC("test", dftNS, nil)
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.StorageURI = &uri
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(BeNil())
+			})
+
+			It("removes OCI secret from imagePullSecrets when annotation is removed", func() {
+				secret := buildSecret("oci-s", dftNS, "oci", nil)
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+				newISVC := buildISVC("test", dftNS, nil)
+				newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "oci-s"}}
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
+			})
+
+			It("performs full cleanup when old secret has been deleted", func() {
+				// deleted-secret is intentionally absent from the fake client
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
+				uri := "https://example.com"
+				newISVC := buildISVC("test", dftNS, nil)
+				newISVC.Spec.Predictor.ServiceAccountName = "deleted-secret-sa"
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.StorageURI = &uri
+				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+				newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "deleted-secret"}}
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
+				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(BeNil())
+				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
+				Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
+			})
+
+			It("preserves user-set SA name when removing S3 connection", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
+				newISVC := buildISVC("test", dftNS, nil)
+				newISVC.Spec.Predictor.ServiceAccountName = "user-custom-sa"
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("user-custom-sa"))
+			})
+		})
+
+		Context("replace (type or secret changed)", func() {
+
+			It("cleans up S3 and injects URI when connection type changes", func() {
+				s3Secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				uriSecret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("https://x")})
+				cli := newDefaulterFakeClient(s3Secret, uriSecret)
+				oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s3-secret"})
+				key := "s3-secret"
+				newISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
+
+				Expect(newISVCDefaulter(cli).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(BeEmpty())
+				Expect(newISVC.Spec.Predictor.Model.Storage).To(BeNil())
+				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
+			})
+
+			It("replaces S3 fields when connection path changes", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				oldISVC := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "old-path",
+				})
+				newISVC := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "new-path",
+				})
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("new-path")))
+			})
+		})
+
+		Context("none (no change)", func() {
+
+			It("produces no mutation when neither old nor new has annotation", func() {
+				oldISVC := buildISVC("test", dftNS, nil)
+				newISVC := buildISVC("test", dftNS, nil)
+				Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.Model).To(BeNil())
+			})
+
+			It("produces no mutation for identical S3 connection", func() {
+				secret := buildSecret("s3-secret", dftNS, "s3", nil)
+				annots := map[string]string{
+					connectionapi.AnnotationConnections:    "s3-secret",
+					connectionapi.AnnotationConnectionPath: "models/v1",
+				}
+				path, key := "models/v1", "s3-secret"
+				oldISVC := buildISVC("test", dftNS, annots)
+				oldISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				oldISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+				oldISVC.Spec.Predictor.Model.Storage.StorageKey = &key
+				oldISVC.Spec.Predictor.Model.Storage.Path = &path
+				newISVC := buildISVC("test", dftNS, annots)
+				newISVC.Spec.Predictor.ServiceAccountName = "s3-secret-sa"
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+				newISVC.Spec.Predictor.Model.Storage.StorageKey = &key
+				newISVC.Spec.Predictor.Model.Storage.Path = &path
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+				Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("models/v1")))
+			})
+
+			It("does not trigger replacement when URI path annotation changes", func() {
+				secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{"URI": []byte("https://x")})
+				uri := "https://x"
+				oldISVC := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "uri-s",
+					connectionapi.AnnotationConnectionPath: "old",
+				})
+				oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				oldISVC.Spec.Predictor.Model.StorageURI = &uri
+				newISVC := buildISVC("test", dftNS, map[string]string{
+					connectionapi.AnnotationConnections:    "uri-s",
+					connectionapi.AnnotationConnectionPath: "new",
+				})
+				newISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+				newISVC.Spec.Predictor.Model.StorageURI = &uri
+
+				Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+				Expect(newISVC.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
+			})
+		})
+	})
+
+	Describe("S3 path priority", func() {
+
+		It("prefers user-set path over annotation path", func() {
+			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "ann-path",
+			})
+			userPath := "user-path"
+			isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+			isvc.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+			isvc.Spec.Predictor.Model.Storage.Path = &userPath
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("user-path")))
+		})
+
+		It("uses annotation path over old spec path on UPDATE replace", func() {
+			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			// Same secret but different path annotation forces replace action
+			oldISVC := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "different-old-path",
+			})
+			newISVC := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "ann-path",
+			})
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("ann-path")))
+		})
+
+		It("falls back to old spec path when no annotation is set on UPDATE inject", func() {
+			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			// Old ISVC has no connection annotation (inject action on update)
+			oldPath := "old-spec-path"
+			oldISVC := buildISVC("test", dftNS, nil)
+			oldISVC.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+			oldISVC.Spec.Predictor.Model.Storage = &kservev1beta1.ModelStorageSpec{}
+			oldISVC.Spec.Predictor.Model.Storage.Path = &oldPath
+			// New ISVC adds connection but no path annotation
+			newISVC := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections: "s3-secret",
+			})
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.Model.Storage.Path).To(HaveValue(Equal("old-spec-path")))
+		})
+	})
+
+	Describe("Backward compatibility (deprecated connection-type-ref)", func() {
+
+		It("injects S3 fields using connection-type-ref: s3", func() {
+			secret := buildSecretWithRef("s3-secret", dftNS, "s3", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+		})
+
+		It("injects storageUri using connection-type-ref: uri-v1", func() {
+			secret := buildSecretWithRef("uri-s", dftNS, "uri-v1", map[string][]byte{"URI": []byte("https://x")})
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
+		})
+
+		It("injects imagePullSecrets using connection-type-ref: oci-v1", func() {
+			secret := buildSecretWithRef("oci-s", dftNS, "oci-v1", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "oci-s"}))
+		})
+	})
+
+	Describe("Utility edge cases exercised through the webhook", func() {
+
+		It("does not overwrite user-set SA name on S3 CREATE", func() {
+			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			isvc.Spec.Predictor.ServiceAccountName = "user-custom-sa"
+			isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("user-custom-sa"))
+			Expect(isvc.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+		})
+
+		It("merges OCI imagePullSecrets with pre-existing different entries", func() {
+			secret := buildSecret("oci-s", dftNS, "oci", nil)
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "existing"},
+				corev1.LocalObjectReference{Name: "oci-s"},
+			))
+		})
+
+		It("preserves other imagePullSecrets entries on OCI removal", func() {
+			secret := buildSecret("oci-s", dftNS, "oci", nil)
+			oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "oci-s"})
+			newISVC := buildISVC("test", dftNS, nil)
+			newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "other"}, {Name: "oci-s"}}
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(ConsistOf(corev1.LocalObjectReference{Name: "other"}))
+		})
+
+		It("triggers replacement when same S3 type but different secret name", func() {
+			oldSec := buildSecret("old-secret", dftNS, "s3", nil)
+			newSec := buildSecret("s3-secret", dftNS, "s3", nil)
+			oldISVC := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "old-secret",
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			newISVC := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			newISVC.Spec.Predictor.ServiceAccountName = "old-secret-sa"
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient(oldSec, newSec)).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+			Expect(newISVC.Spec.Predictor.Model.Storage.StorageKey).To(HaveValue(Equal("s3-secret")))
+		})
+
+		It("prefers https-host over URI key when both present", func() {
+			secret := buildSecret("uri-s", dftNS, "uri", map[string][]byte{
+				"https-host": []byte("https://preferred.com"),
+				"URI":        []byte("https://fallback.com"),
+			})
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "uri-s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://preferred.com")))
+		})
+
+		It("filters imagePullSecrets by name on unknown type removal", func() {
+			// deleted-secret absent from cluster; GetOldConnectionInfo returns Type=""
+			oldISVC := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "deleted-secret"})
+			newISVC := buildISVC("test", dftNS, nil)
+			newISVC.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "a"}, {Name: "b"}}
+
+			Expect(newISVCDefaulter(newDefaulterFakeClient()).Default(dftCtx(admissionv1.Update, dftNS, oldISVC, false), newISVC)).To(Succeed())
+			// CleanupOCIImagePullSecrets("deleted-secret") is a no-op since neither "a" nor "b" match
+			Expect(newISVC.Spec.Predictor.ImagePullSecrets).To(ConsistOf(
+				corev1.LocalObjectReference{Name: "a"},
+				corev1.LocalObjectReference{Name: "b"},
+			))
+		})
+
+		It("clears entire imagePullSecrets when old SecretName is empty", func() {
+			// Corner case unreachable through the normal webhook flow: DetermineAction
+			// requires oldConn.SecretName != "" to produce Remove. Call performISVCCleanup
+			// directly since it is in the same package.
+			isvc := buildISVC("test", dftNS, nil)
+			isvc.Spec.Predictor.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "a"}}
+			Expect(performISVCCleanup(admission.Request{}, isvc, connectionapi.ConnectionInfo{SecretName: "", Type: ""})).To(Succeed())
+			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeNil())
+		})
+
+		It("prefers protocol annotation over deprecated ref on Secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s", Namespace: dftNS,
+					Annotations: map[string]string{
+						connectionapi.AnnotationConnectionTypeProtocol: "uri",
+						connectionapi.AnnotationConnectionTypeRef:      "oci-v1",
+					},
+				},
+				Data: map[string][]byte{"URI": []byte("https://x")},
+			}
+			isvc := buildISVC("test", dftNS, map[string]string{connectionapi.AnnotationConnections: "s"})
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.StorageURI).To(HaveValue(Equal("https://x")))
+			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
+		})
+
+		It("succeeds when SA already exists (idempotent creation)", func() {
+			secret := buildSecret("s3-secret", dftNS, "s3", nil)
+			existingSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "s3-secret-sa", Namespace: dftNS},
+			}
+			isvc := buildISVC("test", dftNS, map[string]string{
+				connectionapi.AnnotationConnections:    "s3-secret",
+				connectionapi.AnnotationConnectionPath: "models/v1",
+			})
+			isvc.Spec.Predictor.Model = &kservev1beta1.ModelSpec{}
+			Expect(newISVCDefaulter(newDefaulterFakeClient(secret, existingSA)).Default(dftCtx(admissionv1.Create, dftNS, nil, false), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.ServiceAccountName).To(Equal("s3-secret-sa"))
+		})
+	})
+})

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -219,7 +219,7 @@ func (d *InferenceServiceCustomDefaulter) applyConnectionsAPI(
 		}
 
 	case connectionapi.ConnectionActionRemove:
-		if err := performISVCCleanup(req, isvc, oldConn); err != nil {
+		if err := performISVCCleanup(isvc, oldConn); err != nil {
 			log.Error(err, "failed to cleanup connection")
 			return err
 		}
@@ -228,7 +228,7 @@ func (d *InferenceServiceCustomDefaulter) applyConnectionsAPI(
 		log.V(1).Info("connection changed, performing replacement",
 			"oldType", oldConn.Type, "newType", newConn.Type,
 			"oldSecret", oldConn.SecretName, "newSecret", newConn.SecretName)
-		if err := performISVCCleanup(req, isvc, oldConn); err != nil {
+		if err := performISVCCleanup(isvc, oldConn); err != nil {
 			log.Error(err, "failed to cleanup old connection")
 			return err
 		}
@@ -342,13 +342,11 @@ func performISVCInjection(
 // all possible injected fields.
 //
 // Parameters:
-//   - req: the admission request (used for namespace in log messages)
 //   - isvc: the InferenceService to clean up
 //   - oldConn: connection info from the previous object version
 //
 // Returns any error from cleanup.
 func performISVCCleanup(
-	req admission.Request,
 	isvc *servingv1beta1.InferenceService,
 	oldConn connectionapi.ConnectionInfo,
 ) error {

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -210,7 +210,7 @@ func (d *InferenceServiceCustomDefaulter) applyConnectionsAPI(
 	switch action {
 	case connectionapi.ConnectionActionInject:
 		isDryRun := req.DryRun != nil && *req.DryRun
-		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+		if err := connectionapi.CreateServiceAccountIfNeeded(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
 		if err := performISVCInjection(ctx, req, isvc, newConn, secret); err != nil {
@@ -233,7 +233,7 @@ func (d *InferenceServiceCustomDefaulter) applyConnectionsAPI(
 			return err
 		}
 		isDryRun := req.DryRun != nil && *req.DryRun
-		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+		if err := connectionapi.CreateServiceAccountIfNeeded(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
 			return err
 		}
 		if err := performISVCInjection(ctx, req, isvc, newConn, secret); err != nil {

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -18,9 +18,11 @@ package v1beta1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
-	servingv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	servingv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
 )
 
 // nolint:unused
@@ -42,7 +47,10 @@ var inferenceservicelog = logf.Log.WithName("inferenceservice-resource")
 func SetupInferenceServiceWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&servingv1beta1.InferenceService{}).
 		WithValidator(&InferenceServiceCustomValidator{client: mgr.GetClient()}).
-		WithDefaulter(&InferenceServiceCustomDefaulter{client: mgr.GetClient()}).
+		WithDefaulter(&InferenceServiceCustomDefaulter{
+			client:    mgr.GetClient(),
+			apiReader: mgr.GetAPIReader(),
+		}).
 		Complete()
 }
 
@@ -126,7 +134,7 @@ func (v *InferenceServiceCustomValidator) ValidateDelete(ctx context.Context, ob
 	return nil, nil
 }
 
-// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1beta1-inferenceservice,mutating=true,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferenceservices,verbs=create,versions=v1beta1,name=minferenceservice-v1beta1.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1beta1-inferenceservice,mutating=true,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=minferenceservice-v1beta1.odh-model-controller.opendatahub.io,admissionReviewVersions=v1
 
 // InferenceServiceCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind InferenceService when those are created or updated.
@@ -134,20 +142,245 @@ func (v *InferenceServiceCustomValidator) ValidateDelete(ctx context.Context, ob
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
 type InferenceServiceCustomDefaulter struct {
-	client client.Client
+	client    client.Client
+	apiReader client.Reader
 }
 
 var _ webhook.CustomDefaulter = &InferenceServiceCustomDefaulter{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind InferenceService.
 func (d *InferenceServiceCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	inferenceservice, ok := obj.(*servingv1beta1.InferenceService)
-
+	isvc, ok := obj.(*servingv1beta1.InferenceService)
 	if !ok {
 		return fmt.Errorf("expected an InferenceService object but got %T", obj)
 	}
-	logger := inferenceservicelog.WithValues("name", inferenceservice.GetName())
-	logger.Info("Defaulting for InferenceService", "name", inferenceservice.GetName())
+	logger := inferenceservicelog.WithValues("name", isvc.GetName())
+	logger.Info("Defaulting for InferenceService", "name", isvc.GetName())
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get admission request from context: %w", err)
+	}
+
+	return d.applyConnectionsAPI(ctx, req, isvc)
+}
+
+// applyConnectionsAPI validates the connection annotation and performs the appropriate injection,
+// cleanup, or replacement on the InferenceService based on the annotation state.
+//
+// Parameters:
+//   - ctx: context for logging and API calls
+//   - req: the admission request (carries operation type, dry-run flag, and old object)
+//   - isvc: the InferenceService being admitted (mutated in-place)
+//
+// Returns any error that should block admission.
+func (d *InferenceServiceCustomDefaulter) applyConnectionsAPI(
+	ctx context.Context,
+	req admission.Request,
+	isvc *servingv1beta1.InferenceService,
+) error {
+	log := logf.FromContext(ctx)
+
+	if isvc.DeletionTimestamp != nil {
+		return nil
+	}
+
+	newConn, secret, err := connectionapi.ValidateConnectionAnnotation(ctx, d.apiReader, isvc, req.Namespace)
+	if err != nil {
+		return err
+	}
+
+	var oldConn connectionapi.ConnectionInfo
+	var action connectionapi.ConnectionAction
+
+	if req.Operation == admissionv1.Update {
+		oldConn, err = connectionapi.GetOldConnectionInfo(ctx, req, d.apiReader)
+		if err != nil {
+			return err
+		}
+		action = connectionapi.DetermineAction(oldConn, newConn)
+	} else {
+		if newConn.SecretName == "" {
+			action = connectionapi.ConnectionActionNone
+		} else {
+			action = connectionapi.ConnectionActionInject
+		}
+	}
+
+	switch action {
+	case connectionapi.ConnectionActionInject:
+		isDryRun := req.DryRun != nil && *req.DryRun
+		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+			return err
+		}
+		if err := performISVCInjection(ctx, req, isvc, newConn, secret); err != nil {
+			log.Error(err, "failed to inject connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionRemove:
+		if err := performISVCCleanup(req, isvc, oldConn); err != nil {
+			log.Error(err, "failed to cleanup connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionReplace:
+		log.V(1).Info("connection changed, performing replacement",
+			"oldType", oldConn.Type, "newType", newConn.Type,
+			"oldSecret", oldConn.SecretName, "newSecret", newConn.SecretName)
+		if err := performISVCCleanup(req, isvc, oldConn); err != nil {
+			log.Error(err, "failed to cleanup old connection")
+			return err
+		}
+		isDryRun := req.DryRun != nil && *req.DryRun
+		if err := connectionapi.ServiceAccountCreation(ctx, d.client, newConn.SecretName, newConn.Type, req.Namespace, isDryRun); err != nil {
+			return err
+		}
+		if err := performISVCInjection(ctx, req, isvc, newConn, secret); err != nil {
+			log.Error(err, "failed to inject new connection")
+			return err
+		}
+
+	case connectionapi.ConnectionActionNone:
+		// no-op
+	}
+
+	return nil
+}
+
+// performISVCInjection injects connection credentials into the InferenceService using typed field access.
+//
+// Dispatches to type-specific injection: S3 sets serviceAccountName and storage key/path;
+// URI sets storageUri; OCI appends to imagePullSecrets.
+//
+// Parameters:
+//   - ctx: context for logging
+//   - req: the admission request (used for UPDATE old-object path priority)
+//   - isvc: the InferenceService to mutate
+//   - connInfo: validated connection info
+//   - secret: the pre-fetched connection Secret (returned by ValidateConnectionAnnotation)
+//
+// Returns any error from injection.
+func performISVCInjection(
+	ctx context.Context,
+	req admission.Request,
+	isvc *servingv1beta1.InferenceService,
+	connInfo connectionapi.ConnectionInfo,
+	secret *corev1.Secret,
+) error {
+	log := logf.FromContext(ctx)
+
+	switch connInfo.Type {
+	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
+		connectionapi.InjectOCIImagePullSecrets(&isvc.Spec.Predictor.ImagePullSecrets, connInfo.SecretName)
+		log.V(1).Info("injected OCI imagePullSecrets", "connection", connInfo.SecretName)
+		// TODO: inject spec.predictor.model.uri for OCI
+		return nil
+
+	case connectionapi.ConnectionTypeProtocolURI.String(), connectionapi.ConnectionTypeRefURI.String():
+		uriValue, err := connectionapi.GetURIValue(secret)
+		if err != nil {
+			return fmt.Errorf("failed to get URI value: %w", err)
+		}
+		if isvc.Spec.Predictor.Model == nil {
+			isvc.Spec.Predictor.Model = &servingv1beta1.ModelSpec{}
+		}
+		isvc.Spec.Predictor.Model.StorageURI = &uriValue
+		log.V(1).Info("injected URI storageUri", "connection", connInfo.SecretName)
+		return nil
+
+	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
+		connectionapi.InjectServiceAccountName(&isvc.Spec.Predictor.ServiceAccountName, connInfo.SecretName+"-sa")
+		log.V(1).Info("injected serviceAccountName", "saName", connInfo.SecretName+"-sa")
+
+		// Retrieve the old spec storage path for priority resolution.
+		var oldSpecPath string
+		if req.Operation == admissionv1.Update && req.OldObject.Raw != nil {
+			oldISVC := &servingv1beta1.InferenceService{}
+			if err := json.Unmarshal(req.OldObject.Raw, oldISVC); err == nil {
+				if oldISVC.Spec.Predictor.Model != nil &&
+					oldISVC.Spec.Predictor.Model.Storage != nil &&
+					oldISVC.Spec.Predictor.Model.Storage.Path != nil {
+					oldSpecPath = *oldISVC.Spec.Predictor.Model.Storage.Path
+				}
+			}
+		}
+
+		if isvc.Spec.Predictor.Model == nil {
+			isvc.Spec.Predictor.Model = &servingv1beta1.ModelSpec{}
+		}
+		if isvc.Spec.Predictor.Model.Storage == nil {
+			isvc.Spec.Predictor.Model.Storage = &servingv1beta1.ModelStorageSpec{}
+		}
+
+		secretName := connInfo.SecretName
+		isvc.Spec.Predictor.Model.Storage.StorageKey = &secretName
+
+		// Path priority: user-set value > annotation value > old spec value > unset.
+		switch {
+		case isvc.Spec.Predictor.Model.Storage.Path != nil && *isvc.Spec.Predictor.Model.Storage.Path != "":
+			// keep the user-set path
+		case connInfo.Path != "":
+			isvc.Spec.Predictor.Model.Storage.Path = &connInfo.Path
+		case oldSpecPath != "":
+			isvc.Spec.Predictor.Model.Storage.Path = &oldSpecPath
+		}
+
+		log.V(1).Info("injected S3 storage key and path", "connection", connInfo.SecretName)
+		return nil
+
+	default:
+		log.V(1).Info("unknown connection type, skipping injection", "connectionType", connInfo.Type)
+		return nil
+	}
+}
+
+// performISVCCleanup removes previously injected connection credentials from the InferenceService
+// using typed field access.
+//
+// Dispatches cleanup based on the old connection type. Unknown type triggers full cleanup across
+// all possible injected fields.
+//
+// Parameters:
+//   - req: the admission request (used for namespace in log messages)
+//   - isvc: the InferenceService to clean up
+//   - oldConn: connection info from the previous object version
+//
+// Returns any error from cleanup.
+func performISVCCleanup(
+	req admission.Request,
+	isvc *servingv1beta1.InferenceService,
+	oldConn connectionapi.ConnectionInfo,
+) error {
+	switch oldConn.Type {
+	case connectionapi.ConnectionTypeProtocolOCI.String(), connectionapi.ConnectionTypeRefOCI.String():
+		connectionapi.CleanupOCIImagePullSecrets(&isvc.Spec.Predictor.ImagePullSecrets, oldConn.SecretName)
+
+	case connectionapi.ConnectionTypeProtocolURI.String(), connectionapi.ConnectionTypeRefURI.String():
+		if isvc.Spec.Predictor.Model != nil {
+			isvc.Spec.Predictor.Model.StorageURI = nil
+		}
+
+	case connectionapi.ConnectionTypeProtocolS3.String(), connectionapi.ConnectionTypeRefS3.String():
+		connectionapi.RemoveServiceAccountName(&isvc.Spec.Predictor.ServiceAccountName, oldConn.SecretName+"-sa")
+		if isvc.Spec.Predictor.Model != nil {
+			isvc.Spec.Predictor.Model.Storage = nil
+		}
+
+	case "":
+		// Unknown type: the old Secret has been deleted or was never annotated.
+		// Perform full cleanup across all fields that any connection type could have set.
+		if oldConn.SecretName != "" {
+			connectionapi.CleanupOCIImagePullSecrets(&isvc.Spec.Predictor.ImagePullSecrets, oldConn.SecretName)
+		} else {
+			isvc.Spec.Predictor.ImagePullSecrets = nil
+		}
+		if isvc.Spec.Predictor.Model != nil {
+			isvc.Spec.Predictor.Model.StorageURI = nil
+			isvc.Spec.Predictor.Model.Storage = nil
+		}
+		connectionapi.RemoveServiceAccountName(&isvc.Spec.Predictor.ServiceAccountName, oldConn.SecretName+"-sa")
+	}
 
 	return nil
 }

--- a/test/utils/secret.go
+++ b/test/utils/secret.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+)
+
+// BuildSecret creates a Secret with a connection-type-protocol annotation for use in webhook tests.
+//
+// Parameters:
+//   - name: Secret name
+//   - namespace: Secret namespace
+//   - connType: value for the connection-type-protocol annotation
+//   - data: Secret data map
+//
+// Returns the constructed Secret.
+func BuildSecret(name, namespace, connType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				connectionapi.AnnotationConnectionTypeProtocol: connType,
+			},
+		},
+		Data: data,
+	}
+}
+
+// BuildSecretWithRef creates a Secret with the deprecated connection-type-ref annotation for use
+// in backward-compatibility webhook tests.
+//
+// Parameters:
+//   - name: Secret name
+//   - namespace: Secret namespace
+//   - refType: value for the connection-type-ref annotation
+//   - data: Secret data map
+//
+// Returns the constructed Secret.
+func BuildSecretWithRef(name, namespace, refType string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				connectionapi.AnnotationConnectionTypeRef: refType,
+			},
+		},
+		Data: data,
+	}
+}


### PR DESCRIPTION
## Description

Migrates the ConnectionsAPI mutating webhook from `opendatahub-operator` to `odh-model-controller`.

- Introduces an internal `connectionapi` package with shared utilities for resolving `opendatahub.io/connections` annotations and injecting credentials into inference resources (S3, URI, OCI types).
- Extends `InferenceServiceCustomDefaulter` (v1beta1) to handle all connection types on CREATE and UPDATE operations (inject, remove, replace, and no-op actions), including S3 path priority, dry-run support, and backward compatibility with the deprecated `connection-type-ref` annotation.
- Adds a new `LLMInferenceServiceCustomDefaulter` (v1alpha2) with the same connection-type coverage, plus a hybrid unstructured approach to cleanly remove `spec.model` on cleanup.
- Registers the new `LLMInferenceService` mutating webhook in `cmd/main.go` and updates the generated `config/webhook/manifests.yaml`.
- Adds 38 Ginkgo specs for the ISVC defaulter (`v1beta1`) and 43 Ginkgo specs for the LLMInferenceService defaulter (`v1alpha2`), both using `controller-runtime` fake clients.

Related Jira: https://redhat.atlassian.net/browse/RHOAIENG-62537

## How Has This Been Tested?

- Unit tests for the ISVC defaulter run under the existing envtest-based Ginkgo suite in `internal/webhook/serving/v1beta1/`; the new specs use fake clients and do not interact with envtest infrastructure.
- Unit tests for the LLMInferenceService defaulter run under a new minimal Ginkgo suite in `internal/webhook/serving/v1alpha2/` with no envtest dependency: `go test ./internal/webhook/serving/v1alpha2/...`
- Full test suite can be run via `make test` once envtest binaries are available.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ConnectionsAPI mutating webhook for LLMInferenceService to auto-inject and clean up credentials; supports S3, URI, and OCI connection types and respects dry-run.

* **Chores**
  * Webhook registrations, manifests, and kustomization updated; mutating webhooks set dry-run sideEffects.
  * InferenceService/LLMInferenceService defaulters enhanced to handle update/cleanup and use API reader for prior-state logic.
  * Added connection utilities and test secret builders.

* **Tests**
  * Extensive suites covering create/update/dry-run flows, edge cases, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->