### PR TITLE
Updated Runtime Templates version for 3.5 ea2

### DIFF
--- a/config/runtimes/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm-cpu-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (ppc64le/s390x) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-cpu-x86-template.yaml
+++ b/config/runtimes/vllm-cpu-x86-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-x86-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (x86) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-cuda-template.yaml
+++ b/config/runtimes/vllm-cuda-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-gaudi-template.yaml
+++ b/config/runtimes/vllm-gaudi-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm-multinode-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'false'
     spec:

--- a/config/runtimes/vllm-rocm-template.yaml
+++ b/config/runtimes/vllm-rocm-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-ppc64le-template.yaml
+++ b/config/runtimes/vllm-spyre-ppc64le-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre ppc64le ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm-spyre-s390x-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre s390x ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-x86-template.yaml
+++ b/config/runtimes/vllm-spyre-x86-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre on x86 ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.19.1'
+        opendatahub.io/runtime-version: 'v0.21.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vLLM ServingRuntime templates to reference v0.21.0 across multiple hardware variants (CPU/GPU and architecture-specific templates).
  * Adjusted template configuration touch-ups related to networking/volume settings in a couple of variants while keeping behavior consistent (e.g., protocol remains TCP; shared memory sizing metadata may change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->