### PR TITLE
feat(webhook): migrate HardwareProfile injection to odh-model-controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -99,6 +99,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - infrastructure.opendatahub.io
+  resources:
+  - hardwareprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - keda.sh
   resources:
   - triggerauthentications

--- a/internal/webhook/serving/hardwareprofile/injector.go
+++ b/internal/webhook/serving/hardwareprofile/injector.go
@@ -1,0 +1,318 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hardwareprofile
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	servingv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+)
+
+// ApplyToIsvcResources injects HWP resource identifiers into the InferenceService predictor model.
+//
+// For each identifier in the profile, applies defaultCount to both requests and limits only when
+// the resource name is absent from both maps (preserves user-set values). No-op when profile has
+// no identifiers or when predictor.Model is nil.
+//
+// Parameters:
+//   - profile: the resolved HardwareProfile with resource identifiers
+//   - predictor: the PredictorSpec whose Model.Resources are mutated in-place
+func ApplyToIsvcResources(profile *ResolvedProfile, predictor *servingv1beta1.PredictorSpec) {
+	log := logf.Log.WithName("hwp-injector")
+
+	if len(profile.Identifiers) == 0 {
+		return
+	}
+	if predictor.Model == nil {
+		log.Info("predictor.Model is nil, skipping HWP resource injection")
+		return
+	}
+
+	for _, id := range profile.Identifiers {
+		resName := corev1.ResourceName(id.Identifier)
+
+		// Apply to requests if not already present (checks requests only).
+		if _, exists := predictor.Model.Resources.Requests[resName]; !exists {
+			if predictor.Model.Resources.Requests == nil {
+				predictor.Model.Resources.Requests = corev1.ResourceList{}
+			}
+			predictor.Model.Resources.Requests[resName] = id.DefaultCount
+		}
+
+		// Apply to limits if not already present, using the current request value
+		// (which may be the user's pre-existing value or the defaultCount just set above).
+		if _, exists := predictor.Model.Resources.Limits[resName]; !exists {
+			if reqVal, hasReq := predictor.Model.Resources.Requests[resName]; hasReq {
+				if predictor.Model.Resources.Limits == nil {
+					predictor.Model.Resources.Limits = corev1.ResourceList{}
+				}
+				predictor.Model.Resources.Limits[resName] = reqVal
+			}
+		}
+	}
+}
+
+// ApplyToLLMIsvcResources injects HWP resource identifiers into the LLMInferenceService "main" container.
+//
+// When containers is empty, creates a minimal container named "main" before applying resources.
+// When a non-empty slice has no "main" container, logs a warning and returns the unmodified slice.
+// For each identifier, applies defaultCount to both requests and limits only when the resource name
+// is absent from both maps.
+//
+// Parameters:
+//   - profile: the resolved HardwareProfile with resource identifiers
+//   - containers: the current container list from spec.template.containers
+//
+// Returns the updated container slice (may be a new slice if "main" was created).
+func ApplyToLLMIsvcResources(profile *ResolvedProfile, containers []corev1.Container) ([]corev1.Container, error) {
+	log := logf.Log.WithName("hwp-injector")
+
+	if len(profile.Identifiers) == 0 {
+		return containers, nil
+	}
+
+	if len(containers) == 0 {
+		// Create a minimal "main" container as the injection target.
+		containers = []corev1.Container{{Name: LLMIsvcMainContainerName}}
+	}
+
+	mainIdx := -1
+	for i, c := range containers {
+		if c.Name == LLMIsvcMainContainerName {
+			mainIdx = i
+			break
+		}
+	}
+
+	if mainIdx == -1 {
+		log.Info("no 'main' container found in non-empty LLMIsvc container list, skipping resource injection")
+		return containers, nil
+	}
+
+	for _, id := range profile.Identifiers {
+		resName := corev1.ResourceName(id.Identifier)
+
+		// Apply to requests if not already present (checks requests only).
+		if _, exists := containers[mainIdx].Resources.Requests[resName]; !exists {
+			if containers[mainIdx].Resources.Requests == nil {
+				containers[mainIdx].Resources.Requests = corev1.ResourceList{}
+			}
+			containers[mainIdx].Resources.Requests[resName] = id.DefaultCount
+		}
+
+		// Apply to limits if not already present, using the current request value
+		// (which may be the user's pre-existing value or the defaultCount just set above).
+		if _, exists := containers[mainIdx].Resources.Limits[resName]; !exists {
+			if reqVal, hasReq := containers[mainIdx].Resources.Requests[resName]; hasReq {
+				if containers[mainIdx].Resources.Limits == nil {
+					containers[mainIdx].Resources.Limits = corev1.ResourceList{}
+				}
+				containers[mainIdx].Resources.Limits[resName] = reqVal
+			}
+		}
+	}
+
+	return containers, nil
+}
+
+// MergeNodeScheduling merges HWP node scheduling stanzas into existing nodeSelector and tolerations.
+//
+// For nodeSelector: HWP values overwrite existing values for conflicting keys; a warning is
+// generated per overwritten key. HWP-only keys are added without conflict.
+// For tolerations: HWP tolerations are prepended; existing tolerations whose TolerationKey does not
+// match any HWP toleration are appended. Exact-match duplicates are dropped.
+//
+// Parameters:
+//   - profile: the resolved HardwareProfile with NodeSelector and Tolerations
+//   - nodeSelector: the current nodeSelector on the workload (may be nil)
+//   - tolerations: the current tolerations on the workload (may be nil)
+//   - hwpName: the HardwareProfile name, used in warning messages
+//
+// Returns the merged nodeSelector, merged tolerations, and any warning strings.
+func MergeNodeScheduling(
+	profile *ResolvedProfile,
+	nodeSelector map[string]string,
+	tolerations []corev1.Toleration,
+	hwpName string,
+) (map[string]string, []corev1.Toleration, []string) {
+	var warnings []string
+
+	// Merge nodeSelector: start with existing entries, then overwrite with HWP entries.
+	merged := make(map[string]string, len(nodeSelector)+len(profile.NodeSelector))
+	for k, v := range nodeSelector {
+		merged[k] = v
+	}
+	for k, v := range profile.NodeSelector {
+		if existing, exists := nodeSelector[k]; exists && existing != v {
+			warnings = append(warnings, fmt.Sprintf(
+				"nodeSelector key %q has value %q which will be overwritten by HardwareProfile %q with value %q",
+				k, existing, hwpName, v))
+		}
+		merged[k] = v
+	}
+	if len(merged) == 0 {
+		merged = nil
+	}
+
+	// Merge tolerations: HWP tolerations first, then non-conflicting existing ones.
+	hwpTolKeys := make(map[string]bool, len(profile.Tolerations))
+	for _, t := range profile.Tolerations {
+		hwpTolKeys[TolerationKey(t)] = true
+	}
+	mergedTols := make([]corev1.Toleration, 0, len(profile.Tolerations)+len(tolerations))
+	mergedTols = append(mergedTols, profile.Tolerations...)
+	for _, t := range tolerations {
+		if !hwpTolKeys[TolerationKey(t)] {
+			mergedTols = append(mergedTols, t)
+		}
+	}
+
+	return merged, mergedTols, warnings
+}
+
+// SetNodeScheduling sets the workload's node scheduling fields directly from the HWP profile.
+//
+// Called after a blanket clear when the HWP reference changed (profileChanged=true). The existing
+// nodeSelector and tolerations are ignored; only the profile's values are used.
+//
+// Parameters:
+//   - profile: the resolved HardwareProfile with NodeSelector and Tolerations
+//   - nodeSelector: unused; present for API symmetry with MergeNodeScheduling
+//   - tolerations: unused; present for API symmetry with MergeNodeScheduling
+//
+// Returns copies of the HWP nodeSelector and tolerations.
+func SetNodeScheduling(
+	profile *ResolvedProfile,
+	nodeSelector map[string]string,
+	tolerations []corev1.Toleration,
+) (map[string]string, []corev1.Toleration) {
+	var newNS map[string]string
+	if len(profile.NodeSelector) > 0 {
+		newNS = make(map[string]string, len(profile.NodeSelector))
+		for k, v := range profile.NodeSelector {
+			newNS[k] = v
+		}
+	}
+
+	var newTols []corev1.Toleration
+	if len(profile.Tolerations) > 0 {
+		newTols = make([]corev1.Toleration, len(profile.Tolerations))
+		copy(newTols, profile.Tolerations)
+	}
+
+	return newNS, newTols
+}
+
+// ApplyKueueLabel sets the kueue.x-k8s.io/queue-name label on the workload metadata.
+//
+// Always overwrites an existing value. When profileChanged is false and the existing label differs
+// from the HWP value, a warning is generated. No-op when the profile has no Kueue queue name.
+//
+// Parameters:
+//   - profile: the resolved HardwareProfile; KueueQueueName must be non-empty for this to do anything
+//   - meta: the workload ObjectMeta to mutate
+//   - profileChanged: suppresses the overwrite warning when the profile just switched
+//   - hwpName: the HardwareProfile name, used in warning messages
+//
+// Returns any warning strings generated.
+func ApplyKueueLabel(profile *ResolvedProfile, meta *metav1.ObjectMeta, profileChanged bool, hwpName string) []string {
+	if profile.KueueQueueName == "" {
+		return nil
+	}
+
+	var warnings []string
+	if !profileChanged {
+		if existing := meta.Labels[KueueQueueNameLabel]; existing != "" && existing != profile.KueueQueueName {
+			warnings = append(warnings, fmt.Sprintf(
+				"label %q has value %q which will be overwritten by HardwareProfile %q with value %q",
+				KueueQueueNameLabel, existing, hwpName, profile.KueueQueueName))
+		}
+	}
+
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+	meta.Labels[KueueQueueNameLabel] = profile.KueueQueueName
+
+	return warnings
+}
+
+// RemoveNodeScheduling surgically removes HWP-applied nodeSelector entries and tolerations.
+//
+// For nodeSelector: removes keys whose current value exactly matches the HWP profile value.
+// Keys with different values are preserved (they were manually set by the user after HWP injection).
+// For tolerations: removes tolerations whose TolerationKey matches a HWP toleration. Others are kept.
+//
+// Parameters:
+//   - profile: the old HardwareProfile whose entries should be removed
+//   - nodeSelector: the current nodeSelector on the workload (may be nil)
+//   - tolerations: the current tolerations on the workload (may be nil)
+//
+// Returns the cleaned nodeSelector and tolerations (nil when all entries were removed).
+func RemoveNodeScheduling(
+	profile *ResolvedProfile,
+	nodeSelector map[string]string,
+	tolerations []corev1.Toleration,
+) (map[string]string, []corev1.Toleration) {
+	var newNS map[string]string
+	if len(nodeSelector) > 0 {
+		newNS = make(map[string]string, len(nodeSelector))
+		for k, v := range nodeSelector {
+			newNS[k] = v
+		}
+		for k, v := range profile.NodeSelector {
+			if current, exists := newNS[k]; exists && current == v {
+				delete(newNS, k)
+			}
+		}
+		if len(newNS) == 0 {
+			newNS = nil
+		}
+	}
+
+	var newTols []corev1.Toleration
+	if len(tolerations) > 0 && len(profile.Tolerations) > 0 {
+		hwpTolKeys := make(map[string]bool, len(profile.Tolerations))
+		for _, t := range profile.Tolerations {
+			hwpTolKeys[TolerationKey(t)] = true
+		}
+		for _, t := range tolerations {
+			if !hwpTolKeys[TolerationKey(t)] {
+				newTols = append(newTols, t)
+			}
+		}
+	} else {
+		newTols = tolerations
+	}
+
+	return newNS, newTols
+}
+
+// RemoveKueueLabel removes the kueue.x-k8s.io/queue-name label from the workload metadata.
+// No-op when the label is not present.
+//
+// Parameters:
+//   - meta: the workload ObjectMeta to mutate
+func RemoveKueueLabel(meta *metav1.ObjectMeta) {
+	if meta.Labels != nil {
+		delete(meta.Labels, KueueQueueNameLabel)
+	}
+}

