### PR TITLE
fix: guard nil Model to prevent panics

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_metrics_service_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_service_reconciler.go
@@ -81,7 +81,7 @@ func (r *KserveRawMetricsServiceReconciler) createDesiredResource(ctx context.Co
 		return nil, err
 	}
 
-	if isvcRuntime.Spec.Annotations == nil || isvcRuntime.Spec.Annotations[constants.PrometheusPortAnnotationKey] == "" {
+	if isvcRuntime == nil || isvcRuntime.Spec.Annotations == nil || isvcRuntime.Spec.Annotations[constants.PrometheusPortAnnotationKey] == "" {
 		log.V(1).Info("No Prometheus annotations on ServingRuntime, skipping creation of metrics resources")
 		return nil, nil
 	}

--- a/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_servicemonitor_reconciler.go
@@ -82,6 +82,10 @@ func (r *KserveRawMetricsServiceMonitorReconciler) createDesiredResource(ctx con
 		return nil, err
 	}
 
+	if isvcRuntime == nil {
+		return nil, nil
+	}
+
 	endpoint := v1.Endpoint{
 		Port:   isvcRuntime.Name + "-metrics",
 		Scheme: ptr.To(v1.Scheme("http")),

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -162,6 +162,10 @@ func FindSupportingRuntimeForISvc(ctx context.Context, cli client.Client, log lo
 		}
 		return desiredServingRuntime, nil
 	} else {
+		if isvc.Spec.Predictor.Model == nil || isvc.Spec.Predictor.Model.ModelFormat.Name == "" {
+			return nil, nil
+		}
+
 		runtimes := &kservev1alpha1.ServingRuntimeList{}
 		err := cli.List(ctx, runtimes, client.InNamespace(isvc.Namespace))
 		if err != nil {


### PR DESCRIPTION
## Description

`FindSupportingRuntimeForISvc` panics with a nil pointer dereference when reconciling raw-mode InferenceServices that have no `ModelFormat` set (e.g. `message-dumper-raw`). The guard checks `Model != nil && Runtime != nil`, but the else branch unconditionally dereferences `Model.ModelFormat.Name` - blowing up when `Model` is nil.

This could be contributing to the e2e-raw test flake where the webhook returns 500 "no endpoints available for service". The repeated panics (15 in ~60 seconds) likely stress the pod enough to lose the leader election lease, causing a restart during which the webhook endpoint is unavailable.

Introduces guards to mitigate flaky tests where ISVCs like `message-dumper-raw` were triggering serving runtime auto-detect and failing intermittently blocking webhook endpoints to be healthy.

**e2e failure:** [build-log.txt](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_kserve/1554/pull-ci-opendatahub-io-kserve-master-e2e-raw/2061489406899916800#1:build-log.txt%3A1669)
**controller logs:** [odh-model-controller pod logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/opendatahub-io_kserve/1554/pull-ci-opendatahub-io-kserve-master-e2e-raw/2061489406899916800/artifacts/e2e-raw/openshift-must-gather/artifacts/gather-openshift/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-11ec132408bc65a929187701d132562d5b609813a819218e55fc672af97864b9/namespaces/kserve/pods/odh-model-controller-696fc77849-qxc8m/manager/manager/logs/)

## How Has This Been Tested?

- Existing reconciler tests pass
- The fix is a straightforward nil guard

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service reconciliation robustness by adding validation checks to prevent failures when model specifications or runtime metadata are missing or incomplete.
  * Enhanced metrics service configuration with better error handling and early validation when supporting runtime information is unavailable during the reconciliation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->