### PR TITLE
Add default ClusterServingRuntime manifests for Phase 1

### DIFF
--- a/config/runtimes/csr-kserve-mlserver-v1.yaml
+++ b/config/runtimes/csr-kserve-mlserver-v1.yaml
@@ -1,0 +1,82 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: csr-kserve-mlserver-v1
+  labels:
+    opendatahub.io/managed: "true"
+  annotations:
+    opendatahub.io/version: "1.0.0"
+    opendatahub.io/template-display-name: "MLServer"
+    opendatahub.io/runtime-version: "1.7.1"
+    openshift.io/display-name: MLServer ServingRuntime for KServe
+    serving.kserve.io/server-type: mlserver
+spec:
+  annotations:
+    opendatahub.io/kserve-runtime: "mlserver"
+    prometheus.io/port: "8082"
+    prometheus.io/path: /metrics
+    monitoring.opendatahub.io/scrape: "true"
+  containers:
+    - name: kserve-container
+      image: quay.io/opendatahub/mlserver:fast
+      env:
+        - name: MLSERVER_MODEL_IMPLEMENTATION
+          value: "{{.Labels.modelClass}}"
+        - name: MLSERVER_HTTP_PORT
+          value: "8080"
+        - name: MLSERVER_MODELS_DIR
+          value: /mnt/models
+      startupProbe:
+        initialDelaySeconds: 1
+        periodSeconds: 1
+        failureThreshold: 1
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              [ -n "$(ls -A /mnt/models 2>/dev/null)" ]
+      readinessProbe:
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        failureThreshold: 3
+        timeoutSeconds: 5
+        httpGet:
+          path: /v2/models/{{.Name}}/ready
+          port: 8080
+      livenessProbe:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+        failureThreshold: 6
+        timeoutSeconds: 5
+        httpGet:
+          path: /v2/models/{{.Name}}/ready
+          port: 8080
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsNonRoot: true
+  protocolVersions:
+    - v2
+  multiModel: false
+  supportedModelFormats:
+    - name: sklearn
+      version: "0"
+    - name: sklearn
+      version: "1"
+    - name: xgboost
+      version: "1"
+    - name: xgboost
+      version: "2"
+    - name: lightgbm
+      version: "3"
+    - name: lightgbm
+      version: "4"
+    - name: onnx
+      version: "1"

--- a/config/runtimes/csr-kserve-mlserver-v1.yaml
+++ b/config/runtimes/csr-kserve-mlserver-v1.yaml
@@ -18,7 +18,7 @@ spec:
     monitoring.opendatahub.io/scrape: "true"
   containers:
     - name: kserve-container
-      image: quay.io/opendatahub/mlserver:fast
+      image: $(mlserver-image)
       env:
         - name: MLSERVER_MODEL_IMPLEMENTATION
           value: "{{.Labels.modelClass}}"
@@ -52,6 +52,13 @@ spec:
         httpGet:
           path: /v2/models/{{.Name}}/ready
           port: 8080
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "2"
+          memory: 4Gi
       ports:
         - containerPort: 8080
           protocol: TCP

--- a/config/runtimes/csr-kserve-ovms-v1.yaml
+++ b/config/runtimes/csr-kserve-ovms-v1.yaml
@@ -1,0 +1,52 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: csr-kserve-ovms-v1
+  labels:
+    opendatahub.io/managed: "true"
+  annotations:
+    opendatahub.io/version: "1.0.0"
+    opendatahub.io/template-display-name: "OpenVINO Model Server"
+    opendatahub.io/runtime-version: "v2026.1.0"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    openshift.io/display-name: OpenVINO Model Server
+spec:
+  annotations:
+    opendatahub.io/kserve-runtime: "ovms"
+    prometheus.io/port: "8888"
+    prometheus.io/path: /metrics
+  multiModel: false
+  supportedModelFormats:
+    - name: openvino_ir
+      version: opset13
+      autoSelect: true
+    - name: onnx
+      version: "1"
+    - name: tensorflow
+      version: "1"
+      autoSelect: true
+    - name: tensorflow
+      version: "2"
+      autoSelect: true
+    - name: paddle
+      version: "2"
+      autoSelect: true
+    - name: pytorch
+      version: "2"
+      autoSelect: true
+  protocolVersions:
+    - v2
+    - grpc-v2
+  containers:
+    - name: kserve-container
+      image: quay.io/opendatahub/openvino_model_server:2025.1-release
+      args:
+        - "--model_name={{.Name}}"
+        - "--port=8001"
+        - "--rest_port=8888"
+        - "--model_path=/mnt/models"
+        - "--file_system_poll_wait_seconds=0"
+        - "--metrics_enable"
+      ports:
+        - containerPort: 8888
+          protocol: TCP

