### PR TITLE
chore: remove kserve and vllm version

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,10 +1,4 @@
 releases:
-  - name: KServe
-    version: v0.14.0
-    repoUrl: https://github.com/kserve/kserve/
-  - name: vLLM
-    version: v0.11.2
-    repoUrl: https://github.com/vllm-project/vllm
   - name: OpenVINO Model Server
     version: v2025.4
     repoUrl: https://github.com/openvinotoolkit/model_server


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- this is out of date and we are using "kserve" to host these info

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated release entries for KServe and vLLM from component metadata.
  * Updated the release listing order so OpenVINO Model Server now appears first, followed by the remaining components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->