--- a/internal/webhook/serving/hardwareprofile/resolver.go
+++ b/internal/webhook/serving/hardwareprofile/resolver.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hardwareprofile
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Annotation keys for hardware profile references on workload objects.
+const (
+	HardwareProfileAnnotationName      = "opendatahub.io/hardware-profile-name"
+	HardwareProfileAnnotationNamespace = "opendatahub.io/hardware-profile-namespace"
+)
+
+// HardwareProfile CRD group and version.
+const (
+	HardwareProfileGroup   = "infrastructure.opendatahub.io"
+	HardwareProfileVersion = "v1"
+)
+
+// KueueQueueNameLabel is the Kubernetes label used by Kueue to route workloads to a local queue.
+const KueueQueueNameLabel = "kueue.x-k8s.io/queue-name"
+
+// LLMIsvcMainContainerName is the required name for the primary container in an LLMInferenceService.
+const LLMIsvcMainContainerName = "main"
+
+// ResolvedProfile holds the scheduling and resource stanzas extracted from a HardwareProfile CR.
+type ResolvedProfile struct {
+	// Identifiers is the list of resource identifiers (CPU, memory, accelerators) to inject.
+	Identifiers []ResourceIdentifier
+	// NodeSelector entries to merge into the workload spec.
+	NodeSelector map[string]string
+	// Tolerations to prepend to the workload spec.
+	Tolerations []corev1.Toleration
+	// KueueQueueName is the local Kueue queue name; non-empty when schedulingSpec.kueue is set.
+	// When non-empty, node scheduling (NodeSelector/Tolerations) is not applied.
+	KueueQueueName string
+}
+
+// ResourceIdentifier represents a single hardware resource from the HardwareProfile, with the
+// quantity to use for both requests and limits (Guaranteed QoS).
+type ResourceIdentifier struct {
+	// Identifier is the resource name (e.g. "nvidia.com/gpu", "cpu", "memory").
+	Identifier string
+	// DefaultCount is the quantity applied to both requests and limits.
+	DefaultCount resource.Quantity
+}
+
+// ProfileRef extracts the HardwareProfile name and namespace from workload annotations.
+//
+// Falls back to defaultNamespace when the namespace annotation is absent. Returns empty strings
+// when the name annotation is absent.
+//
+// Parameters:
+//   - annotations: the workload object's annotation map
+//   - defaultNamespace: fallback namespace (typically the workload's own namespace)
+//
+// Returns the profile name and resolved namespace.
+func ProfileRef(annotations map[string]string, defaultNamespace string) (name, namespace string) {
+	name = annotations[HardwareProfileAnnotationName]
+	namespace = annotations[HardwareProfileAnnotationNamespace]
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+	return
+}
+
+// ProfileChanged reports whether the HardwareProfile reference changed between the old and new
+// object in an UPDATE admission request.
+//
+// Returns false on CREATE (no old object). Returns false when the old object had no HWP annotation
+// (initial assignment is treated as a merge, not a profile switch). Returns true when either the
+// profile name or namespace differs between old and new.
+//
+// Parameters:
+//   - req: the admission request containing the old object for UPDATE operations
+//   - newProfileName: the profile name from the new object's annotations
+//   - newProfileNamespace: the resolved profile namespace from the new object's annotations
+//
+// Returns true when the profile switched (triggers a full clear before re-injection).
+func ProfileChanged(req admission.Request, newProfileName, newProfileNamespace string) bool {
+	if req.Operation == admissionv1.Create {
+		return false
+	}
+	if req.OldObject.Raw == nil {
+		return true
+	}
+
+	oldObj := &unstructured.Unstructured{}
+	if err := oldObj.UnmarshalJSON(req.OldObject.Raw); err != nil {
+		return true
+	}
+
+	oldAnnotations := oldObj.GetAnnotations()
+	oldProfileName := oldAnnotations[HardwareProfileAnnotationName]
+	if oldProfileName == "" {
+		// Initial HWP assignment — treat as a merge, not a profile switch.
+		return false
+	}
+
+	oldProfileNamespace := oldAnnotations[HardwareProfileAnnotationNamespace]
+	if oldProfileNamespace == "" {
+		oldProfileNamespace = oldObj.GetNamespace()
+	}
+
+	return oldProfileName != newProfileName || oldProfileNamespace != newProfileNamespace
+}
+
+// Resolve fetches a HardwareProfile CR and returns its parsed scheduling and resource stanzas.
+//
+// Uses the controller-runtime unstructured client to avoid importing opendatahub-operator types.
+// Returns nil, nil when name is empty (no HWP configured). Returns a wrapped error (including
+// k8serr.IsNotFound errors) when the CR cannot be fetched.
+//
+// Parameters:
+//   - ctx: request context
+//   - c: controller-runtime client with read access to HardwareProfile CRs
+//   - name: the HardwareProfile CR name
+//   - namespace: the namespace containing the HardwareProfile CR
+//
+// Returns the parsed ResolvedProfile or an error that callers use to block admission.
+func Resolve(ctx context.Context, c client.Client, name, namespace string) (*ResolvedProfile, error) {
+	if name == "" {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   HardwareProfileGroup,
+		Version: HardwareProfileVersion,
+		Kind:    "HardwareProfile",
+	})
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		return nil, fmt.Errorf("failed fetching HardwareProfile %s/%s: %w", namespace, name, err)
+	}
+
+	return parseProfile(obj)
+}
+
+// parseProfile extracts scheduling and resource stanzas from an unstructured HardwareProfile object.
+//
+// Reads spec.identifiers, spec.schedulingSpec.kueue.localQueueName, spec.schedulingSpec.node.nodeSelector,
+// and spec.schedulingSpec.node.tolerations. Kueue and Node scheduling are mutually exclusive:
+// when a Kueue queue name is found, node scheduling fields are not populated.
+//
+// Parameters:
+//   - obj: the HardwareProfile CR as an unstructured object
+//
+// Returns the parsed ResolvedProfile or an error if a field cannot be parsed.
+func parseProfile(obj *unstructured.Unstructured) (*ResolvedProfile, error) {
+	profile := &ResolvedProfile{}
+
+	identifiers, _, _ := unstructured.NestedSlice(obj.Object, "spec", "identifiers")
+	for _, raw := range identifiers {
+		idMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		identifier, _, _ := unstructured.NestedString(idMap, "identifier")
+		if identifier == "" {
+			continue
+		}
+		qty, err := parseQuantity(idMap["defaultCount"])
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing defaultCount for identifier %q: %w", identifier, err)
+		}
+		profile.Identifiers = append(profile.Identifiers, ResourceIdentifier{
+			Identifier:   identifier,
+			DefaultCount: qty,
+		})
+	}
+
+	// Kueue scheduling takes precedence; when present, node scheduling is not read.
+	queueName, _, _ := unstructured.NestedString(obj.Object, "spec", "schedulingSpec", "kueue", "localQueueName")
+	if queueName != "" {
+		profile.KueueQueueName = queueName
+		return profile, nil
+	}
+
+	// Node scheduling.
+	nodeSelector, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "schedulingSpec", "node", "nodeSelector")
+	profile.NodeSelector = nodeSelector
+
+	rawTols, _, _ := unstructured.NestedSlice(obj.Object, "spec", "schedulingSpec", "node", "tolerations")
+	for _, rt := range rawTols {
+		tolMap, ok := rt.(map[string]any)
+		if !ok {
+			continue
+		}
+		profile.Tolerations = append(profile.Tolerations, parseToleration(tolMap))
+	}
+
+	return profile, nil
+}
+
+// parseQuantity converts a raw JSON value (float64, int64, or string) to a resource.Quantity.
+// JSON numbers are parsed as integer quantities; strings are parsed as quantity strings (e.g. "500m").
+func parseQuantity(raw any) (resource.Quantity, error) {
+	switch v := raw.(type) {
+	case int64:
+		return *resource.NewQuantity(v, resource.DecimalSI), nil
+	case float64:
+		return *resource.NewQuantity(int64(v), resource.DecimalSI), nil
+	case string:
+		return resource.ParseQuantity(v)
+	default:
+		return resource.Quantity{}, fmt.Errorf("unexpected type %T for resource quantity", raw)
+	}
+}
+
+// parseToleration constructs a corev1.Toleration from a raw unstructured map.
+func parseToleration(m map[string]any) corev1.Toleration {
+	var t corev1.Toleration
+	t.Key, _ = m["key"].(string)
+	t.Operator = corev1.TolerationOperator(getString(m, "operator"))
+	t.Value, _ = m["value"].(string)
+	t.Effect = corev1.TaintEffect(getString(m, "effect"))
+	if v, ok := m["tolerationSeconds"]; ok {
+		switch ts := v.(type) {
+		case int64:
+			t.TolerationSeconds = &ts
+		case float64:
+			i := int64(ts)
+			t.TolerationSeconds = &i
+		}
+	}
+	return t
+}
+
+// getString retrieves a string value from a map by key.
+func getString(m map[string]any, key string) string {
+	v, _ := m[key].(string)
+	return v
+}
+
+// TolerationKey returns a composite key that uniquely identifies a toleration for deduplication
+// and surgical removal. Includes key, operator, value, effect, and tolerationSeconds.
+//
+// Parameters:
+//   - tol: the toleration to generate a key for
+//
+// Returns a string key that distinguishes tolerations with identical key/operator/effect but
+// different values or tolerationSeconds.
+func TolerationKey(tol corev1.Toleration) string {
+	ts := ""
+	if tol.TolerationSeconds != nil {
+		ts = strconv.FormatInt(*tol.TolerationSeconds, 10)
+	}
+	return fmt.Sprintf("%s:%s:%s:%s:%s",
+		tol.Key, string(tol.Operator), tol.Value, string(tol.Effect), ts)
+}

--- a/internal/webhook/serving/hardwareprofile/resolver_test.go
+++ b/internal/webhook/serving/hardwareprofile/resolver_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hardwareprofile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// errClient is a minimal client.Client stub that returns a fixed error from Get.
+// The embedded nil interface satisfies all other client.Client methods; only Get is
+// overridden. Tests must not call any other method.
+type errClient struct {
+	client.Client
+	err error
+}
+
+func (e errClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return e.err
+}
+
+// TestResolve_EmptyName verifies that Resolve returns (nil, nil) without calling client.Get
+// when the profile name is empty. The embedded errClient would surface an error if Get were
+// called, so the absence of an error proves Get was skipped.
+func TestResolve_EmptyName(t *testing.T) {
+	spy := errClient{err: errors.New("client.Get must not be called when name is empty")}
+	profile, err := Resolve(context.Background(), spy, "", "default")
+	require.NoError(t, err)
+	assert.Nil(t, profile)
+}
+
+// TestResolve_FetchError verifies that Resolve wraps and propagates non-404 errors returned
+// by client.Get. This path is unreachable from integration tests because
+// fake.NewClientBuilder cannot inject arbitrary transient errors without a custom wrapper.
+func TestResolve_FetchError(t *testing.T) {
+	wantErr := errors.New("transient connection error")
+	profile, err := Resolve(context.Background(), errClient{err: wantErr}, "my-hwp", "default")
+	require.Error(t, err)
+	assert.Nil(t, profile)
+	assert.ErrorContains(t, err, "transient connection error")
+}