--- a/config/runtimes/csr-kserve-ovms-v1.yaml
+++ b/config/runtimes/csr-kserve-ovms-v1.yaml
@@ -39,7 +39,7 @@ spec:
     - grpc-v2
   containers:
     - name: kserve-container
-      image: quay.io/opendatahub/openvino_model_server:2025.1-release
+      image: $(ovms-image)
       args:
         - "--model_name={{.Name}}"
         - "--port=8001"

--- a/config/runtimes/csr-kserve-vllm-v1.yaml
+++ b/config/runtimes/csr-kserve-vllm-v1.yaml
@@ -1,0 +1,38 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: csr-kserve-vllm-v1
+  labels:
+    opendatahub.io/managed: "true"
+  annotations:
+    opendatahub.io/version: "1.0.0"
+    opendatahub.io/template-display-name: "vLLM"
+    opendatahub.io/runtime-version: "v0.21.0"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
+spec:
+  annotations:
+    opendatahub.io/kserve-runtime: "vllm"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  containers:
+    - name: kserve-container
+      image: quay.io/vllm/vllm-cuda:latest
+      command:
+        - python
+        - -m
+        - vllm.entrypoints.openai.api_server
+      args:
+        - "--port=8080"
+        - "--model=/mnt/models"
+        - "--served-model-name={{.Name}}"
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+      ports:
+        - containerPort: 8080
+          protocol: TCP

--- a/config/runtimes/csr-kserve-vllm-v1.yaml
+++ b/config/runtimes/csr-kserve-vllm-v1.yaml
@@ -21,7 +21,7 @@ spec:
       name: vLLM
   containers:
     - name: kserve-container
-      image: quay.io/vllm/vllm-cuda:latest
+      image: $(vllm-cuda-image)
       command:
         - python
         - -m

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
   - vllm/
   - hf-detector-template.yaml
   - autogluon-template.yaml
+  - csr-kserve-mlserver-v1.yaml
+  - csr-kserve-ovms-v1.yaml
+  - csr-kserve-vllm-v1.yaml


### PR DESCRIPTION
  ## Summary

Adds 3 default ClusterServingRuntime manifests to enable CLI/GitOps model deployment workflows without Dashboard dependency.

Part of Phase 1 CSR migration to decouple serving runtime management from OpenShift Templates.

  ## Changes

  **New Files:**
  - `config/runtimes/csr-kserve-mlserver-v1.yaml` - MLServer (sklearn, xgboost, lightgbm, onnx)
  - `config/runtimes/csr-kserve-ovms-v1.yaml` - OpenVINO Model Server
  - `config/runtimes/csr-kserve-vllm-v1.yaml` - vLLM for LLMs

  **Modified:**
  - `config/runtimes/kustomization.yaml` - Added CSR resources

  ## Key Features

  - Cluster-scoped runtimes available to all namespaces
  - Prefix-based naming (`csr-kserve-*-v1`) prevents conflicts
  - Version tracking via `opendatahub.io/version` annotations
  - Backward compatible - existing Template workflow unchanged

  ## Related

  - JIRA: [RHOAIENG-71868](https://redhat.atlassian.net/browse/RHOAIENG-71868)
  - [Phase 1 Backend Plan](https://docs.google.com/document/d/16exEcAbTXI7c0ylJmqFZmPLUTdXMiNMzefs1Eljra6M/edit)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-serving runtime templates for MLServer, OpenVINO Model Server (OVMS), and vLLM.
  * MLServer supports scikit-learn, XGBoost, LightGBM, and ONNX models with health checks, metrics, and hardened non-root execution.
  * OVMS supports configured model-serving protocols and exposes a metrics port.
  * vLLM provides an OpenAI-compatible API with Prometheus metrics and GPU acceleration support.
  * All three runtimes are included in the default runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-71868]: https://redhat.atlassian.net/browse/RHOAIENG-71868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