### PR TITLE
feat : Add vLLM-Omni CUDA ServingRuntime template for multimodal inference (Dev Preview)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -216,6 +216,7 @@ Pre-built ServingRuntime templates for supported model servers live in `config/r
 | `vllm-gaudi-template.yaml` | vLLM (Intel Gaudi) |
 | `vllm-spyre-*.yaml` | vLLM (IBM Spyre accelerator) |
 | `vllm-multinode-template.yaml` | vLLM multi-node (Ray) |
+| `vllm-omni-cuda-template.yaml` | vLLM-Omni (NVIDIA GPU, multimodal) |
 | `ovms-kserve-template.yaml` | OpenVINO Model Server |
 | `mlserver-template.yaml` | Seldon MLServer |
 | `mlserver-cuda-template.yaml` | Seldon MLServer (NVIDIA GPU) |

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -352,6 +352,15 @@ replacements:
       - select:
           kind: Template
           name: vllm-cpu-x86-runtime-template-fast-2
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.vllm-omni-cuda-image
+    targets:
+      - select:
+          kind: Template
+          name: vllm-omni-cuda-runtime-template
         fieldPaths:
           - objects.0.spec.containers.0.image
   - source:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -28,4 +28,5 @@ vllm-rocm-image-fast-2=quay.io/vllm/vllm-rocm:latest
 vllm-spyre-image=quay.io/vllm/vllm:latest
 vllm-spyre-image-fast-1=quay.io/vllm/vllm:latest
 vllm-spyre-image-fast-2=quay.io/vllm/vllm:latest
+vllm-omni-cuda-image=quay.io/vllm/vllm-omni-cuda:latest
 guardrails-detector-huggingface-runtime-image=quay.io/trustyai/guardrails-detector-huggingface-runtime:latest

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,4 +1,7 @@
 releases:
+  - name: vLLM-Omni
+    version: v0.22.0
+    repoUrl: https://github.com/vllm-project/vllm-omni
   - name: OpenVINO Model Server
     version: v2025.4
     repoUrl: https://github.com/openvinotoolkit/model_server

--- a/config/runtimes/vllm-omni-cuda-template.yaml
+++ b/config/runtimes/vllm-omni-cuda-template.yaml
@@ -1,0 +1,62 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: vLLM-Omni ServingRuntime with CUDA support for multimodal inference (audio, vision, diffusion) on NVIDIA GPUs
+    openshift.io/display-name: vLLM-Omni NVIDIA GPU ServingRuntime for KServe - Dev Preview
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/vllm-project/vllm-omni
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM-Omni NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI for multimodal inference including omni, diffusion, and TTS models (Dev Preview)
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+    opendatahub.io/model-type: '["generative"]'
+  name: vllm-omni-cuda-runtime-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: vllm-omni-cuda-runtime
+      annotations:
+        openshift.io/display-name: vLLM-Omni NVIDIA GPU ServingRuntime for KServe - Dev Preview
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+        opendatahub.io/runtime-version: 'v0.22.0'
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        opendatahub.io/kserve-runtime: 'vllm-omni'
+        prometheus.io/port: '8080'
+        prometheus.io/path: '/metrics'
+        monitoring.opendatahub.io/scrape: 'true'
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: true
+          name: vLLM-Omni
+      containers:
+        - name: kserve-container
+          image: $(vllm-omni-cuda-image)
+          command:
+            - vllm
+            - serve
+          args:
+            - "--port=8080"
+            - "--model=/mnt/models"
+            - "--omni"
+            - "--served-model-name={{.Name}}"
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -107,6 +107,7 @@ const (
 	OvmsRuntimeName         = "ovms"
 	TgisRuntimeName         = "tgis"
 	VllmRuntimeName         = "vllm"
+	VllmOmniRuntimeName     = "vllm-omni"
 	MLServerRuntimeName     = "mlserver"
 	AutogluonRuntimeName    = "autogluon"
 )

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
@@ -200,6 +200,7 @@ func (r *KserveMetricsDashboardReconciler) processDelta(ctx context.Context, log
 //   - IsNimRuntimeAnnotation: Returns NIMMetricsData if set to "true"
 //   - KServeRuntimeAnnotation with OvmsRuntimeName: Returns OvmsMetricsData
 //   - KServeRuntimeAnnotation with VllmRuntimeName: Returns VllmMetricsData
+//   - KServeRuntimeAnnotation with VllmOmniRuntimeName: Returns VllmMetricsData
 //   - KServeRuntimeAnnotation with TgisRuntimeName: Returns TgisMetricsData
 //   - KServeRuntimeAnnotation with MLServerRuntimeName: Returns MLServerMetricsData
 //   - KServeRuntimeAnnotation with AutogluonRuntimeName: Returns AutogluonMetricsData
@@ -224,6 +225,8 @@ func getMetricsData(runtime *kservev1alpha1.ServingRuntime) (string, bool) {
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.OvmsRuntimeName:
 		return constants.OvmsMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.VllmRuntimeName:
+		return constants.VllmMetricsData, true
+	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.VllmOmniRuntimeName:
 		return constants.VllmMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.TgisRuntimeName:
 		return constants.TgisMetricsData, true

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
@@ -217,6 +217,53 @@ var _ = Describe("KserveMetricsDashboardReconciler", func() {
 			})
 		})
 
+		When("vLLM-Omni CUDA Runtime is used", func() {
+			It("should create ConfigMap with supported=true and vLLM metrics", func(ctx SpecContext) {
+				servingRuntime := createServingRuntime("vllm-omni-cuda-runtime", map[string]string{
+					constants.KServeRuntimeAnnotation: constants.VllmOmniRuntimeName,
+				})
+
+				isvc := &kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vllm-omni-cuda-model",
+						Namespace: "test-namespace",
+					},
+					Spec: kservev1beta1.InferenceServiceSpec{
+						Predictor: kservev1beta1.PredictorSpec{
+							Model: &kservev1beta1.ModelSpec{
+								ModelFormat: kservev1beta1.ModelFormat{Name: "huggingface"},
+								Runtime:     ptr.To("vllm-omni-cuda-runtime"),
+							},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(isvc, servingRuntime).
+					Build()
+				reconciler := NewKserveMetricsDashboardReconciler(client)
+
+				err := reconciler.Reconcile(ctx, log.Log, isvc)
+				Expect(err).NotTo(HaveOccurred())
+
+				configMap := &corev1.ConfigMap{}
+				err = client.Get(ctx, k8stypes.NamespacedName{
+					Name:      isvc.Name + constants.KserveMetricsConfigMapNameSuffix,
+					Namespace: isvc.Namespace,
+				}, configMap)
+				Expect(err).NotTo(HaveOccurred())
+
+				fromGetMetrics, _ := getMetricsData(servingRuntime)
+				finaldata := utils.SubstituteVariablesInQueries(fromGetMetrics, isvc.Namespace, isvc.Name)
+
+				Expect(configMap.Data["supported"]).To(Equal("true"))
+				Expect(configMap.Data["metrics"]).To(Equal(finaldata))
+				Expect(configMap.Data["metrics"]).To(ContainSubstring("vllm-omni-cuda-model"))
+				Expect(configMap.Data["metrics"]).To(ContainSubstring("test-namespace"))
+			})
+		})
+
 		When("TGIS Runtime is used", func() {
 			It("should create ConfigMap with supported=true and TGIS metrics", func(ctx SpecContext) {
 				// Create TGIS ServingRuntime


### PR DESCRIPTION
feat : Add vLLM-Omni CUDA ServingRuntime template for multimodal inference (Dev Preview)

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

Adds a new OpenShift Template for the vLLM-Omni CUDA ServingRuntime, enabling multimodal inference (omni, diffusion, TTS) on NVIDIA GPUs as a Dev Preview feature.

**Changes:**
- **`config/runtimes/vllm-omni-cuda-template.yaml`**: New ServingRuntime template targeting NVIDIA GPUs with `vllm serve --omni` entrypoint, following existing vLLM variant conventions
- **`config/runtimes/kustomization.yaml`**: Registered the new template
- **`config/base/params.env`**: Added `vllm-omni-cuda-image` placeholder
- **`config/base/kustomization.yaml`**: Added kustomize replacement block to wire the image into the template
- **`internal/controller/constants/constants.go`**: Added `VllmOmniRuntimeName` constant (`vllm-omni`)
- **`internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go`**: Added `vllm-omni` case to metrics switch (reuses `VllmMetricsData` since vllm-omni inherits vLLM's Prometheus metrics)
- **`internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go`**: Added unit test for the new metrics case
- **`config/component_metadata.yaml`**: Added vLLM-Omni entry (v0.22.0)
- **`architecture.md`**: Added row to the Runtime Templates table

**Key design decisions:**
- `opendatahub.io/kserve-runtime: 'vllm-omni'` — distinct from `vllm` because vllm-omni is a separate software stack, not just a hardware variant
- Reuses `VllmMetricsData` for metrics since vllm-omni inherits upstream vLLM's Prometheus metric names
- Display name includes "- Dev Preview" suffix per maturity convention

Jira-Link: https://redhat.atlassian.net/browse/RHOAIENG-66881

## How Has This Been Tested?

- Verified all modified Go files compile without errors (`go build ./...`)
- Ran unit tests for the metrics dashboard reconciler (`go test ./internal/controller/serving/reconcilers/...`) — all pass including the new vLLM-Omni test case
- Validated template YAML structure against existing vLLM variants (cuda, gaudi, spyre, cpu-x86) for consistency
- Confirmed kustomize replacement wiring is correct by comparing with existing replacement blocks

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for vLLM-Omni CUDA runtime (v0.22.0) for multimodal model serving on NVIDIA GPUs, selectable as a ServingRuntime with metrics dashboard support.

* **Documentation**
  * Updated architecture and component metadata to document the vLLM-Omni runtime and its template/configuration.

* **Tests**
  * Added test coverage validating metrics dashboard generation for vLLM-Omni deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->