### PR TITLE
fix(release): exclude llm-d images from params.env update in kserve

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -216,8 +216,9 @@ jobs:
               r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver)):((?:odh-model-serving-api-)?)(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           else:
+            # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []


### PR DESCRIPTION
As per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image tagging logic in the release process to prevent unintended updates to specific deployment artifact types during automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->