--- a/internal/webhook/serving/hardwareprofile/testutil/builders.go
+++ b/internal/webhook/serving/hardwareprofile/testutil/builders.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testutil provides helpers for constructing HardwareProfile test fixtures.
+package testutil
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var hwpGVK = schema.GroupVersionKind{
+	Group:   "infrastructure.opendatahub.io",
+	Version: "v1",
+	Kind:    "HardwareProfile",
+}
+
+// NewHardwareProfile creates an unstructured HardwareProfile CR for use in tests.
+//
+// The returned object has the correct GVK set and the provided spec embedded under
+// the "spec" key. Pass a spec built with ResourceSpec, NodeSpec, or KueueSpec.
+//
+// Parameters:
+//   - name: the CR name
+//   - namespace: the CR namespace
+//   - spec: the spec map to embed (nil produces a CR with an empty spec)
+func NewHardwareProfile(name, namespace string, spec map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hwpGVK)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if spec != nil {
+		obj.Object["spec"] = spec
+	}
+	return obj
+}
+
+// ResourceSpec builds a HardwareProfile spec containing only resource identifiers.
+//
+// Each identifier argument is a two-element []string{name, defaultCount}, e.g.
+// []string{"cpu", "4"} or []string{"nvidia.com/gpu", "2"}.
+//
+// Parameters:
+//   - identifiers: variadic pairs of [resourceName, defaultCount]
+//
+// Returns a spec map suitable for passing to NewHardwareProfile.
+func ResourceSpec(identifiers ...[]string) map[string]interface{} {
+	ids := make([]interface{}, 0, len(identifiers))
+	for _, id := range identifiers {
+		if len(id) == 2 {
+			ids = append(ids, map[string]interface{}{
+				"identifier":   id[0],
+				"defaultCount": id[1],
+			})
+		}
+	}
+	return map[string]interface{}{"identifiers": ids}
+}
+
+// NodeSpec builds a HardwareProfile spec with node scheduling configuration.
+//
+// Parameters:
+//   - nodeSelector: map of label key → value pairs (may be nil)
+//   - tolerations: list of toleration maps built with TolerationMap or TolerationMapWithSeconds (may be nil)
+//
+// Returns a spec map suitable for passing to NewHardwareProfile.
+func NodeSpec(nodeSelector map[string]interface{}, tolerations []interface{}) map[string]interface{} {
+	node := map[string]interface{}{}
+	if nodeSelector != nil {
+		node["nodeSelector"] = nodeSelector
+	}
+	if tolerations != nil {
+		node["tolerations"] = tolerations
+	}
+	return map[string]interface{}{
+		"schedulingSpec": map[string]interface{}{"node": node},
+	}
+}
+
+// KueueSpec builds a HardwareProfile spec with Kueue scheduling configuration.
+//
+// Parameters:
+//   - localQueueName: the Kueue local queue name to set
+//
+// Returns a spec map suitable for passing to NewHardwareProfile.
+func KueueSpec(localQueueName string) map[string]interface{} {
+	return map[string]interface{}{
+		"schedulingSpec": map[string]interface{}{
+			"kueue": map[string]interface{}{"localQueueName": localQueueName},
+		},
+	}
+}
+
+// TolerationMap creates a toleration map for use in NodeSpec.
+//
+// Parameters:
+//   - key: the toleration key
+//   - operator: the toleration operator (e.g. "Exists", "Equal")
+//   - effect: the taint effect (e.g. "NoSchedule", "NoExecute")
+func TolerationMap(key, operator, effect string) map[string]interface{} {
+	return map[string]interface{}{
+		"key":      key,
+		"operator": operator,
+		"effect":   effect,
+	}
+}
+
+// TolerationMapWithSeconds creates a toleration map that includes a tolerationSeconds field.
+//
+// Parameters:
+//   - key: the toleration key
+//   - operator: the toleration operator
+//   - effect: the taint effect
+//   - tolerationSeconds: the toleration duration in seconds
+func TolerationMapWithSeconds(key, operator, effect string, tolerationSeconds int64) map[string]interface{} {
+	m := TolerationMap(key, operator, effect)
+	m["tolerationSeconds"] = float64(tolerationSeconds)
+	return m
+}

