### PR TITLE
test(e2e): verify AuthPolicy injects flow control headers on inference paths

### DIFF
--- a/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
+++ b/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
@@ -3,11 +3,28 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 )
+
+// echoResponse captures the subset of the ealen/echo-server JSON response
+// needed to inspect reflected request headers.
+type echoResponse struct {
+	Request struct {
+		Headers map[string]string `json:"headers"`
+	} `json:"request"`
+}
+
+func parseEchoHeaders(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var resp echoResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("failed to parse echo server response: %v\nbody: %s", err, body)
+	}
+	return resp.Request.Headers
+}
 
 // TestFlowControlHeadersSA verifies that the AuthPolicy injects the correct
 // flow control headers for an authenticated ServiceAccount on an inference path.
@@ -30,18 +47,18 @@ func TestFlowControlHeadersSA(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	bodyStr := string(body)
+	headers := parseEchoHeaders(t, body)
 
-	if !strings.Contains(bodyStr, "x-gateway-inference-fairness-id") {
-		t.Error("response does not contain x-gateway-inference-fairness-id header")
-	}
-	if !strings.Contains(bodyStr, "https://kubernetes.default.svc") {
-		t.Error("fairness-id should be the cluster issuer (https://kubernetes.default.svc)")
+	if val, ok := headers["x-gateway-inference-fairness-id"]; !ok {
+		t.Error("x-gateway-inference-fairness-id header not injected")
+	} else if val != "https://kubernetes.default.svc" {
+		t.Errorf("fairness-id = %q, want %q", val, "https://kubernetes.default.svc")
 	}
 
-	expectedObjective := fmt.Sprintf("x-gateway-inference-objective\":%q", ns)
-	if !strings.Contains(bodyStr, expectedObjective) && !strings.Contains(bodyStr, fmt.Sprintf("x-gateway-inference-objective\": %q", ns)) {
-		t.Errorf("objective header value should be %q, body: %s", ns, bodyStr)
+	if val, ok := headers["x-gateway-inference-objective"]; !ok {
+		t.Error("x-gateway-inference-objective header not injected")
+	} else if val != ns {
+		t.Errorf("objective = %q, want namespace %q", val, ns)
 	}
 }
 
@@ -70,19 +87,21 @@ func TestFlowControlHeadersCrossNamespace(t *testing.T) {
 	if respA.StatusCode != http.StatusOK {
 		t.Fatalf("tenant A: expected 200, got %d", respA.StatusCode)
 	}
-	expectedA := fmt.Sprintf("x-gateway-inference-objective\":%q", nsA)
-	bodyAStr := string(bodyA)
-	if !strings.Contains(bodyAStr, expectedA) && !strings.Contains(bodyAStr, fmt.Sprintf("x-gateway-inference-objective\": %q", nsA)) {
-		t.Errorf("tenant A objective header value should be %q, body: %s", nsA, bodyAStr)
+	headersA := parseEchoHeaders(t, bodyA)
+	if val, ok := headersA["x-gateway-inference-objective"]; !ok {
+		t.Error("tenant A: x-gateway-inference-objective header not injected")
+	} else if val != nsA {
+		t.Errorf("tenant A: objective = %q, want %q", val, nsA)
 	}
 
 	respB, bodyB := batchEnv.gatewayGet(t, path, tokenB, nil)
 	if respB.StatusCode != http.StatusOK {
 		t.Fatalf("tenant B: expected 200, got %d", respB.StatusCode)
 	}
-	expectedB := fmt.Sprintf("x-gateway-inference-objective\":%q", nsB)
-	bodyBStr := string(bodyB)
-	if !strings.Contains(bodyBStr, expectedB) && !strings.Contains(bodyBStr, fmt.Sprintf("x-gateway-inference-objective\": %q", nsB)) {
-		t.Errorf("tenant B objective header value should be %q, body: %s", nsB, bodyBStr)
+	headersB := parseEchoHeaders(t, bodyB)
+	if val, ok := headersB["x-gateway-inference-objective"]; !ok {
+		t.Error("tenant B: x-gateway-inference-objective header not injected")
+	} else if val != nsB {
+		t.Errorf("tenant B: objective = %q, want %q", val, nsB)
 	}
 }

--- a/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
+++ b/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
@@ -13,17 +13,31 @@ import (
 // needed to inspect reflected request headers.
 type echoResponse struct {
 	Request struct {
-		Headers map[string]string `json:"headers"`
+		Headers map[string]json.RawMessage `json:"headers"`
 	} `json:"request"`
 }
 
-func parseEchoHeaders(t *testing.T, body []byte) map[string]string {
+// parseEchoHeader extracts a single header value from the echo server response.
+// Handles both string ("value") and array (["value"]) formats.
+func parseEchoHeader(t *testing.T, body []byte, header string) (string, bool) {
 	t.Helper()
 	var resp echoResponse
 	if err := json.Unmarshal(body, &resp); err != nil {
 		t.Fatalf("failed to parse echo server response: %v\nbody: %s", err, body)
 	}
-	return resp.Request.Headers
+	raw, ok := resp.Request.Headers[header]
+	if !ok {
+		return "", false
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, true
+	}
+	var arr []string
+	if json.Unmarshal(raw, &arr) == nil && len(arr) > 0 {
+		return arr[0], true
+	}
+	return "", false
 }
 
 // TestFlowControlHeadersSA verifies that the AuthPolicy injects the correct
@@ -47,15 +61,13 @@ func TestFlowControlHeadersSA(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	headers := parseEchoHeaders(t, body)
-
-	if val, ok := headers["x-gateway-inference-fairness-id"]; !ok {
+	if val, ok := parseEchoHeader(t, body, "x-gateway-inference-fairness-id"); !ok {
 		t.Error("x-gateway-inference-fairness-id header not injected")
 	} else if val != "https://kubernetes.default.svc" {
 		t.Errorf("fairness-id = %q, want %q", val, "https://kubernetes.default.svc")
 	}
 
-	if val, ok := headers["x-gateway-inference-objective"]; !ok {
+	if val, ok := parseEchoHeader(t, body, "x-gateway-inference-objective"); !ok {
 		t.Error("x-gateway-inference-objective header not injected")
 	} else if val != ns {
 		t.Errorf("objective = %q, want namespace %q", val, ns)
@@ -87,8 +99,12 @@ func TestFlowControlHeadersCrossNamespace(t *testing.T) {
 	if respA.StatusCode != http.StatusOK {
 		t.Fatalf("tenant A: expected 200, got %d", respA.StatusCode)
 	}
-	headersA := parseEchoHeaders(t, bodyA)
-	if val, ok := headersA["x-gateway-inference-objective"]; !ok {
+	if val, ok := parseEchoHeader(t, bodyA, "x-gateway-inference-fairness-id"); !ok {
+		t.Error("tenant A: x-gateway-inference-fairness-id header not injected")
+	} else if val != "https://kubernetes.default.svc" {
+		t.Errorf("tenant A: fairness-id = %q, want %q", val, "https://kubernetes.default.svc")
+	}
+	if val, ok := parseEchoHeader(t, bodyA, "x-gateway-inference-objective"); !ok {
 		t.Error("tenant A: x-gateway-inference-objective header not injected")
 	} else if val != nsA {
 		t.Errorf("tenant A: objective = %q, want %q", val, nsA)
@@ -98,10 +114,42 @@ func TestFlowControlHeadersCrossNamespace(t *testing.T) {
 	if respB.StatusCode != http.StatusOK {
 		t.Fatalf("tenant B: expected 200, got %d", respB.StatusCode)
 	}
-	headersB := parseEchoHeaders(t, bodyB)
-	if val, ok := headersB["x-gateway-inference-objective"]; !ok {
+	if val, ok := parseEchoHeader(t, bodyB, "x-gateway-inference-fairness-id"); !ok {
+		t.Error("tenant B: x-gateway-inference-fairness-id header not injected")
+	} else if val != "https://kubernetes.default.svc" {
+		t.Errorf("tenant B: fairness-id = %q, want %q", val, "https://kubernetes.default.svc")
+	}
+	if val, ok := parseEchoHeader(t, bodyB, "x-gateway-inference-objective"); !ok {
 		t.Error("tenant B: x-gateway-inference-objective header not injected")
 	} else if val != nsB {
 		t.Errorf("tenant B: objective = %q, want %q", val, nsB)
+	}
+}
+
+// TestNonInferencePathNoFlowControlHeaders verifies that flow control headers
+// are NOT injected on non-inference paths. The AuthPolicy should scope header
+// injection to inference paths only (e.g., /v1/chat/completions).
+func TestNonInferencePathNoFlowControlHeaders(t *testing.T) {
+	t.Parallel()
+
+	ns := batchEnv.createNamespace(t, "e2e-fc", nil)
+	batchEnv.deployEchoServer(t, ns)
+	batchEnv.createHTTPRoute(t, ns, "echo-noninference", fmt.Sprintf("/%s/echo-server", ns))
+	batchEnv.createServiceAccount(t, ns, "fc-user")
+	batchEnv.grantInferenceAccess(t, ns, ns, "fc-user")
+	token := batchEnv.requestToken(t, ns, "fc-user")
+	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), token)
+
+	path := fmt.Sprintf("/%s/echo-server/v1/files", ns)
+	resp, body := batchEnv.gatewayGet(t, path, token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if _, ok := parseEchoHeader(t, body, "x-gateway-inference-fairness-id"); ok {
+		t.Error("non-inference path should not have x-gateway-inference-fairness-id header")
+	}
+	if _, ok := parseEchoHeader(t, body, "x-gateway-inference-objective"); ok {
+		t.Error("non-inference path should not have x-gateway-inference-objective header")
 	}
 }

--- a/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
+++ b/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
@@ -39,11 +39,9 @@ func TestFlowControlHeadersSA(t *testing.T) {
 		t.Error("fairness-id should be the cluster issuer (https://kubernetes.default.svc)")
 	}
 
-	if !strings.Contains(bodyStr, "x-gateway-inference-objective") {
-		t.Error("response does not contain x-gateway-inference-objective header")
-	}
-	if !strings.Contains(bodyStr, ns) {
-		t.Errorf("objective should be the SA namespace %q", ns)
+	expectedObjective := fmt.Sprintf("x-gateway-inference-objective\":%q", ns)
+	if !strings.Contains(bodyStr, expectedObjective) && !strings.Contains(bodyStr, fmt.Sprintf("x-gateway-inference-objective\": %q", ns)) {
+		t.Errorf("objective header value should be %q, body: %s", ns, bodyStr)
 	}
 }
 
@@ -72,15 +70,19 @@ func TestFlowControlHeadersCrossNamespace(t *testing.T) {
 	if respA.StatusCode != http.StatusOK {
 		t.Fatalf("tenant A: expected 200, got %d", respA.StatusCode)
 	}
-	if !strings.Contains(string(bodyA), nsA) {
-		t.Errorf("tenant A objective should contain namespace %q", nsA)
+	expectedA := fmt.Sprintf("x-gateway-inference-objective\":%q", nsA)
+	bodyAStr := string(bodyA)
+	if !strings.Contains(bodyAStr, expectedA) && !strings.Contains(bodyAStr, fmt.Sprintf("x-gateway-inference-objective\": %q", nsA)) {
+		t.Errorf("tenant A objective header value should be %q, body: %s", nsA, bodyAStr)
 	}
 
 	respB, bodyB := batchEnv.gatewayGet(t, path, tokenB, nil)
 	if respB.StatusCode != http.StatusOK {
 		t.Fatalf("tenant B: expected 200, got %d", respB.StatusCode)
 	}
-	if !strings.Contains(string(bodyB), nsB) {
-		t.Errorf("tenant B objective should contain namespace %q", nsB)
+	expectedB := fmt.Sprintf("x-gateway-inference-objective\":%q", nsB)
+	bodyBStr := string(bodyB)
+	if !strings.Contains(bodyBStr, expectedB) && !strings.Contains(bodyBStr, fmt.Sprintf("x-gateway-inference-objective\": %q", nsB)) {
+		t.Errorf("tenant B objective header value should be %q, body: %s", nsB, bodyBStr)
 	}
 }

--- a/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
+++ b/internal/controller/test/e2e/flowcontrol_authpolicy_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestFlowControlHeadersSA verifies that the AuthPolicy injects the correct
+// flow control headers for an authenticated ServiceAccount on an inference path.
+//
+// Expected: fairness-id = cluster issuer, objective = SA namespace.
+func TestFlowControlHeadersSA(t *testing.T) {
+	t.Parallel()
+
+	ns := batchEnv.createNamespace(t, "e2e-fc", nil)
+	batchEnv.deployEchoServer(t, ns)
+	batchEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	batchEnv.createServiceAccount(t, ns, "fc-user")
+	batchEnv.grantInferenceAccess(t, ns, ns, "fc-user")
+	token := batchEnv.requestToken(t, ns, "fc-user")
+	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), token)
+
+	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", ns)
+	resp, body := batchEnv.gatewayGet(t, path, token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	bodyStr := string(body)
+
+	if !strings.Contains(bodyStr, "x-gateway-inference-fairness-id") {
+		t.Error("response does not contain x-gateway-inference-fairness-id header")
+	}
+	if !strings.Contains(bodyStr, "https://kubernetes.default.svc") {
+		t.Error("fairness-id should be the cluster issuer (https://kubernetes.default.svc)")
+	}
+
+	if !strings.Contains(bodyStr, "x-gateway-inference-objective") {
+		t.Error("response does not contain x-gateway-inference-objective header")
+	}
+	if !strings.Contains(bodyStr, ns) {
+		t.Errorf("objective should be the SA namespace %q", ns)
+	}
+}
+
+// TestFlowControlHeadersCrossNamespace verifies that two ServiceAccounts from
+// different namespaces get different objective values (their respective
+// namespace names), ensuring tenant isolation in flow control.
+func TestFlowControlHeadersCrossNamespace(t *testing.T) {
+	t.Parallel()
+
+	nsA := batchEnv.createNamespace(t, "e2e-fc", nil)
+	batchEnv.deployEchoServer(t, nsA)
+	batchEnv.createHTTPRoute(t, nsA, "echo-inference", fmt.Sprintf("/%s/echo-server", nsA))
+	batchEnv.createServiceAccount(t, nsA, "tenant-user")
+	batchEnv.grantInferenceAccess(t, nsA, nsA, "tenant-user")
+	tokenA := batchEnv.requestToken(t, nsA, "tenant-user")
+	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", nsA), tokenA)
+
+	nsB := batchEnv.createNamespace(t, "e2e-fc", nil)
+	batchEnv.createServiceAccount(t, nsB, "tenant-user")
+	batchEnv.grantInferenceAccess(t, nsA, nsB, "tenant-user")
+	tokenB := batchEnv.requestToken(t, nsB, "tenant-user")
+
+	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", nsA)
+
+	respA, bodyA := batchEnv.gatewayGet(t, path, tokenA, nil)
+	if respA.StatusCode != http.StatusOK {
+		t.Fatalf("tenant A: expected 200, got %d", respA.StatusCode)
+	}
+	if !strings.Contains(string(bodyA), nsA) {
+		t.Errorf("tenant A objective should contain namespace %q", nsA)
+	}
+
+	respB, bodyB := batchEnv.gatewayGet(t, path, tokenB, nil)
+	if respB.StatusCode != http.StatusOK {
+		t.Fatalf("tenant B: expected 200, got %d", respB.StatusCode)
+	}
+	if !strings.Contains(string(bodyB), nsB) {
+		t.Errorf("tenant B objective should contain namespace %q", nsB)
+	}
+}


### PR DESCRIPTION
## Summary

Verify that the user-defined AuthPolicy injects `x-gateway-inference-fairness-id` and
`x-gateway-inference-objective` headers on inference paths. Two tests:

- **TestFlowControlHeadersSA**: SA gets `fairness-id=https://kubernetes.default.svc`,
  `objective={SA namespace}` (CEL extraction from `system:serviceaccount:{ns}:{name}`)
- **TestFlowControlHeadersCrossNamespace**: two SAs from different namespaces get
  different objective values, confirming tenant isolation

Uses inference paths only. Independent of batch. Follows `batch_authpolicy_test.go` pattern.
Requires `make test-e2e-controller` (controller + gateway + Authorino deployed).

Closes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating flow-control header injection on gateway inference responses
  * Added coverage for single-namespace behavior with expected fairness and objective values
  * Added cross-namespace scenarios to confirm each caller receives the correct tenant objective based on the requesting namespace
<!-- end of auto-generated comment: release notes by coderabbit.ai -->