### PR TITLE
fix(release): add go build smoke test after kserve dep update

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -384,13 +384,21 @@ jobs:
             f.write(new_content)
 
           print("Running go mod tidy...")
-          result = subprocess.run(['go', 'mod', 'tidy'], capture_output=True, text=True)
+          try:
+            result = subprocess.run(['go', 'mod', 'tidy'], capture_output=True, text=True, timeout=300)
+          except subprocess.TimeoutExpired:
+            print(f"::error::go mod tidy timed out after 300s")
+            raise SystemExit(1)
           if result.returncode != 0:
             print(f"::error::go mod tidy failed:\n{result.stderr}")
             raise SystemExit(1)
 
           print("Running go build ./... (smoke test)...")
-          result = subprocess.run(['go', 'build', './...'], capture_output=True, text=True)
+          try:
+            result = subprocess.run(['go', 'build', './...'], capture_output=True, text=True, timeout=300)
+          except subprocess.TimeoutExpired:
+            print(f"::error::go build timed out after 300s")
+            raise SystemExit(1)
           if result.returncode != 0:
             print(f"::error::go build failed after kserve dependency update:\n{result.stderr}")
             raise SystemExit(1)

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -379,10 +379,7 @@ jobs:
 
           print(f"{prefix_label}Updating kserve dependency: {old_version} -> {tag_name}")
 
-          if dry_run:
-            print(f"✓ {prefix_label}kserve dependency would be updated")
-            raise SystemExit(0)
-
+          # Write go.mod even in dry run — needed for tidy + build validation
           with open('go.mod', 'w') as f:
             f.write(new_content)
 
@@ -392,6 +389,12 @@ jobs:
             print(f"::error::go mod tidy failed:\n{result.stderr}")
             raise SystemExit(1)
 
+          print("Running go build ./... (smoke test)...")
+          result = subprocess.run(['go', 'build', './...'], capture_output=True, text=True)
+          if result.returncode != 0:
+            print(f"::error::go build failed after kserve dependency update:\n{result.stderr}")
+            raise SystemExit(1)
+
           with open('go.mod', 'r') as f:
             resolved = f.read()
           resolved_match = pattern.search(resolved)
@@ -399,7 +402,11 @@ jobs:
             resolved_version = resolved_match.group(0).rsplit(' ', 1)[1]
             print(f"  Resolved to: {resolved_version}")
 
-          print(f"✓ kserve dependency updated")
+          if dry_run:
+            print(f"✓ {prefix_label}kserve dependency validated (build passed) — changes not committed")
+            raise SystemExit(0)
+
+          print(f"✓ kserve dependency updated and validated")
         shell: python
 
       - name: Commit release changes (if any)


### PR DESCRIPTION
## Summary
- Add `go build ./...` after `go mod tidy` in the release workflow's kserve dependency update step
- Catches type mismatches (e.g. renamed API types) before commit/tag/push
- Restructure dry run to validate full tidy+build pipeline instead of exiting early

## Context
The release workflow updates the kserve go.mod replace directive but previously didn't verify that odh-model-controller still compiles against the new version. This caused silent build failures when kserve API types changed (e.g. `UntypedObjectReference` → `GatewayObjectReference`), only caught later during Konflux container builds.

## Test plan
- [ ] Trigger workflow with `dry_run: true` targeting `odh-model-controller` — verify build check runs and passes
- [ ] Trigger workflow with a known-incompatible kserve tag — verify build check fails and blocks release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved the dependency update workflow by ensuring the updated module file is written in both dry-run and non-dry-run modes.
  * Added a validation sequence that runs a module tidy followed by a full build smoke test, with clearer failure/timeout behavior.
  * Enhanced logging to confirm the resolved kserve version after a successful update.
  * Updated dry-run completion messaging to reflect “changes not committed.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->