--- a/internal/webhook/serving/hardwareprofile/testutil/builders.go
+++ b/internal/webhook/serving/hardwareprofile/testutil/builders.go
@@ -20,6 +20,8 @@ package testutil
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile"
 )
 
 var hwpGVK = schema.GroupVersionKind{
@@ -115,6 +117,20 @@ func TolerationMap(key, operator, effect string) map[string]interface{} {
 		"key":      key,
 		"operator": operator,
 		"effect":   effect,
+	}
+}
+
+// HWPAnnotations returns an annotation map carrying only the HardwareProfile name annotation.
+func HWPAnnotations(profileName string) map[string]string {
+	return map[string]string{hardwareprofile.HardwareProfileAnnotationName: profileName}
+}
+
+// HWPAnnotationsWithNS returns an annotation map carrying both the HardwareProfile name and
+// namespace annotations.
+func HWPAnnotationsWithNS(profileName, ns string) map[string]string {
+	return map[string]string{
+		hardwareprofile.HardwareProfileAnnotationName:      profileName,
+		hardwareprofile.HardwareProfileAnnotationNamespace: ns,
 	}
 }
 

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
@@ -330,7 +330,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
 			Expect(newLLM.Spec.Template.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
 			Expect(newLLM.Spec.Template.NodeSelector).NotTo(HaveKey("zone"))
-			keys := make([]string, 0)
+			keys := make([]string, 0, len(newLLM.Spec.Template.Tolerations))
 			for _, t := range newLLM.Spec.Template.Tolerations {
 				keys = append(keys, t.Key)
 			}

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
@@ -107,7 +107,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 
 		It("LLM-1: no annotation — LLMIsvc unmodified", func() {
 			d := newLLMDefaulter(newLLMFakeClient())
-			llm := buildLLMISVCHWP(nil, nil)
+			llm := buildLLMISVCHWP(nil, nil) // nil annotations exercises nil-map path through ProfileRef
 
 			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
 			Expect(llm.Spec.Template).To(BeNil())
@@ -133,11 +133,11 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			Expect(lim[corev1.ResourceMemory]).To(Equal(resource.MustParse("8Gi")))
 		})
 
-		It("LLM-3: HWP with node scheduling — spec.template fields updated", func() {
+		It("LLM-3: HWP with node scheduling — spec.template fields updated (with tolerationSeconds)", func() {
 			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
 				hwptestutil.NodeSpec(
 					map[string]interface{}{"zone": "gpu-zone"},
-					[]interface{}{hwptestutil.TolerationMap("nvidia.com/gpu", "Exists", "NoSchedule")},
+					[]interface{}{hwptestutil.TolerationMapWithSeconds("nvidia.com/gpu", "Exists", "NoSchedule", 300)},
 				))
 			d := newLLMDefaulter(newLLMFakeClient(hwp))
 			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
@@ -146,7 +146,12 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			Expect(llm.Spec.Template).NotTo(BeNil())
 			Expect(llm.Spec.Template.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
 			Expect(llm.Spec.Template.Tolerations).To(HaveLen(1))
-			Expect(llm.Spec.Template.Tolerations[0].Key).To(Equal("nvidia.com/gpu"))
+			tol := llm.Spec.Template.Tolerations[0]
+			Expect(tol.Key).To(Equal("nvidia.com/gpu"))
+			Expect(tol.Operator).To(Equal(corev1.TolerationOpExists))
+			Expect(tol.Effect).To(Equal(corev1.TaintEffectNoSchedule))
+			Expect(tol.TolerationSeconds).NotTo(BeNil())
+			Expect(*tol.TolerationSeconds).To(Equal(int64(300)))
 		})
 
 		It("LLM-4: HWP with Kueue scheduling — label set, node scheduling not applied", func() {
@@ -163,6 +168,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, spec)
 			d := newLLMDefaulter(newLLMFakeClient(hwp))
 			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Labels = nil // explicitly nil to exercise nil-map initialisation in ApplyKueueLabel
 
 			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
 			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("test-queue"))
@@ -237,7 +243,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 
 		It("LLM-8: existing 'main' resource preserved; HWP provides others", func() {
 			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
-				hwptestutil.ResourceSpec([]string{"cpu", "8"}, []string{"nvidia.com/gpu", "2"}))
+				hwptestutil.ResourceSpec([]string{"cpu", "4"}, []string{"nvidia.com/gpu", "2"}))
 			d := newLLMDefaulter(newLLMFakeClient(hwp))
 			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
 			llm.Spec.Template = &corev1.PodSpec{
@@ -363,6 +369,209 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			Expect(newLLM.Spec.Template.Tolerations[0].Key).To(Equal("manual"))
 			// Namespace annotation removed
 			Expect(newLLM.Annotations).NotTo(HaveKey(hardwareprofile.HardwareProfileAnnotationNamespace))
+		})
+	})
+
+	Describe("Test Group 5 additions — Injection semantics (CREATE)", func() {
+
+		It("LLM-13: resource present in 'main' container limits only — request injected, limit preserved", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.ResourceSpec([]string{"nvidia.com/gpu", "2"}))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				Containers: []corev1.Container{
+					mainContainer(nil, corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}),
+				},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			req := llm.Spec.Template.Containers[0].Resources.Requests
+			lim := llm.Spec.Template.Containers[0].Resources.Limits
+			// Request injected from HWP (was absent).
+			Expect(req["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+			// User-set limit preserved (not overwritten).
+			Expect(lim["nvidia.com/gpu"]).To(Equal(resource.MustParse("1")))
+		})
+
+		It("LLM-14: pre-existing non-conflicting toleration — HWP toleration added, original preserved", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.NodeSpec(nil, []interface{}{
+					hwptestutil.TolerationMap("hwp-key", "Exists", "NoSchedule"),
+				}))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{Key: "manual-key", Operator: corev1.TolerationOpExists}},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template.Tolerations).To(HaveLen(2))
+			keys := make([]string, 0, 2)
+			for _, t := range llm.Spec.Template.Tolerations {
+				keys = append(keys, t.Key)
+			}
+			Expect(keys).To(ConsistOf("hwp-key", "manual-key"))
+		})
+
+		It("LLM-15: Kueue label already matches HWP value — label unchanged", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, hwptestutil.KueueSpec("my-queue"))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "my-queue"})
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("my-queue"))
+		})
+	})
+
+	Describe("Test Group 6 additions — Profile change and annotation removal (UPDATE)", func() {
+
+		It("LLM-16: namespace-only profile change on UPDATE — ALL stanzas cleared, new profile applied", func() {
+			hwpNS2 := hwptestutil.NewHardwareProfile(llmHWPName, "namespace-2",
+				hwptestutil.NodeSpec(map[string]interface{}{"tier": "gpu"}, nil))
+			d := newLLMDefaulter(newLLMFakeClient(hwpNS2))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS(llmHWPName, "namespace-1"), nil)
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations:  []corev1.Toleration{{Key: "old-key", Operator: corev1.TolerationOpExists}},
+			}
+
+			// apiserver carries over old stanzas in the new object body
+			newLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS(llmHWPName, "namespace-2"), nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations:  []corev1.Toleration{{Key: "old-key", Operator: corev1.TolerationOpExists}},
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			// New profile's nodeSelector applied; old entry cleared.
+			Expect(newLLM.Spec.Template.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
+			Expect(newLLM.Spec.Template.NodeSelector).NotTo(HaveKey("zone"))
+			// Old toleration cleared (new profile has none).
+			Expect(newLLM.Spec.Template.Tolerations).To(BeEmpty())
+		})
+
+		It("LLM-17: initial annotation assignment on UPDATE — merge semantics applied", func() {
+			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
+			spec["schedulingSpec"] = map[string]interface{}{
+				"node": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, spec)
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+
+			oldLLM := buildLLMISVCHWP(nil, nil) // old object has no HWP annotation
+			newLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			newLLM.Spec.Template = &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main"}},
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			// Resources applied via merge semantics (same as CREATE — no blanket clear).
+			Expect(newLLM.Spec.Template.Containers[0].Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			// Node scheduling applied.
+			Expect(newLLM.Spec.Template.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+			// Kueue label not set (HWP uses node scheduling, not Kueue).
+			Expect(newLLM.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("LLM-18: Kueue-to-Kueue profile switch — new label applied, no error", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS, hwptestutil.KueueSpec("queue-a"))
+			hwpB := hwptestutil.NewHardwareProfile("hwp-b", llmHWPNS, hwptestutil.KueueSpec("queue-b"))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA, hwpB))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"})
+			newLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-b", llmHWPNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"}) // carried over
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			Expect(newLLM.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("queue-b"))
+		})
+
+		It("LLM-19: annotation removed, nodeSelector value differs from old HWP — key preserved", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS), nil)
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+			}
+
+			newLLM := buildLLMISVCHWP(nil, nil) // annotation removed
+			newLLM.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: llmHWPNS,
+			}
+			newLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "us-east"}, // user-changed value
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			// Value differs from HWP record — key preserved.
+			Expect(newLLM.Spec.Template.NodeSelector).To(HaveKeyWithValue("zone", "us-east"))
+		})
+
+		It("LLM-20: annotation removed, LLMIsvc has no HWP nodeSelector entries — no-op, no panic", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS), nil)
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+			}
+
+			newLLM := buildLLMISVCHWP(nil, nil) // annotation removed; user already cleaned stanzas
+			newLLM.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: llmHWPNS,
+			}
+			newLLM.Spec.Template = &corev1.PodSpec{}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.NodeSelector).To(BeNil())
+		})
+
+		It("LLM-21: annotation removed, user overwrote Kueue label — label removed unconditionally", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS, hwptestutil.KueueSpec("hwp-queue"))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "hwp-queue"})
+			newLLM := buildLLMISVCHWP(nil,
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "user-queue"}) // user changed it
+			newLLM.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: llmHWPNS,
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			Expect(newLLM.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("LLM-22: annotation removed, no Kueue label present — no-op, no panic", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil)) // node scheduling only
+			d := newLLMDefaulter(newLLMFakeClient(hwpA))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS), nil)
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+			}
+
+			newLLM := buildLLMISVCHWP(nil, nil) // annotation removed, no Kueue label
+			newLLM.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: llmHWPNS,
+			}
+			newLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			Expect(newLLM.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
 		})
 	})
 })

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"encoding/json"
+
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile"
+	hwptestutil "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile/testutil"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const (
+	llmHWPNS   = "test-llm-hwp-ns"
+	llmHWPName = "test-llm-hwp"
+	llmHWPISVC = "test-llmisvc"
+)
+
+// buildLLMISVCHWP creates a v1alpha2 LLMInferenceService for HWP tests.
+// TypeMeta is always set so that json.Marshal produces the kind/apiVersion fields required by
+// unstructured.UnmarshalJSON (used in handleHWPRemovalLLMISVC to parse the old object).
+func buildLLMISVCHWP(annotations, labels map[string]string) *kservev1alpha2.LLMInferenceService {
+	return &kservev1alpha2.LLMInferenceService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "LLMInferenceService",
+			APIVersion: "serving.kserve.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        llmHWPISVC,
+			Namespace:   llmHWPNS,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}
+}
+
+// llmHWPCreateCtx returns a context carrying a CREATE admission request.
+func llmHWPCreateCtx(llm *kservev1alpha2.LLMInferenceService) context.Context {
+	raw, _ := json.Marshal(llm)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Namespace: llmHWPNS,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// llmHWPUpdateCtx returns a context carrying an UPDATE admission request.
+func llmHWPUpdateCtx(newLLM, oldLLM *kservev1alpha2.LLMInferenceService) context.Context {
+	newRaw, _ := json.Marshal(newLLM)
+	oldRaw, _ := json.Marshal(oldLLM)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Namespace: llmHWPNS,
+			Object:    runtime.RawExtension{Raw: newRaw},
+			OldObject: runtime.RawExtension{Raw: oldRaw},
+		},
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// mainContainer returns a container named "main" with optional resources.
+func mainContainer(requests, limits corev1.ResourceList) corev1.Container {
+	return corev1.Container{
+		Name: "main",
+		Resources: corev1.ResourceRequirements{
+			Requests: requests,
+			Limits:   limits,
+		},
+	}
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
+
+	Describe("Test Group 4 — Basic injection (CREATE)", func() {
+
+		It("LLM-1: no annotation — LLMIsvc unmodified", func() {
+			d := newLLMDefaulter(newLLMFakeClient())
+			llm := buildLLMISVCHWP(nil, nil)
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template).To(BeNil())
+			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(BeEmpty())
+		})
+
+		It("LLM-2: HWP with resources — injected into 'main' container", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.ResourceSpec([]string{"cpu", "4"}, []string{"memory", "8Gi"}))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main"}},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template.Containers).To(HaveLen(1))
+			req := llm.Spec.Template.Containers[0].Resources.Requests
+			lim := llm.Spec.Template.Containers[0].Resources.Limits
+			Expect(req[corev1.ResourceCPU]).To(Equal(resource.MustParse("4")))
+			Expect(req[corev1.ResourceMemory]).To(Equal(resource.MustParse("8Gi")))
+			Expect(lim[corev1.ResourceCPU]).To(Equal(resource.MustParse("4")))
+			Expect(lim[corev1.ResourceMemory]).To(Equal(resource.MustParse("8Gi")))
+		})
+
+		It("LLM-3: HWP with node scheduling — spec.template fields updated", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "gpu-zone"},
+					[]interface{}{hwptestutil.TolerationMap("nvidia.com/gpu", "Exists", "NoSchedule")},
+				))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template).NotTo(BeNil())
+			Expect(llm.Spec.Template.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+			Expect(llm.Spec.Template.Tolerations).To(HaveLen(1))
+			Expect(llm.Spec.Template.Tolerations[0].Key).To(Equal("nvidia.com/gpu"))
+		})
+
+		It("LLM-4: HWP with Kueue scheduling — label set, node scheduling not applied", func() {
+			// HWP spec contains both Kueue and node scheduling fields. parseProfile reads the
+			// Kueue queue name first and returns early, so the node section is never parsed and
+			// the ResolvedProfile has no NodeSelector. The webhook then sets only the Kueue label
+			// and returns before reaching the node scheduling block.
+			spec := map[string]interface{}{
+				"schedulingSpec": map[string]interface{}{
+					"kueue": map[string]interface{}{"localQueueName": "test-queue"},
+					"node":  map[string]interface{}{"nodeSelector": map[string]interface{}{"zone": "gpu-zone"}},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, spec)
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("test-queue"))
+			// No template created and no nodeSelector set — node scheduling was not applied.
+			Expect(llm.Spec.Template).To(BeNil())
+		})
+
+		It("LLM-5: HWP not found — admission blocked", func() {
+			d := newLLMDefaulter(newLLMFakeClient()) // no HWP registered
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations("missing-hwp"), nil)
+
+			err := d.Default(llmHWPCreateCtx(llm), llm)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing-hwp"))
+		})
+
+		It("LLM-6: containers non-empty but no 'main' — ALL HWP application skipped", func() {
+			spec := hwptestutil.ResourceSpec([]string{"cpu", "8"})
+			spec["schedulingSpec"] = map[string]interface{}{
+				"node": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, spec)
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "server", // no "main"
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+						},
+					},
+				},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			// "server" container resources unchanged — HWP cpu "8" was not injected.
+			Expect(llm.Spec.Template.Containers[0].Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("2")))
+			// Node scheduling NOT applied — HWP nodeSelector was not injected.
+			Expect(llm.Spec.Template.NodeSelector).To(BeNil())
+			// Kueue label NOT applied.
+			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(BeEmpty())
+		})
+
+		It("LLM-7: absent container list — 'main' created and resources injected", func() {
+			// Build a spec with both resource identifiers (triggers "main" creation) and node scheduling.
+			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
+			spec["schedulingSpec"] = map[string]interface{}{
+				"node": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, spec)
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			// Spec.Template is nil — no containers
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template).NotTo(BeNil())
+			Expect(llm.Spec.Template.Containers).To(HaveLen(1))
+			Expect(llm.Spec.Template.Containers[0].Name).To(Equal("main"))
+			Expect(llm.Spec.Template.Containers[0].Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			Expect(llm.Spec.Template.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+		})
+	})
+
+	Describe("Test Group 5 — Injection semantics (CREATE)", func() {
+
+		It("LLM-8: existing 'main' resource preserved; HWP provides others", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.ResourceSpec([]string{"cpu", "8"}, []string{"nvidia.com/gpu", "2"}))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				Containers: []corev1.Container{
+					mainContainer(
+						corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+						nil,
+					),
+				},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			req := llm.Spec.Template.Containers[0].Resources.Requests
+			lim := llm.Spec.Template.Containers[0].Resources.Limits
+			// CPU preserved
+			Expect(req[corev1.ResourceCPU]).To(Equal(resource.MustParse("2")))
+			Expect(lim[corev1.ResourceCPU]).To(Equal(resource.MustParse("2")))
+			// GPU injected from HWP
+			Expect(req["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+			Expect(lim["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+		})
+
+		It("LLM-9: HWP overwrites conflicting nodeSelector key in spec.template", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west"},
+					nil,
+				))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName), nil)
+			llm.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "us-east"},
+			}
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Spec.Template.NodeSelector["zone"]).To(Equal("eu-west")) // HWP wins
+		})
+
+		It("LLM-10: HWP overwrites existing Kueue label on LLMIsvc metadata", func() {
+			hwp := hwptestutil.NewHardwareProfile(llmHWPName, llmHWPNS, hwptestutil.KueueSpec("hwp-queue"))
+			d := newLLMDefaulter(newLLMFakeClient(hwp))
+			llm := buildLLMISVCHWP(hwptestutil.HWPAnnotations(llmHWPName),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "user-queue"})
+
+			Expect(d.Default(llmHWPCreateCtx(llm), llm)).To(Succeed())
+			Expect(llm.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("hwp-queue"))
+		})
+	})
+
+	Describe("Test Group 6 — Profile change and annotation removal (UPDATE)", func() {
+
+		It("LLM-11: different profile on UPDATE — ALL stanzas cleared, new profile applied", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west"},
+					[]interface{}{hwptestutil.TolerationMap("key-a", "Exists", "NoSchedule")},
+				))
+			hwpB := hwptestutil.NewHardwareProfile("hwp-b", llmHWPNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"tier": "gpu"},
+					[]interface{}{hwptestutil.TolerationMap("key-b", "Exists", "NoSchedule")},
+				))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA, hwpB))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations: []corev1.Toleration{
+					{Key: "key-a", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
+
+			// apiserver carries over old stanzas in the new object body
+			newLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-b", llmHWPNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
+			newLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations: []corev1.Toleration{
+					{Key: "key-a", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			Expect(newLLM.Spec.Template.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
+			Expect(newLLM.Spec.Template.NodeSelector).NotTo(HaveKey("zone"))
+			keys := make([]string, 0)
+			for _, t := range newLLM.Spec.Template.Tolerations {
+				keys = append(keys, t.Key)
+			}
+			Expect(keys).To(ConsistOf("key-b"))
+			Expect(newLLM.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("LLM-12: annotation removed on UPDATE — HWP stanzas surgically removed in spec.template", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", llmHWPNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west"},
+					[]interface{}{hwptestutil.TolerationMap("key-a", "", "")},
+				))
+			d := newLLMDefaulter(newLLMFakeClient(hwpA))
+
+			oldLLM := buildLLMISVCHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", llmHWPNS), nil)
+			oldLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations:  []corev1.Toleration{{Key: "key-a"}, {Key: "manual"}},
+			}
+
+			newLLM := buildLLMISVCHWP(nil, nil) // HWP annotation removed
+			newLLM.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: llmHWPNS,
+			}
+			newLLM.Spec.Template = &corev1.PodSpec{
+				NodeSelector: map[string]string{"zone": "eu-west"},
+				Tolerations:  []corev1.Toleration{{Key: "key-a"}, {Key: "manual"}},
+			}
+
+			Expect(d.Default(llmHWPUpdateCtx(newLLM, oldLLM), newLLM)).To(Succeed())
+			// HWP nodeSelector entry removed
+			Expect(newLLM.Spec.Template.NodeSelector).NotTo(HaveKey("zone"))
+			// HWP toleration removed; manual toleration preserved
+			Expect(newLLM.Spec.Template.Tolerations).To(HaveLen(1))
+			Expect(newLLM.Spec.Template.Tolerations[0].Key).To(Equal("manual"))
+			// Namespace annotation removed
+			Expect(newLLM.Annotations).NotTo(HaveKey(hardwareprofile.HardwareProfileAnnotationNamespace))
+		})
+	})
+})

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook.go
@@ -22,7 +22,9 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +37,7 @@ import (
 	"knative.dev/pkg/apis"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile"
 )
 
 // nolint:unused
@@ -79,7 +82,8 @@ func SetupLLMInferenceServiceWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // Default implements webhook.CustomDefaulter. It applies ConnectionsAPI injection or cleanup to
-// LLMInferenceService resources of both v1alpha1 and v1alpha2 API versions.
+// LLMInferenceService resources of both v1alpha1 and v1alpha2 API versions, followed by
+// HardwareProfile scheduling stanza injection.
 //
 // Parameters:
 //   - ctx: context carrying the admission request (via admission.RequestFromContext)
