### PR TITLE
chore: update OWNERS -- add KillianGolds as approver and reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - israel-hdez
   - jlost
   - Jooho
+  - KillianGolds
   - mholder6
   - mwaykole
   - pierDipi
@@ -23,6 +24,7 @@ reviewers:
   - israel-hdez
   - jlost
   - Jooho
+  - KillianGolds
   - mholder6
   - mwaykole
   - pierDipi


### PR DESCRIPTION
## Description
Updates `OWNERS` to reflect current team membership: adds @KillianGolds to both the `approvers` and `reviewers` lists. I've been reviewing PRs in this repo without an entry in `OWNERS`, so this corrects the ownership roles. Alphabetical placement only, no other changes.

## How Has This Been Tested?
- Verified `OWNERS` remains valid YAML.
- Single squashed commit, signed off matching the author identity so DCO passes.
- No code or test changes.

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description (N/A, OWNERS housekeeping)
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work