### PR TITLE
fix: update gateway ref types for kserve v1alpha2 and fix e2e image injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,15 +165,15 @@ e2e-kserve-overlay: kustomize ## Create a kustomize overlay injecting the contro
 	@sed -i 's|^odh-model-controller=.*|odh-model-controller=$(ODH_MODEL_CONTROLLER_IMAGE)|' "$(E2E_OVERLAY_DIR)/params.env"
 	@sed -i 's|^odh-model-serving-api=.*|odh-model-serving-api=$(SERVER_IMG)|' "$(E2E_OVERLAY_DIR)/params.env"
 	@cd "$(E2E_OVERLAY_DIR)" && \
-		ctrl_img=$$(sed -n 's/^odh-model-controller=\([^:@]*\).*/\1/p' ../../config/base/params.env) && \
-		srv_img=$$(sed -n 's/^odh-model-serving-api=\([^:@]*\).*/\1/p' ../../config/base/params.env) && \
 		$(KUSTOMIZE) init && \
 		$(KUSTOMIZE) edit add resource ../../config/base && \
 		$(KUSTOMIZE) edit add configmap odh-model-controller-parameters \
 			--behavior=merge \
 			--from-env-file=params.env && \
-		$(KUSTOMIZE) edit set image "$$ctrl_img=$(ODH_MODEL_CONTROLLER_IMAGE)" && \
-		$(KUSTOMIZE) edit set image "$$srv_img=$(SERVER_IMG)"
+		printf '[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"%s"}]' '$(ODH_MODEL_CONTROLLER_IMAGE)' > patch-controller.json && \
+		printf '[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"%s"}]' '$(SERVER_IMG)' > patch-server.json && \
+		$(KUSTOMIZE) edit add patch --kind Deployment --name odh-model-controller --path patch-controller.json && \
+		$(KUSTOMIZE) edit add patch --kind Deployment --name model-serving-api --path patch-server.json
 	@echo "Created e2e overlay at $(E2E_OVERLAY_DIR)"
 	@echo "  controller: $(ODH_MODEL_CONTROLLER_IMAGE)"
 	@echo "  server: $(SERVER_IMG)"

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/cert-manager/cert-manager v1.16.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/dot v1.8.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
@@ -114,7 +115,7 @@ require (
 	github.com/kuadrant/policy-machinery v0.7.1-0.20251119154946-1ca17a075dd2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/llm-d/llm-d-workload-variant-autoscaler v0.6.0 // indirect
+	github.com/llm-d/llm-d-workload-variant-autoscaler v0.7.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/martinlindhe/base36 v1.1.1 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
@@ -187,7 +188,7 @@ require (
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.7
 
 // Use ODH release branch instead
-replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933
+replace github.com/kserve/kserve => github.com/opendatahub-io/kserve v0.0.0-20260615193157-c53af872808d
 
 // CVE-2025-68156: Update expr-lang/expr to v1.17.7
 replace github.com/expr-lang/expr => github.com/expr-lang/expr v1.17.7

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/datawire/dlib v1.3.0 h1:KkmyXU1kwm3oPBk1ypR70YbcOlEXWzEbx5RE0iRXTGk=
 github.com/datawire/dlib v1.3.0/go.mod h1:NiGDmetmbkBvtznpWSx6C0vA0s0LK9aHna3LJDqjruk=
@@ -246,8 +248,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/llm-d/llm-d-workload-variant-autoscaler v0.6.0 h1:aMM1MSNB+Jki0X7upzlO41GJKqbxHBIcg5bcUM0mGKs=
-github.com/llm-d/llm-d-workload-variant-autoscaler v0.6.0/go.mod h1:cIQeclF2T5eoDQpCALS2qvormkaxRpkWyXQ1XsqmhxY=
+github.com/llm-d/llm-d-workload-variant-autoscaler v0.7.0 h1:tubrh9eoBR7lLhOyFyvW5/F2ws97b/sl5ogqwJtVEc8=
+github.com/llm-d/llm-d-workload-variant-autoscaler v0.7.0/go.mod h1:CC4Xh7HuMiqCWcOOKwU/AYFBj2m1qwuODDLoRdZkBRI=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/martinlindhe/base36 v1.1.1 h1:1F1MZ5MGghBXDZ2KJ3QfxmiydlWOGB8HCEtkap5NkVg=
@@ -282,8 +284,8 @@ github.com/open-telemetry/opentelemetry-operator v0.113.0 h1:EoN3SLwF9dP5Ou7gFcf
 github.com/open-telemetry/opentelemetry-operator v0.113.0/go.mod h1:eQ8W+MxP+q5Tewf5Cx1vNXvRynjP9JNgrBbUO7TqjXQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933 h1:dCwn+v11R58UxND1RhimSLi4Dub6nuKzJnvsltYuZkI=
-github.com/opendatahub-io/kserve v0.0.0-20260504183808-1fed56624933/go.mod h1:wBepkgRTeDeGTyuNsE22q0Z1hma4psyb05ZdV7XaCsM=
+github.com/opendatahub-io/kserve v0.0.0-20260615193157-c53af872808d h1:ZPhU64tZikAsNm0Iwf6DqrPsY1Lq4KWytYM36v6C4tM=
+github.com/opendatahub-io/kserve v0.0.0-20260615193157-c53af872808d/go.mod h1:cvJMuCP3Tj04bPk5m1gpTObnQJJdyHtPiZxRLr6BGW0=
 github.com/openshift/api v0.0.0-20260306002634-d3bbdada155c h1:YQYiDzOLJzwQunxCaa5OpyNyMLPz4HJ2CLaKqUQOQjQ=
 github.com/openshift/api v0.0.0-20260306002634-d3bbdada155c/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/openshift/client-go v0.0.0-20260306160707-3935d929fc7d h1:T+9HFgEEcnu1TDDfsO5JcJC6N0/Kzob5AtG9IpITHJ8=

--- a/internal/controller/serving/llm/fixture/llmisvc_builders.go
+++ b/internal/controller/serving/llm/fixture/llmisvc_builders.go
@@ -59,7 +59,7 @@ func WithModelName(name string) LLMInferenceServiceOption {
 	}
 }
 
-func WithGatewayRefs(refs ...v1alpha2.UntypedObjectReference) LLMInferenceServiceOption {
+func WithGatewayRefs(refs ...v1alpha2.GatewayObjectReference) LLMInferenceServiceOption {
 	return func(llmSvc *v1alpha2.LLMInferenceService) {
 		if llmSvc.Spec.Router == nil {
 			llmSvc.Spec.Router = &v1alpha2.RouterSpec{}
@@ -123,10 +123,12 @@ func WithManagedRoute() LLMInferenceServiceOption {
 	}
 }
 
-func LLMGatewayRef(name, namespace string) v1alpha2.UntypedObjectReference {
-	return v1alpha2.UntypedObjectReference{
-		Name:      gatewayapiv1.ObjectName(name),
-		Namespace: gatewayapiv1.Namespace(namespace),
+func LLMGatewayRef(name, namespace string) v1alpha2.GatewayObjectReference {
+	return v1alpha2.GatewayObjectReference{
+		UntypedObjectReference: v1alpha2.UntypedObjectReference{
+			Name:      gatewayapiv1.ObjectName(name),
+			Namespace: gatewayapiv1.Namespace(namespace),
+		},
 	}
 }
 

--- a/internal/controller/serving/llm/gateway_controller.go
+++ b/internal/controller/serving/llm/gateway_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -359,7 +360,7 @@ func (r *GatewayReconciler) isGatewayReferencedByLLMService(ctx context.Context,
 // getEffectiveGatewayRefs returns the effective gateway references for an LLMInferenceService.
 // The service's own gateway refs take precedence over those inherited from BaseRef configs,
 // matching the "last one wins" merge semantics used by kserve's MergeSpecs.
-func (r *GatewayReconciler) getEffectiveGatewayRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, llmSvc *kservev1alpha2.LLMInferenceService) []kservev1alpha2.UntypedObjectReference {
+func (r *GatewayReconciler) getEffectiveGatewayRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, llmSvc *kservev1alpha2.LLMInferenceService) []kservev1alpha2.GatewayObjectReference {
 	nsLabels := r.fetchNamespaceLabels(ctx, llmSvc.Namespace)
 
 	// Service's own refs take precedence (replace config refs)
@@ -370,7 +371,7 @@ func (r *GatewayReconciler) getEffectiveGatewayRefs(ctx context.Context, gateway
 	logger := log.FromContext(ctx)
 
 	// Fall back to config refs; last BaseRef with gateway refs wins
-	var refs []kservev1alpha2.UntypedObjectReference
+	var refs []kservev1alpha2.GatewayObjectReference
 	for _, baseRef := range llmSvc.Spec.BaseRefs {
 		cfg, err := r.fetchLLMISvcConfig(ctx, baseRef.Name, llmSvc.Namespace)
 		if err != nil {
@@ -397,12 +398,12 @@ func (r *GatewayReconciler) fetchNamespaceLabels(ctx context.Context, namespace 
 	return ns.Labels
 }
 
-func filterAllowedRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, refs []kservev1alpha2.UntypedObjectReference, targetNS string, nsLabels map[string]string) []kservev1alpha2.UntypedObjectReference {
+func filterAllowedRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, refs []kservev1alpha2.GatewayObjectReference, targetNS string, nsLabels map[string]string) []kservev1alpha2.GatewayObjectReference {
 	if gateway == nil {
 		return refs
 	}
 
-	var allowed []kservev1alpha2.UntypedObjectReference
+	var allowed []kservev1alpha2.GatewayObjectReference
 	for _, ref := range refs {
 		refNs := string(ref.Namespace)
 		if refNs == "" {
@@ -631,14 +632,14 @@ func hasSelectorListeners(gw *gatewayapiv1.Gateway) bool {
 	return false
 }
 
-func getConfigGatewayRefs(cfg *kservev1alpha2.LLMInferenceServiceConfig) []kservev1alpha2.UntypedObjectReference {
+func getConfigGatewayRefs(cfg *kservev1alpha2.LLMInferenceServiceConfig) []kservev1alpha2.GatewayObjectReference {
 	if cfg.Spec.Router != nil && cfg.Spec.Router.Gateway.HasRefs() {
 		return cfg.Spec.Router.Gateway.Refs
 	}
 	return nil
 }
 
-func gatewayRequestsFromRefs(refs []kservev1alpha2.UntypedObjectReference, fallbackNamespace string) []reconcile.Request {
+func gatewayRequestsFromRefs(refs []kservev1alpha2.GatewayObjectReference, fallbackNamespace string) []reconcile.Request {
 	requests := make([]reconcile.Request, 0, len(refs))
 	for _, ref := range refs {
 		namespace := string(ref.Namespace)
@@ -666,16 +667,19 @@ func referencesConfig(svc *kservev1alpha2.LLMInferenceService, configName string
 }
 
 // gatewayRefsEqual reports whether two sets of gateway refs are equivalent (order-independent).
-func gatewayRefsEqual(a, b []kservev1alpha2.UntypedObjectReference) bool {
+func gatewayRefsEqual(a, b []kservev1alpha2.GatewayObjectReference) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	cmp := func(x, y kservev1alpha2.UntypedObjectReference) int {
+	cmp := func(x, y kservev1alpha2.GatewayObjectReference) int {
 		if c := strings.Compare(string(x.Namespace), string(y.Namespace)); c != 0 {
 			return c
 		}
-		return strings.Compare(string(x.Name), string(y.Name))
+		if c := strings.Compare(string(x.Name), string(y.Name)); c != 0 {
+			return c
+		}
+		return strings.Compare(string(ptr.Deref(x.SectionName, "")), string(ptr.Deref(y.SectionName, "")))
 	}
 
 	sortedA := slices.Clone(a)
@@ -684,7 +688,8 @@ func gatewayRefsEqual(a, b []kservev1alpha2.UntypedObjectReference) bool {
 	slices.SortFunc(sortedB, cmp)
 
 	for i := range sortedA {
-		if sortedA[i].Name != sortedB[i].Name || sortedA[i].Namespace != sortedB[i].Namespace {
+		if sortedA[i].Name != sortedB[i].Name || sortedA[i].Namespace != sortedB[i].Namespace ||
+			ptr.Deref(sortedA[i].SectionName, "") != ptr.Deref(sortedB[i].SectionName, "") {
 			return false
 		}
 	}
@@ -737,7 +742,7 @@ func gatewayRefsChanged(old, new *kservev1alpha2.LLMInferenceService) bool {
 	return false
 }
 
-func getGatewayRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, llmSvc *kservev1alpha2.LLMInferenceService, nsLabels map[string]string) []kservev1alpha2.UntypedObjectReference {
+func getGatewayRefs(ctx context.Context, gateway *gatewayapiv1.Gateway, llmSvc *kservev1alpha2.LLMInferenceService, nsLabels map[string]string) []kservev1alpha2.GatewayObjectReference {
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Gateway.HasRefs() {
 		return filterAllowedRefs(ctx, gateway, slices.Clone(llmSvc.Spec.Router.Gateway.Refs), llmSvc.Namespace, nsLabels)
 	}

--- a/internal/controller/serving/llm/gateway_controller_test.go
+++ b/internal/controller/serving/llm/gateway_controller_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Gateway Controller", func() {
 				}
 				llmSvc.Spec.Router = &kservev1alpha2.RouterSpec{
 					Gateway: &kservev1alpha2.GatewaySpec{
-						Refs: []kservev1alpha2.UntypedObjectReference{
+						Refs: []kservev1alpha2.GatewayObjectReference{
 							fixture.LLMGatewayRef(gatewayName, testNs),
 						},
 					},
@@ -419,7 +419,7 @@ var _ = Describe("Gateway Controller", func() {
 				if err := envTest.Client.Get(ctx, types.NamespacedName{Name: llmSvc.Name, Namespace: testNs}, llmSvc); err != nil {
 					return err
 				}
-				llmSvc.Spec.Router.Gateway.Refs = []kservev1alpha2.UntypedObjectReference{refB, refA}
+				llmSvc.Spec.Router.Gateway.Refs = []kservev1alpha2.GatewayObjectReference{refB, refA}
 				return envTest.Client.Update(ctx, llmSvc)
 			}).WithContext(ctx).Should(Succeed())
 

--- a/internal/controller/serving/llm/gateway_filter_test.go
+++ b/internal/controller/serving/llm/gateway_filter_test.go
@@ -10,10 +10,12 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func ref(name, namespace string) kservev1alpha2.UntypedObjectReference {
-	return kservev1alpha2.UntypedObjectReference{
-		Name:      gatewayapiv1.ObjectName(name),
-		Namespace: gatewayapiv1.Namespace(namespace),
+func ref(name, namespace string) kservev1alpha2.GatewayObjectReference {
+	return kservev1alpha2.GatewayObjectReference{
+		UntypedObjectReference: kservev1alpha2.UntypedObjectReference{
+			Name:      gatewayapiv1.ObjectName(name),
+			Namespace: gatewayapiv1.Namespace(namespace),
+		},
 	}
 }
 
@@ -64,16 +66,16 @@ func TestFilterAllowedRefs(t *testing.T) {
 	tests := []struct {
 		name     string
 		gateway  *gatewayapiv1.Gateway
-		refs     []kservev1alpha2.UntypedObjectReference
+		refs     []kservev1alpha2.GatewayObjectReference
 		targetNS string
 		nsLabels map[string]string
 		wantLen  int
-		wantRefs []kservev1alpha2.UntypedObjectReference
+		wantRefs []kservev1alpha2.GatewayObjectReference
 	}{
 		{
 			name:    "nil gateway returns all refs",
 			gateway: nil,
-			refs:    []kservev1alpha2.UntypedObjectReference{ref("gw", "ns")},
+			refs:    []kservev1alpha2.GatewayObjectReference{ref("gw", "ns")},
 			wantLen: 1,
 		},
 		{
@@ -86,49 +88,49 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:     "ref to different gateway is kept",
 			gateway:  gateway("gw-a", "ns", sameListener("http")),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw-b", "ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw-b", "ns")},
 			targetNS: "other",
 			wantLen:  1,
 		},
 		{
 			name:     "From All allows ref from any namespace",
 			gateway:  gateway("gw", "gw-ns", allListener("http")),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "other-ns",
 			wantLen:  1,
 		},
 		{
 			name:     "From Same allows ref from same namespace",
 			gateway:  gateway("gw", "ns", sameListener("http")),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "ns")},
 			targetNS: "ns",
 			wantLen:  1,
 		},
 		{
 			name:     "From Same rejects ref from different namespace",
 			gateway:  gateway("gw", "gw-ns", sameListener("http")),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "other-ns",
 			wantLen:  0,
 		},
 		{
 			name:     "nil allowedRoutes defaults to Same, same namespace",
 			gateway:  gateway("gw", "ns", gatewayapiv1.Listener{Name: "http"}),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "ns")},
 			targetNS: "ns",
 			wantLen:  1,
 		},
 		{
 			name:     "nil allowedRoutes defaults to Same, different namespace",
 			gateway:  gateway("gw", "gw-ns", gatewayapiv1.Listener{Name: "http"}),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "other-ns",
 			wantLen:  0,
 		},
 		{
 			name:     "From Selector with matching labels allows",
 			gateway:  gateway("gw", "gw-ns", selectorListener()),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "any-ns",
 			nsLabels: map[string]string{"env": "prod"},
 			wantLen:  1,
@@ -136,7 +138,7 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:     "From Selector with non-matching labels rejects",
 			gateway:  gateway("gw", "gw-ns", selectorListener()),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "any-ns",
 			nsLabels: map[string]string{"env": "staging"},
 			wantLen:  0,
@@ -144,7 +146,7 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:     "From Selector with nil labels rejects",
 			gateway:  gateway("gw", "gw-ns", selectorListener()),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "any-ns",
 			nsLabels: nil,
 			wantLen:  0,
@@ -152,7 +154,7 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:    "empty ref namespace defaults to targetNS",
 			gateway: gateway("gw", "app-ns", allListener("http")),
-			refs:    []kservev1alpha2.UntypedObjectReference{ref("gw", "")},
+			refs:    []kservev1alpha2.GatewayObjectReference{ref("gw", "")},
 			// ref ns is empty → defaults to targetNS ("app-ns") → matches gateway ns
 			targetNS: "app-ns",
 			wantLen:  1,
@@ -160,7 +162,7 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:     "empty ref namespace defaults to targetNS, no match",
 			gateway:  gateway("gw", "gw-ns", sameListener("http")),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "")},
 			targetNS: "other-ns",
 			// ref ns defaults to "other-ns" → doesn't match gateway ns "gw-ns" → kept as different gateway
 			wantLen: 1,
@@ -168,7 +170,7 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:    "multiple listeners, one allows",
 			gateway: gateway("gw", "gw-ns", sameListener("internal"), allListener("external")),
-			refs:    []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:    []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			// sameListener rejects "other-ns", but allListener allows it
 			targetNS: "other-ns",
 			wantLen:  1,
@@ -176,21 +178,21 @@ func TestFilterAllowedRefs(t *testing.T) {
 		{
 			name:     "gateway with no listeners rejects",
 			gateway:  gateway("gw", "gw-ns"),
-			refs:     []kservev1alpha2.UntypedObjectReference{ref("gw", "gw-ns")},
+			refs:     []kservev1alpha2.GatewayObjectReference{ref("gw", "gw-ns")},
 			targetNS: "gw-ns",
 			wantLen:  0,
 		},
 		{
 			name:    "mixed refs: matching and non-matching gateways",
 			gateway: gateway("gw", "gw-ns", sameListener("http")),
-			refs: []kservev1alpha2.UntypedObjectReference{
+			refs: []kservev1alpha2.GatewayObjectReference{
 				ref("gw", "gw-ns"),        // matches gateway, Same rejects "other-ns"
 				ref("other-gw", "gw-ns"),  // different gateway, kept
 				ref("gw", "different-ns"), // different namespace, kept
 			},
 			targetNS: "other-ns",
 			wantLen:  2,
-			wantRefs: []kservev1alpha2.UntypedObjectReference{
+			wantRefs: []kservev1alpha2.GatewayObjectReference{
 				ref("other-gw", "gw-ns"),
 				ref("gw", "different-ns"),
 			},

--- a/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
@@ -267,7 +267,7 @@ var _ = Describe("BaseRefs and Spec Merging", func() {
 		)
 		config.Spec.Router = &kservev1alpha2.RouterSpec{
 			Gateway: &kservev1alpha2.GatewaySpec{
-				Refs: []kservev1alpha2.UntypedObjectReference{
+				Refs: []kservev1alpha2.GatewayObjectReference{
 					fixture.LLMGatewayRef(gatewayName, gatewayNamespace),
 				},
 			},


### PR DESCRIPTION
## Summary
The Konflux build for odh-v3.5-EA2 failed because the release workflow auto-bumped the kserve dependency to a commit that introduced a breaking API change: `GatewaySpec.Refs` was changed from `[]UntypedObjectReference` to `[]GatewayObjectReference` in kserve v1alpha2.

This PR:
- Bumps the kserve dependency to the odh-v3.5-EA2 commit (`c53af872808d`)
- Updates all gateway-related functions, tests, and fixtures to use `GatewayObjectReference`
- Adds `SectionName` comparison to `gatewayRefsEqual` to account for the new field
- Fixes e2e kustomize overlay image injection: replaces `kustomize edit set image` (which collided when both images share the same base repo name due to Konflux workaround) with JSON patches targeted by Deployment name

## Root cause
The release workflow auto-bumps the kserve `replace` directive in `go.mod` at release time and runs `go mod tidy`, but does not run `go build` to verify the code still compiles. The kserve dependency on incubating was pinned to a May 4 commit, while the odh-v3.5-EA2 kserve tag resolved to a June 15 commit that changed the `Refs` field type. Since no PR was involved in the release commit, no CI caught the incompatibility.

The e2e tests were also failing on all incubating PRs because PR #758 changed `odh-model-serving-api` to publish under the same `quay.io/opendatahub/odh-model-controller` repo (Konflux workaround), causing `kustomize edit set image` to overwrite the controller image with the server image. The fix uses per-Deployment JSON patches which are unambiguous.

## Follow-up
- Consider adding a `go build ./...` step after `go mod tidy` in the release workflow to prevent this class of failure
- The Prow e2e tests are currently blocked by an unrelated `STORAGE_INITIALIZER_IMAGE: unbound variable` error in the kserve e2e setup script (`opendatahub-io/kserve` master branch)

## Files changed
- `go.mod` / `go.sum` -- bump kserve to odh-v3.5-EA2 commit
- `internal/controller/serving/llm/gateway_controller.go` -- update types + `SectionName` comparison
- `internal/controller/serving/llm/gateway_filter_test.go` -- update test types
- `internal/controller/serving/llm/gateway_controller_test.go` -- update test types
- `internal/controller/serving/llm/llm_inferenceservice_controller_test.go` -- update test types
- `internal/controller/serving/llm/fixture/llmisvc_builders.go` -- update builder types
- `Makefile` -- fix e2e overlay image injection using JSON patches instead of `kustomize edit set image`