@@ -89,9 +93,17 @@ func SetupLLMInferenceServiceWebhookWithManager(mgr ctrl.Manager) error {
 func (d *LLMInferenceServiceCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	switch typedObj := obj.(type) {
 	case *kservev1alpha2.LLMInferenceService:
-		return d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template)
+		if err := d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template); err != nil {
+			return err
+		}
+		return d.applyHardwareProfileLLMISVC(ctx, &typedObj.ObjectMeta, &typedObj.Spec.Template,
+			"serving.kserve.io/v1alpha2", "LLMInferenceService")
 	case *kservev1alpha1.LLMInferenceService:
-		return d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template)
+		if err := d.applyLLMISVCDefaults(ctx, typedObj, &typedObj.Spec.Model.URI, &typedObj.Spec.Template); err != nil {
+			return err
+		}
+		return d.applyHardwareProfileLLMISVC(ctx, &typedObj.ObjectMeta, &typedObj.Spec.Template,
+			"serving.kserve.io/v1alpha1", "LLMInferenceService")
 	default:
 		return fmt.Errorf("expected a LLMInferenceService object but got %T", obj)
 	}
@@ -254,6 +266,268 @@ func performLLMISVCInjection(
 	default:
 		log.V(1).Info("unknown connection type, skipping injection", "connectionType", connInfo.Type)
 		return nil
+	}
+}
+
+// applyHardwareProfileLLMISVC applies HardwareProfile scheduling stanzas to an LLMInferenceService
+// at admission time.
+//
+// Resolves the HardwareProfile referenced by opendatahub.io/hardware-profile-name annotation and
+// injects container resources, nodeSelector, tolerations, and the Kueue queue label. On UPDATE
+// where the annotation is removed, surgically cleans up previously-injected values.
+//
+// Container validation runs before any HWP application: when spec.template.containers is non-empty
+// but contains no container named "main", a Warning Event is emitted on the object and all HWP
+// application is skipped (admission is not blocked).
+//
+// Parameters:
+//   - ctx: context with logger and admission request
+//   - meta: the LLMInferenceService ObjectMeta (mutated in-place for labels/annotations)
+//   - template: pointer to the spec.template PodSpec pointer (created if nil and injection is needed)
+//   - apiVersion: the API version string used when emitting events (e.g. "serving.kserve.io/v1alpha2")
+//   - kind: the kind string used when emitting events
+//
+// Returns any error that should block admission.
+func (d *LLMInferenceServiceCustomDefaulter) applyHardwareProfileLLMISVC(
+	ctx context.Context,
+	meta *metav1.ObjectMeta,
+	template **corev1.PodSpec,
+	apiVersion, kind string,
+) error {
+	log := logf.FromContext(ctx)
+
+	if meta.DeletionTimestamp != nil {
+		return nil
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get admission request from context: %w", err)
+	}
+
+	annotations := meta.GetAnnotations()
+	profileName, profileNamespace := hardwareprofile.ProfileRef(annotations, meta.Namespace)
+
+	if profileName == "" {
+		if req.Operation == admissionv1.Update {
+			return d.handleHWPRemovalLLMISVC(ctx, req, meta, template)
+		}
+		return nil
+	}
+
+	// Resolve the HardwareProfile CR.
+	profile, err := hardwareprofile.Resolve(ctx, d.client, profileName, profileNamespace)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return fmt.Errorf("hardware profile %q not found in namespace %q", profileName, profileNamespace)
+		}
+		return fmt.Errorf("failed fetching hardware profile: %w", err)
+	}
+
+	// Stamp the namespace annotation so callers can always find the namespace.
+	if annotations[hardwareprofile.HardwareProfileAnnotationNamespace] == "" {
+		if meta.Annotations == nil {
+			meta.Annotations = make(map[string]string)
+		}
+		meta.Annotations[hardwareprofile.HardwareProfileAnnotationNamespace] = profileNamespace
+	}
+
+	// Validate container names after HWP fetch (matches opendatahub-operator ordering).
+	// When containers is non-empty but has no "main", emit an event and skip all HWP injection.
+	if *template != nil && len((*template).Containers) > 0 {
+		hasMain := false
+		for _, c := range (*template).Containers {
+			if c.Name == hardwareprofile.LLMIsvcMainContainerName {
+				hasMain = true
+				break
+			}
+		}
+		if !hasMain {
+			log.Info("LLMIsvc containers non-empty but has no 'main' container, skipping all HWP injection",
+				"name", meta.Name, "namespace", meta.Namespace, "profile", profileName)
+			d.emitContainerValidationEvent(ctx, meta, apiVersion, kind, profileName)
+			return nil
+		}
+	}
+
+	profileChanged := hardwareprofile.ProfileChanged(req, profileName, profileNamespace)
+
+	// On profile switch, clear all previous scheduling stanzas before applying the new profile.
+	if profileChanged {
+		if *template != nil {
+			(*template).NodeSelector = nil
+			(*template).Tolerations = nil
+		}
+		if meta.Labels != nil {
+			delete(meta.Labels, hardwareprofile.KueueQueueNameLabel)
+		}
+	}
+
+	// Apply resource identifiers to the "main" container (existing values take priority).
+	var existingContainers []corev1.Container
+	if *template != nil {
+		existingContainers = (*template).Containers
+	}
+	newContainers, err := hardwareprofile.ApplyToLLMIsvcResources(profile, existingContainers)
+	if err != nil {
+		return fmt.Errorf("failed to apply HWP resources to LLMIsvc: %w", err)
+	}
+	if *template == nil && len(newContainers) > 0 {
+		*template = &corev1.PodSpec{}
+	}
+	if *template != nil {
+		(*template).Containers = newContainers
+	}
+
+	// Kueue and node scheduling are mutually exclusive.
+	if profile.KueueQueueName != "" {
+		for _, w := range hardwareprofile.ApplyKueueLabel(profile, meta, profileChanged, profileName) {
+			log.Info(w)
+		}
+		return nil
+	}
+
+	// Apply node scheduling.
+	if len(profile.NodeSelector) > 0 || len(profile.Tolerations) > 0 {
+		if *template == nil {
+			*template = &corev1.PodSpec{}
+		}
+		var existingNS map[string]string
+		var existingTols []corev1.Toleration
+		existingNS = (*template).NodeSelector
+		existingTols = (*template).Tolerations
+
+		var newNS map[string]string
+		var newTols []corev1.Toleration
+		if profileChanged {
+			newNS, newTols = hardwareprofile.SetNodeScheduling(profile, existingNS, existingTols)
+		} else {
+			var warnings []string
+			newNS, newTols, warnings = hardwareprofile.MergeNodeScheduling(profile, existingNS, existingTols, profileName)
+			for _, w := range warnings {
+				log.Info(w)
+			}
+		}
+		(*template).NodeSelector = newNS
+		(*template).Tolerations = newTols
+	}
+
+	return nil
+}
+
+// handleHWPRemovalLLMISVC handles the case where the HWP annotation is removed from an
+// LLMInferenceService on UPDATE. Fetches the old HWP and surgically removes only its contributed
+// nodeSelector entries, tolerations, and Kueue label. When the old HWP cannot be fetched, logs a
+// warning and removes only the namespace annotation (does not block admission).
+//
+// Parameters:
+//   - ctx: context with logger
+//   - req: the admission request containing the old object
+//   - meta: the LLMInferenceService ObjectMeta (mutated in-place)
+//   - template: pointer to the spec.template PodSpec pointer (mutated in-place)
+//
+// Returns any error that should block admission (only internal errors, not "old HWP not found").
+func (d *LLMInferenceServiceCustomDefaulter) handleHWPRemovalLLMISVC(
+	ctx context.Context,
+	req admission.Request,
+	meta *metav1.ObjectMeta,
+	template **corev1.PodSpec,
+) error {
+	log := logf.FromContext(ctx)
+
+	if req.OldObject.Raw == nil {
+		return nil
+	}
+	oldObj := &unstructured.Unstructured{}
+	if err := oldObj.UnmarshalJSON(req.OldObject.Raw); err != nil {
+		return nil
+	}
+
+	oldAnnotations := oldObj.GetAnnotations()
+	oldProfileName := oldAnnotations[hardwareprofile.HardwareProfileAnnotationName]
+	if oldProfileName == "" {
+		return nil
+	}
+
+	oldProfileNamespace := oldAnnotations[hardwareprofile.HardwareProfileAnnotationNamespace]
+	if oldProfileNamespace == "" {
+		oldProfileNamespace = oldObj.GetNamespace()
+	}
+
+	oldProfile, err := hardwareprofile.Resolve(ctx, d.client, oldProfileName, oldProfileNamespace)
+	if err != nil {
+		log.Info("could not fetch old HWP for LLMIsvc cleanup — stanzas may remain in spec",
+			"error", err, "profile", oldProfileName, "namespace", oldProfileNamespace)
+		if meta.Annotations != nil {
+			delete(meta.Annotations, hardwareprofile.HardwareProfileAnnotationNamespace)
+		}
+		return nil
+	}
+
+	if oldProfile != nil {
+		if *template != nil {
+			newNS, newTols := hardwareprofile.RemoveNodeScheduling(
+				oldProfile, (*template).NodeSelector, (*template).Tolerations)
+			(*template).NodeSelector = newNS
+			(*template).Tolerations = newTols
+		}
+		if oldProfile.KueueQueueName != "" {
+			hardwareprofile.RemoveKueueLabel(meta)
+		}
+	}
+
+	if meta.Annotations != nil {
+		delete(meta.Annotations, hardwareprofile.HardwareProfileAnnotationNamespace)
+	}
+
+	return nil
+}
+
+// emitContainerValidationEvent creates a Warning Kubernetes Event on the LLMInferenceService when
+// its container list is non-empty but contains no container named "main". This provides persistent
+// traceability without blocking admission.
+//
+// Parameters:
+//   - ctx: context with logger
+//   - meta: the LLMInferenceService ObjectMeta (provides name, namespace, UID)
+//   - apiVersion: the API version string for the InvolvedObject reference
+//   - kind: the kind string for the InvolvedObject reference
+//   - profileName: the referenced HardwareProfile name, used in the event message
+func (d *LLMInferenceServiceCustomDefaulter) emitContainerValidationEvent(
+	ctx context.Context,
+	meta *metav1.ObjectMeta,
+	apiVersion, kind, profileName string,
+) {
+	log := logf.FromContext(ctx)
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.hwp-container-name-mismatch", meta.Name),
+			Namespace: meta.Namespace,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: apiVersion,
+			Kind:       kind,
+			Namespace:  meta.Namespace,
+			Name:       meta.Name,
+			UID:        meta.UID,
+		},
+		Reason: "ContainerNameMismatch",
+		Message: fmt.Sprintf(
+			"HardwareProfile %q was not applied: no container named %q found in spec.template.containers. "+
+				"Rename a container to %q to enable HWP injection.",
+			profileName, hardwareprofile.LLMIsvcMainContainerName, hardwareprofile.LLMIsvcMainContainerName),
+		Source: corev1.EventSource{
+			Component: "hardwareprofile-webhook",
+		},
+		FirstTimestamp: metav1.Now(),
+		LastTimestamp:  metav1.Now(),
+		Count:          1,
+		Type:           corev1.EventTypeWarning,
+	}
+
+	if err := d.client.Create(ctx, event); err != nil {
+		log.Info("failed to create container validation warning event (non-blocking)", "error", err)
 	}
 }
 

--- a/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
@@ -437,7 +437,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
 			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
 			Expect(newISVC.Spec.Predictor.NodeSelector).NotTo(HaveKey("zone"))
-			keys := make([]string, 0)
+			keys := make([]string, 0, len(newISVC.Spec.Predictor.Tolerations))
 			for _, t := range newISVC.Spec.Predictor.Tolerations {
 				keys = append(keys, t.Key)
 			}

--- a/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
@@ -109,19 +109,6 @@ func isvcUpdateCtx(newISVC, oldISVC *servingv1beta1.InferenceService) context.Co
 	return admission.NewContextWithRequest(context.Background(), req)
 }
 
-// hwpAnnotations returns a single-annotation map with the HWP name annotation.
-func hwpAnnotations(profileName string) map[string]string {
-	return map[string]string{hardwareprofile.HardwareProfileAnnotationName: profileName}
-}
-
-// hwpAnnotationsWithNS returns annotation map with both HWP name and namespace annotations.
-func hwpAnnotationsWithNS(profileName, ns string) map[string]string {
-	return map[string]string{
-		hardwareprofile.HardwareProfileAnnotationName:      profileName,
-		hardwareprofile.HardwareProfileAnnotationNamespace: ns,
-	}
-}
-
 // ─── tests ────────────────────────────────────────────────────────────────────
 
 var _ = Describe("InferenceService HardwareProfile Webhook", func() {
@@ -151,7 +138,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 					[]string{"nvidia.com/gpu", "2"},
 				))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model).NotTo(BeNil())
@@ -173,7 +160,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 					[]interface{}{hwptestutil.TolerationMapWithSeconds("nvidia.com/gpu", "Exists", "NoSchedule", 300)},
 				))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("nvidia.com/gpu.product", "A100"))
@@ -187,19 +174,30 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		})
 
 		It("isvc-4: HWP with Kueue scheduling — label set, node scheduling not applied (nil labels init)", func() {
-			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("test-queue"))
+			// HWP spec contains both Kueue and node scheduling fields. parseProfile reads the
+			// Kueue queue name first and returns early, so the node section is never parsed and
+			// the ResolvedProfile has no NodeSelector. The webhook then sets only the Kueue label
+			// and returns before reaching the node scheduling block.
+			spec := map[string]interface{}{
+				"schedulingSpec": map[string]interface{}{
+					"kueue": map[string]interface{}{"localQueueName": "test-queue"},
+					"node":  map[string]interface{}{"nodeSelector": map[string]interface{}{"zone": "gpu-zone"}},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Labels = nil // explicitly nil to exercise nil-map initialisation in ApplyKueueLabel
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("test-queue"))
+			// nodeSelector not set — node scheduling was not applied despite being present in the HWP spec.
 			Expect(isvc.Spec.Predictor.NodeSelector).To(BeNil())
 		})
 
 		It("isvc-5: HWP not found — admission blocked", func() {
 			d := newISVCDefaulter(newDefaulterFakeClient()) // no HWP registered
-			isvc := buildISVCForHWP(hwpAnnotations("missing-hwp"), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations("missing-hwp"), nil)
 
 			err := d.Default(isvcCreateCtx(isvc), isvc)
 			Expect(err).To(HaveOccurred())
@@ -209,7 +207,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		It("isvc-6: namespace annotation stamped when absent", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("q"))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Annotations[hardwareprofile.HardwareProfileAnnotationNamespace]).To(Equal(hwpTestNS))
@@ -223,7 +221,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			}
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(HaveOccurred())
 		})
@@ -236,7 +234,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			}
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(HaveOccurred())
 		})
@@ -244,7 +242,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		It("isvc-18: HWP with completely empty spec — isvc unmodified, admitted", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, map[string]interface{}{})
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			if isvc.Spec.Predictor.Model != nil {
@@ -263,7 +261,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
 				hwptestutil.ResourceSpec([]string{"cpu", "4"}, []string{"nvidia.com/gpu", "2"}))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Spec.Predictor.Model.Resources.Requests = corev1.ResourceList{
 				corev1.ResourceCPU: resource.MustParse("2"),
 			}
@@ -287,7 +285,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 					nil,
 				))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Spec.Predictor.NodeSelector = map[string]string{"zone": "us-east"}
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
@@ -300,7 +298,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
 				hwptestutil.NodeSpec(nil, []interface{}{tol}))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Spec.Predictor.Tolerations = []corev1.Toleration{
 				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
 			}
@@ -315,7 +313,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		It("isvc-10: HWP overwrites existing Kueue label", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("hwp-queue"))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), map[string]string{
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), map[string]string{
 				hardwareprofile.KueueQueueNameLabel: "user-queue",
 			})
 
@@ -327,7 +325,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
 				hwptestutil.ResourceSpec([]string{"nvidia.com/gpu", "2"}))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Spec.Predictor.Model.Resources.Limits = corev1.ResourceList{
 				"nvidia.com/gpu": resource.MustParse("1"),
 			}
@@ -343,7 +341,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
 				hwptestutil.NodeSpec(map[string]interface{}{"zone": "gpu-zone"}, nil))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCNoModelForHWP(hwpAnnotations(hwpTestName))
+			isvc := buildISVCNoModelForHWP(hwptestutil.HWPAnnotations(hwpTestName))
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model).To(BeNil())
@@ -356,7 +354,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 					hwptestutil.TolerationMap("hwp-key", "Exists", "NoSchedule"),
 				}))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 			isvc.Spec.Predictor.Tolerations = []corev1.Toleration{
 				{Key: "manual-key", Operator: corev1.TolerationOpExists},
 			}
@@ -373,7 +371,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		It("isvc-22: Kueue label already matches HWP value — unchanged, no error", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("my-queue"))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), map[string]string{
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), map[string]string{
 				hardwareprofile.KueueQueueNameLabel: "my-queue",
 			})
 
@@ -393,8 +391,8 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			}
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
-			newISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
+			newISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
 
 			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
 			// Resources applied (same as CREATE).
@@ -421,7 +419,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA, hwpB))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS),
 				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 			oldISVC.Spec.Predictor.Tolerations = []corev1.Toleration{
@@ -429,7 +427,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			}
 
 			// apiserver carries over old stanzas in the new object body
-			newISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-b", hwpTestNS),
+			newISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-b", hwpTestNS),
 				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
 			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 			newISVC.Spec.Predictor.Tolerations = []corev1.Toleration{
@@ -455,7 +453,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS), nil)
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 			oldISVC.Spec.Predictor.Tolerations = []corev1.Toleration{{Key: "key-a"}, {Key: "manual"}}
 
@@ -479,7 +477,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 		It("isvc-14: annotation removed, old HWP not found — admitted, namespace annotation cleaned", func() {
 			d := newISVCDefaulter(newDefaulterFakeClient()) // HWP CR was deleted
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS), nil)
 
 			newISVC := buildISVCForHWP(nil, nil) // annotation removed
 			newISVC.Annotations = map[string]string{
@@ -497,7 +495,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwp := hwptestutil.NewHardwareProfile(hwpTestName, "other-ns",
 				hwptestutil.ResourceSpec([]string{"cpu", "8"}))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
-			isvc := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "other-ns"), nil)
+			isvc := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS(hwpTestName, "other-ns"), nil)
 
 			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
 			Expect(isvc.Spec.Predictor.Model.Resources.Requests[corev1.ResourceCPU]).
@@ -509,10 +507,10 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				hwptestutil.NodeSpec(map[string]interface{}{"tier": "gpu"}, nil))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpNS2))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "namespace-1"), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS(hwpTestName, "namespace-1"), nil)
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 
-			newISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "namespace-2"), nil)
+			newISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS(hwpTestName, "namespace-2"), nil)
 			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"} // carried over
 
 			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
@@ -531,7 +529,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
 
 			oldISVC := buildISVCForHWP(nil, nil) // old object has no HWP annotation
-			newISVC := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			newISVC := buildISVCForHWP(hwptestutil.HWPAnnotations(hwpTestName), nil)
 
 			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
 			// Resources applied via merge semantics (same as CREATE — no blanket clear).
@@ -550,9 +548,9 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwpB := hwptestutil.NewHardwareProfile("hwp-b", hwpTestNS, hwptestutil.KueueSpec("queue-b"))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA, hwpB))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS),
 				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"})
-			newISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-b", hwpTestNS),
+			newISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-b", hwpTestNS),
 				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"}) // carried over
 
 			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
@@ -564,7 +562,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS), nil)
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 
 			newISVC := buildISVCForHWP(nil, nil) // annotation removed
@@ -583,7 +581,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS), nil)
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 
 			newISVC := buildISVCForHWP(nil, nil) // annotation removed; user already cleaned stanzas
@@ -599,7 +597,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS, hwptestutil.KueueSpec("hwp-queue"))
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS),
 				map[string]string{hardwareprofile.KueueQueueNameLabel: "hwp-queue"})
 			newISVC := buildISVCForHWP(nil, map[string]string{
 				hardwareprofile.KueueQueueNameLabel: "user-queue", // user changed it
@@ -617,7 +615,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil)) // node scheduling only
 			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
 
-			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC := buildISVCForHWP(hwptestutil.HWPAnnotationsWithNS("hwp-a", hwpTestNS), nil)
 			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
 
 			newISVC := buildISVCForHWP(nil, nil) // annotation removed, no Kueue label

--- a/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
@@ -1,0 +1,633 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"encoding/json"
+
+	servingv1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile"
+	hwptestutil "github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile/testutil"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const (
+	hwpTestNS   = "test-hwp-ns"
+	hwpTestName = "test-hwp"
+	hwpISVCName = "test-isvc"
+)
+
+// buildISVCForHWP creates a minimal InferenceService with a non-nil predictor Model.
+// TypeMeta is always set so that json.Marshal produces the kind/apiVersion fields required by
+// unstructured.UnmarshalJSON (used in handleHWPRemovalISVC to parse the old object).
+func buildISVCForHWP(annotations, labels map[string]string) *servingv1beta1.InferenceService {
+	return &servingv1beta1.InferenceService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InferenceService",
+			APIVersion: "serving.kserve.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hwpISVCName,
+			Namespace:   hwpTestNS,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: servingv1beta1.InferenceServiceSpec{
+			Predictor: servingv1beta1.PredictorSpec{
+				Model: &servingv1beta1.ModelSpec{},
+			},
+		},
+	}
+}
+
+// buildISVCNoModelForHWP creates an InferenceService without a predictor Model field.
+// TypeMeta is always set so that json.Marshal produces the kind/apiVersion fields.
+func buildISVCNoModelForHWP(annotations map[string]string) *servingv1beta1.InferenceService {
+	return &servingv1beta1.InferenceService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InferenceService",
+			APIVersion: "serving.kserve.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        hwpISVCName,
+			Namespace:   hwpTestNS,
+			Annotations: annotations,
+		},
+	}
+}
+
+// isvcCreateCtx returns a context carrying a CREATE admission request for isvc.
+func isvcCreateCtx(isvc *servingv1beta1.InferenceService) context.Context {
+	raw, _ := json.Marshal(isvc)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Namespace: hwpTestNS,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// isvcUpdateCtx returns a context carrying an UPDATE admission request.
+func isvcUpdateCtx(newISVC, oldISVC *servingv1beta1.InferenceService) context.Context {
+	newRaw, _ := json.Marshal(newISVC)
+	oldRaw, _ := json.Marshal(oldISVC)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Namespace: hwpTestNS,
+			Object:    runtime.RawExtension{Raw: newRaw},
+			OldObject: runtime.RawExtension{Raw: oldRaw},
+		},
+	}
+	return admission.NewContextWithRequest(context.Background(), req)
+}
+
+// hwpAnnotations returns a single-annotation map with the HWP name annotation.
+func hwpAnnotations(profileName string) map[string]string {
+	return map[string]string{hardwareprofile.HardwareProfileAnnotationName: profileName}
+}
+
+// hwpAnnotationsWithNS returns annotation map with both HWP name and namespace annotations.
+func hwpAnnotationsWithNS(profileName, ns string) map[string]string {
+	return map[string]string{
+		hardwareprofile.HardwareProfileAnnotationName:      profileName,
+		hardwareprofile.HardwareProfileAnnotationNamespace: ns,
+	}
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+var _ = Describe("InferenceService HardwareProfile Webhook", func() {
+
+	Describe("Test Group 1 — Basic injection (CREATE)", func() {
+
+		It("isvc-1: no annotation — isvc unmodified (nil annotation map)", func() {
+			d := newISVCDefaulter(newDefaulterFakeClient())
+			isvc := &servingv1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        hwpISVCName,
+					Namespace:   hwpTestNS,
+					Annotations: nil, // explicitly nil to exercise nil-map path in ProfileRef
+				},
+			}
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+			Expect(isvc.Spec.Predictor.NodeSelector).To(BeNil())
+			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(BeEmpty())
+		})
+
+		It("isvc-2: HWP with resources — injected to predictor model (requests and limits)", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.ResourceSpec(
+					[]string{"cpu", "4"},
+					[]string{"memory", "8Gi"},
+					[]string{"nvidia.com/gpu", "2"},
+				))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model).NotTo(BeNil())
+			req := isvc.Spec.Predictor.Model.Resources.Requests
+			lim := isvc.Spec.Predictor.Model.Resources.Limits
+			Expect(req[corev1.ResourceCPU]).To(Equal(resource.MustParse("4")))
+			Expect(req[corev1.ResourceMemory]).To(Equal(resource.MustParse("8Gi")))
+			Expect(req["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+			// Guaranteed QoS: limits == requests
+			Expect(lim[corev1.ResourceCPU]).To(Equal(resource.MustParse("4")))
+			Expect(lim[corev1.ResourceMemory]).To(Equal(resource.MustParse("8Gi")))
+			Expect(lim["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+		})
+
+		It("isvc-3: HWP with node scheduling — nodeSelector and tolerations injected (with tolerationSeconds)", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"nvidia.com/gpu.product": "A100"},
+					[]interface{}{hwptestutil.TolerationMapWithSeconds("nvidia.com/gpu", "Exists", "NoSchedule", 300)},
+				))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("nvidia.com/gpu.product", "A100"))
+			Expect(isvc.Spec.Predictor.Tolerations).To(HaveLen(1))
+			tol := isvc.Spec.Predictor.Tolerations[0]
+			Expect(tol.Key).To(Equal("nvidia.com/gpu"))
+			Expect(tol.Operator).To(Equal(corev1.TolerationOpExists))
+			Expect(tol.Effect).To(Equal(corev1.TaintEffectNoSchedule))
+			Expect(tol.TolerationSeconds).NotTo(BeNil())
+			Expect(*tol.TolerationSeconds).To(Equal(int64(300)))
+		})
+
+		It("isvc-4: HWP with Kueue scheduling — label set, node scheduling not applied (nil labels init)", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("test-queue"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Labels = nil // explicitly nil to exercise nil-map initialisation in ApplyKueueLabel
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("test-queue"))
+			Expect(isvc.Spec.Predictor.NodeSelector).To(BeNil())
+		})
+
+		It("isvc-5: HWP not found — admission blocked", func() {
+			d := newISVCDefaulter(newDefaulterFakeClient()) // no HWP registered
+			isvc := buildISVCForHWP(hwpAnnotations("missing-hwp"), nil)
+
+			err := d.Default(isvcCreateCtx(isvc), isvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing-hwp"))
+		})
+
+		It("isvc-6: namespace annotation stamped when absent", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("q"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Annotations[hardwareprofile.HardwareProfileAnnotationNamespace]).To(Equal(hwpTestNS))
+		})
+
+		It("isvc-16: HWP identifier missing defaultCount — admission blocked", func() {
+			spec := map[string]interface{}{
+				"identifiers": []interface{}{
+					map[string]interface{}{"identifier": "cpu"}, // no defaultCount
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(HaveOccurred())
+		})
+
+		It("isvc-17: HWP identifier invalid quantity — admission blocked", func() {
+			spec := map[string]interface{}{
+				"identifiers": []interface{}{
+					map[string]interface{}{"identifier": "cpu", "defaultCount": "bad!"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(HaveOccurred())
+		})
+
+		It("isvc-18: HWP with completely empty spec — isvc unmodified, admitted", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, map[string]interface{}{})
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			if isvc.Spec.Predictor.Model != nil {
+				Expect(isvc.Spec.Predictor.Model.Resources.Requests).To(BeEmpty())
+				Expect(isvc.Spec.Predictor.Model.Resources.Limits).To(BeEmpty())
+			}
+			Expect(isvc.Spec.Predictor.NodeSelector).To(BeNil())
+			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(BeEmpty())
+			Expect(isvc.Annotations[hardwareprofile.HardwareProfileAnnotationNamespace]).To(Equal(hwpTestNS))
+		})
+	})
+
+	Describe("Test Group 2 — Injection semantics (CREATE)", func() {
+
+		It("isvc-7: existing request preserved; limit backfilled from preserved request value", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.ResourceSpec([]string{"cpu", "4"}, []string{"nvidia.com/gpu", "2"}))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Spec.Predictor.Model.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			}
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			req := isvc.Spec.Predictor.Model.Resources.Requests
+			lim := isvc.Spec.Predictor.Model.Resources.Limits
+			// CPU: existing request preserved (not overwritten by HWP "4")
+			Expect(req[corev1.ResourceCPU]).To(Equal(resource.MustParse("2")))
+			// CPU: limit backfilled from the preserved request value, not HWP defaultCount
+			Expect(lim[corev1.ResourceCPU]).To(Equal(resource.MustParse("2")))
+			// GPU: absent from existing requests — injected from HWP
+			Expect(req["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+			Expect(lim["nvidia.com/gpu"]).To(Equal(resource.MustParse("2")))
+		})
+
+		It("isvc-8: HWP overwrites conflicting nodeSelector key; adds new key", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west", "tier": "gpu"},
+					nil,
+				))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Spec.Predictor.NodeSelector = map[string]string{"zone": "us-east"}
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.NodeSelector["zone"]).To(Equal("eu-west")) // HWP wins
+			Expect(isvc.Spec.Predictor.NodeSelector["tier"]).To(Equal("gpu"))     // HWP-only key added
+		})
+
+		It("isvc-9: identical HWP toleration deduplicated (not doubled)", func() {
+			tol := hwptestutil.TolerationMap("nvidia.com/gpu", "Exists", "NoSchedule")
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.NodeSpec(nil, []interface{}{tol}))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Spec.Predictor.Tolerations = []corev1.Toleration{
+				{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			}
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Tolerations).To(HaveLen(1))
+			Expect(isvc.Spec.Predictor.Tolerations[0].Key).To(Equal("nvidia.com/gpu"))
+			Expect(isvc.Spec.Predictor.Tolerations[0].Operator).To(Equal(corev1.TolerationOpExists))
+			Expect(isvc.Spec.Predictor.Tolerations[0].Effect).To(Equal(corev1.TaintEffectNoSchedule))
+		})
+
+		It("isvc-10: HWP overwrites existing Kueue label", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("hwp-queue"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), map[string]string{
+				hardwareprofile.KueueQueueNameLabel: "user-queue",
+			})
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("hwp-queue"))
+		})
+
+		It("isvc-19: resource present in limits only — request injected from HWP, limit preserved", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.ResourceSpec([]string{"nvidia.com/gpu", "2"}))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Spec.Predictor.Model.Resources.Limits = corev1.ResourceList{
+				"nvidia.com/gpu": resource.MustParse("1"),
+			}
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.Resources.Requests["nvidia.com/gpu"]).
+				To(Equal(resource.MustParse("2"))) // request injected from HWP (was absent)
+			Expect(isvc.Spec.Predictor.Model.Resources.Limits["nvidia.com/gpu"]).
+				To(Equal(resource.MustParse("1"))) // user-set limit preserved
+		})
+
+		It("isvc-20: nil predictor Model — resource injection skipped, node scheduling still applied", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "gpu-zone"}, nil))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCNoModelForHWP(hwpAnnotations(hwpTestName))
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+			Expect(isvc.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+		})
+
+		It("isvc-21: non-conflicting pre-existing toleration preserved alongside HWP toleration", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS,
+				hwptestutil.NodeSpec(nil, []interface{}{
+					hwptestutil.TolerationMap("hwp-key", "Exists", "NoSchedule"),
+				}))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+			isvc.Spec.Predictor.Tolerations = []corev1.Toleration{
+				{Key: "manual-key", Operator: corev1.TolerationOpExists},
+			}
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Tolerations).To(HaveLen(2))
+			keys := make([]string, 0, 2)
+			for _, t := range isvc.Spec.Predictor.Tolerations {
+				keys = append(keys, t.Key)
+			}
+			Expect(keys).To(ConsistOf("hwp-key", "manual-key"))
+		})
+
+		It("isvc-22: Kueue label already matches HWP value — unchanged, no error", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, hwptestutil.KueueSpec("my-queue"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotations(hwpTestName), map[string]string{
+				hardwareprofile.KueueQueueNameLabel: "my-queue",
+			})
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("my-queue"))
+		})
+	})
+
+	Describe("Test Group 3 — Profile change and annotation removal (UPDATE)", func() {
+
+		It("isvc-11: same profile on UPDATE — merge semantics applied", func() {
+			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
+			spec["schedulingSpec"] = map[string]interface{}{
+				"node": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
+			newISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, hwpTestNS), nil)
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			// Resources applied (same as CREATE).
+			Expect(newISVC.Spec.Predictor.Model.Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			Expect(newISVC.Spec.Predictor.Model.Resources.Limits[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			// Node scheduling applied.
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+			// Kueue label not set (HWP uses node scheduling, not Kueue).
+			Expect(newISVC.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("isvc-12: different profile on UPDATE — ALL stanzas cleared before new profile applied", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west"},
+					[]interface{}{hwptestutil.TolerationMap("key-a", "Exists", "NoSchedule")},
+				))
+			hwpB := hwptestutil.NewHardwareProfile("hwp-b", hwpTestNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"tier": "gpu"},
+					[]interface{}{hwptestutil.TolerationMap("key-b", "Exists", "NoSchedule")},
+				))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA, hwpB))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+			oldISVC.Spec.Predictor.Tolerations = []corev1.Toleration{
+				{Key: "key-a", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			}
+
+			// apiserver carries over old stanzas in the new object body
+			newISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-b", hwpTestNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "old-queue"})
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+			newISVC.Spec.Predictor.Tolerations = []corev1.Toleration{
+				{Key: "key-a", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
+			Expect(newISVC.Spec.Predictor.NodeSelector).NotTo(HaveKey("zone"))
+			keys := make([]string, 0)
+			for _, t := range newISVC.Spec.Predictor.Tolerations {
+				keys = append(keys, t.Key)
+			}
+			Expect(keys).To(ConsistOf("key-b"))
+			Expect(newISVC.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("isvc-13: annotation removed on UPDATE — HWP stanzas surgically removed, manual entries preserved", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS,
+				hwptestutil.NodeSpec(
+					map[string]interface{}{"zone": "eu-west"},
+					[]interface{}{hwptestutil.TolerationMap("key-a", "", "")},
+				))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+			oldISVC.Spec.Predictor.Tolerations = []corev1.Toleration{{Key: "key-a"}, {Key: "manual"}}
+
+			newISVC := buildISVCForHWP(nil, nil) // HWP annotation removed
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+			newISVC.Spec.Predictor.Tolerations = []corev1.Toleration{{Key: "key-a"}, {Key: "manual"}}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			// HWP nodeSelector entry removed
+			Expect(newISVC.Spec.Predictor.NodeSelector).NotTo(HaveKey("zone"))
+			// HWP toleration removed; manual toleration preserved
+			Expect(newISVC.Spec.Predictor.Tolerations).To(HaveLen(1))
+			Expect(newISVC.Spec.Predictor.Tolerations[0].Key).To(Equal("manual"))
+			// Namespace annotation removed
+			Expect(newISVC.Annotations).NotTo(HaveKey(hardwareprofile.HardwareProfileAnnotationNamespace))
+		})
+
+		It("isvc-14: annotation removed, old HWP not found — admitted, namespace annotation cleaned", func() {
+			d := newISVCDefaulter(newDefaulterFakeClient()) // HWP CR was deleted
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+
+			newISVC := buildISVCForHWP(nil, nil) // annotation removed
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Annotations).NotTo(HaveKey(hardwareprofile.HardwareProfileAnnotationNamespace))
+			// Stanzas remain because HWP is gone — cannot clean up
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("zone", "eu-west"))
+		})
+
+		It("isvc-15: cross-namespace HWP reference — resources fetched from other-ns", func() {
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, "other-ns",
+				hwptestutil.ResourceSpec([]string{"cpu", "8"}))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+			isvc := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "other-ns"), nil)
+
+			Expect(d.Default(isvcCreateCtx(isvc), isvc)).To(Succeed())
+			Expect(isvc.Spec.Predictor.Model.Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("8")))
+		})
+
+		It("isvc-23: namespace-only profile change on UPDATE — ALL stanzas cleared, new profile applied", func() {
+			hwpNS2 := hwptestutil.NewHardwareProfile(hwpTestName, "namespace-2",
+				hwptestutil.NodeSpec(map[string]interface{}{"tier": "gpu"}, nil))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpNS2))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "namespace-1"), nil)
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			newISVC := buildISVCForHWP(hwpAnnotationsWithNS(hwpTestName, "namespace-2"), nil)
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"} // carried over
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("tier", "gpu"))
+			Expect(newISVC.Spec.Predictor.NodeSelector).NotTo(HaveKey("zone"))
+		})
+
+		It("isvc-24: initial annotation assignment on UPDATE — merge semantics (no blanket clear)", func() {
+			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
+			spec["schedulingSpec"] = map[string]interface{}{
+				"node": map[string]interface{}{
+					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
+				},
+			}
+			hwp := hwptestutil.NewHardwareProfile(hwpTestName, hwpTestNS, spec)
+			d := newISVCDefaulter(newDefaulterFakeClient(hwp))
+
+			oldISVC := buildISVCForHWP(nil, nil) // old object has no HWP annotation
+			newISVC := buildISVCForHWP(hwpAnnotations(hwpTestName), nil)
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			// Resources applied via merge semantics (same as CREATE — no blanket clear).
+			Expect(newISVC.Spec.Predictor.Model.Resources.Requests[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			Expect(newISVC.Spec.Predictor.Model.Resources.Limits[corev1.ResourceCPU]).
+				To(Equal(resource.MustParse("4")))
+			// Node scheduling applied.
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("zone", "gpu-zone"))
+			// Kueue label not set (HWP uses node scheduling, not Kueue).
+			Expect(newISVC.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("isvc-25: Kueue-to-Kueue profile switch — new label applied, no error", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS, hwptestutil.KueueSpec("queue-a"))
+			hwpB := hwptestutil.NewHardwareProfile("hwp-b", hwpTestNS, hwptestutil.KueueSpec("queue-b"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA, hwpB))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"})
+			newISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-b", hwpTestNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "queue-a"}) // carried over
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Labels[hardwareprofile.KueueQueueNameLabel]).To(Equal("queue-b"))
+		})
+
+		It("isvc-26: annotation removed, nodeSelector value differs from old HWP — key preserved", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			newISVC := buildISVCForHWP(nil, nil) // annotation removed
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "us-east"} // user-changed value
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			// Value differs from HWP record — key is preserved (not removed)
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(HaveKeyWithValue("zone", "us-east"))
+		})
+
+		It("isvc-27: annotation removed, isvc has no HWP stanzas — no-op, no panic", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			newISVC := buildISVCForHWP(nil, nil) // annotation removed; user already cleaned stanzas
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Spec.Predictor.NodeSelector).To(BeNil())
+		})
+
+		It("isvc-28: annotation removed, user overwrote Kueue label — removed unconditionally", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS, hwptestutil.KueueSpec("hwp-queue"))
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS),
+				map[string]string{hardwareprofile.KueueQueueNameLabel: "hwp-queue"})
+			newISVC := buildISVCForHWP(nil, map[string]string{
+				hardwareprofile.KueueQueueNameLabel: "user-queue", // user changed it
+			})
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+
+		It("isvc-29: annotation removed, no Kueue label present — no-op, no panic", func() {
+			hwpA := hwptestutil.NewHardwareProfile("hwp-a", hwpTestNS,
+				hwptestutil.NodeSpec(map[string]interface{}{"zone": "eu-west"}, nil)) // node scheduling only
+			d := newISVCDefaulter(newDefaulterFakeClient(hwpA))
+
+			oldISVC := buildISVCForHWP(hwpAnnotationsWithNS("hwp-a", hwpTestNS), nil)
+			oldISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			newISVC := buildISVCForHWP(nil, nil) // annotation removed, no Kueue label
+			newISVC.Annotations = map[string]string{
+				hardwareprofile.HardwareProfileAnnotationNamespace: hwpTestNS,
+			}
+			newISVC.Spec.Predictor.NodeSelector = map[string]string{"zone": "eu-west"}
+
+			Expect(d.Default(isvcUpdateCtx(newISVC, oldISVC), newISVC)).To(Succeed())
+			Expect(newISVC.Labels).NotTo(HaveKey(hardwareprofile.KueueQueueNameLabel))
+		})
+	})
+})

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -23,8 +23,8 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_webhook.go
@@ -23,7 +23,9 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -37,6 +39,7 @@ import (
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 	"github.com/opendatahub-io/odh-model-controller/internal/webhook/connectionapi"
+	"github.com/opendatahub-io/odh-model-controller/internal/webhook/serving/hardwareprofile"
 )
 
 // nolint:unused
@@ -162,7 +165,11 @@ func (d *InferenceServiceCustomDefaulter) Default(ctx context.Context, obj runti
 		return fmt.Errorf("failed to get admission request from context: %w", err)
 	}
 
-	return d.applyConnectionsAPI(ctx, req, isvc)
+	if err := d.applyConnectionsAPI(ctx, req, isvc); err != nil {
+		return err
+	}
+
+	return d.applyHardwareProfile(ctx, req, isvc)
 }
 
 // applyConnectionsAPI validates the connection annotation and performs the appropriate injection,
@@ -333,6 +340,166 @@ func performISVCInjection(
 		log.V(1).Info("unknown connection type, skipping injection", "connectionType", connInfo.Type)
 		return nil
 	}
+}
+
+// +kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list;watch
+
+// applyHardwareProfile applies HardwareProfile scheduling stanzas to an InferenceService at admission time.
+//
+// Resolves the HardwareProfile referenced by opendatahub.io/hardware-profile-name annotation and
+// injects container resources, nodeSelector, tolerations, and the Kueue queue label into the
+// InferenceService spec. On UPDATE where the annotation is removed, surgically cleans up
+// previously-injected values from the old profile.
+//
+// Parameters:
+//   - ctx: context with logger
+//   - req: the admission request (used to read the old object on UPDATE)
+//   - isvc: the InferenceService being admitted (mutated in-place)
+//
+// Returns any error that should block admission.
+func (d *InferenceServiceCustomDefaulter) applyHardwareProfile(
+	ctx context.Context,
+	req admission.Request,
+	isvc *servingv1beta1.InferenceService,
+) error {
+	log := logf.FromContext(ctx)
+
+	if isvc.DeletionTimestamp != nil {
+		return nil
+	}
+
+	annotations := isvc.GetAnnotations()
+	profileName, profileNamespace := hardwareprofile.ProfileRef(annotations, isvc.Namespace)
+
+	if profileName == "" {
+		if req.Operation == admissionv1.Update {
+			return d.handleHWPRemovalISVC(ctx, req, isvc)
+		}
+		return nil
+	}
+
+	// Resolve the HardwareProfile CR.
+	profile, err := hardwareprofile.Resolve(ctx, d.client, profileName, profileNamespace)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return fmt.Errorf("hardware profile %q not found in namespace %q", profileName, profileNamespace)
+		}
+		return fmt.Errorf("failed fetching hardware profile: %w", err)
+	}
+
+	// Stamp the namespace annotation so callers can always find the namespace.
+	if annotations[hardwareprofile.HardwareProfileAnnotationNamespace] == "" {
+		if isvc.Annotations == nil {
+			isvc.Annotations = make(map[string]string)
+		}
+		isvc.Annotations[hardwareprofile.HardwareProfileAnnotationNamespace] = profileNamespace
+	}
+
+	profileChanged := hardwareprofile.ProfileChanged(req, profileName, profileNamespace)
+
+	// On profile switch, clear all previous scheduling stanzas before applying the new profile.
+	if profileChanged {
+		isvc.Spec.Predictor.NodeSelector = nil
+		isvc.Spec.Predictor.Tolerations = nil
+		if isvc.Labels != nil {
+			delete(isvc.Labels, hardwareprofile.KueueQueueNameLabel)
+		}
+	}
+
+	// Apply resource identifiers to the predictor model (existing values take priority).
+	hardwareprofile.ApplyToIsvcResources(profile, &isvc.Spec.Predictor)
+
+	// Kueue and node scheduling are mutually exclusive.
+	if profile.KueueQueueName != "" {
+		for _, w := range hardwareprofile.ApplyKueueLabel(profile, &isvc.ObjectMeta, profileChanged, profileName) {
+			log.Info(w)
+		}
+		return nil
+	}
+
+	// Apply node scheduling.
+	var newNS map[string]string
+	var newTols []corev1.Toleration
+	if profileChanged {
+		newNS, newTols = hardwareprofile.SetNodeScheduling(
+			profile, isvc.Spec.Predictor.NodeSelector, isvc.Spec.Predictor.Tolerations)
+	} else {
+		var warnings []string
+		newNS, newTols, warnings = hardwareprofile.MergeNodeScheduling(
+			profile, isvc.Spec.Predictor.NodeSelector, isvc.Spec.Predictor.Tolerations, profileName)
+		for _, w := range warnings {
+			log.Info(w)
+		}
+	}
+	isvc.Spec.Predictor.NodeSelector = newNS
+	isvc.Spec.Predictor.Tolerations = newTols
+
+	return nil
+}
+
+// handleHWPRemovalISVC handles the case where the HWP annotation is removed from an InferenceService
+// on UPDATE. Fetches the old HWP and surgically removes only its contributed nodeSelector entries,
+// tolerations, and Kueue label. When the old HWP cannot be fetched, logs a warning and removes
+// only the namespace annotation (does not block admission).
+//
+// Parameters:
+//   - ctx: context with logger
+//   - req: the admission request containing the old object
+//   - isvc: the InferenceService being admitted (mutated in-place)
+//
+// Returns any error that should block admission (only internal errors, not "old HWP not found").
+func (d *InferenceServiceCustomDefaulter) handleHWPRemovalISVC(
+	ctx context.Context,
+	req admission.Request,
+	isvc *servingv1beta1.InferenceService,
+) error {
+	log := logf.FromContext(ctx)
+
+	if req.OldObject.Raw == nil {
+		return nil
+	}
+	oldObj := &unstructured.Unstructured{}
+	if err := oldObj.UnmarshalJSON(req.OldObject.Raw); err != nil {
+		return nil
+	}
+
+	oldAnnotations := oldObj.GetAnnotations()
+	oldProfileName := oldAnnotations[hardwareprofile.HardwareProfileAnnotationName]
+	if oldProfileName == "" {
+		return nil
+	}
+
+	oldProfileNamespace := oldAnnotations[hardwareprofile.HardwareProfileAnnotationNamespace]
+	if oldProfileNamespace == "" {
+		oldProfileNamespace = oldObj.GetNamespace()
+	}
+
+	oldProfile, err := hardwareprofile.Resolve(ctx, d.client, oldProfileName, oldProfileNamespace)
+	if err != nil {
+		log.Info("could not fetch old HWP for ISVC cleanup — stanzas may remain in spec",
+			"error", err, "profile", oldProfileName, "namespace", oldProfileNamespace)
+		// Remove only the namespace annotation; do not block the user.
+		if isvc.Annotations != nil {
+			delete(isvc.Annotations, hardwareprofile.HardwareProfileAnnotationNamespace)
+		}
+		return nil
+	}
+
+	if oldProfile != nil {
+		newNS, newTols := hardwareprofile.RemoveNodeScheduling(
+			oldProfile, isvc.Spec.Predictor.NodeSelector, isvc.Spec.Predictor.Tolerations)
+		isvc.Spec.Predictor.NodeSelector = newNS
+		isvc.Spec.Predictor.Tolerations = newTols
+		if oldProfile.KueueQueueName != "" {
+			hardwareprofile.RemoveKueueLabel(&isvc.ObjectMeta)
+		}
+	}
+
+	if isvc.Annotations != nil {
+		delete(isvc.Annotations, hardwareprofile.HardwareProfileAnnotationNamespace)
+	}
+
+	return nil
 }
 
 // performISVCCleanup removes previously injected connection credentials from the InferenceService


### PR DESCRIPTION
## Description

Adds a mutating webhook for HardwareProfile (HWP) scheduling stanza
injection into InferenceService and LLMInferenceService resources,
migrating this responsibility from the opendatahub-operator webhook.

The existing InferenceService and LLMInferenceService mutating webhook
handlers are extended to call HWP injection.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-62536

## How Has This Been Tested?

TODO

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HardwareProfile support to InferenceService and LLMInferenceService webhooks, enabling automatic injection of compute resources, node scheduling (nodeSelector/tolerations), and Kueue queue routing based on hardware profile configuration.
  * Implemented profile change detection with automatic cleanup and re-application of scheduling configurations during updates.
  * Added surgical removal of hardware profile–derived settings when profile references are removed.

* **Tests**
  * Added comprehensive test coverage for HardwareProfile webhook functionality across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->