### PR TITLE
feat: enable SecureServing, TLS profile watcher, and cert provisioning

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 
+	configv1 "github.com/openshift/api/config/v1"
 	templatev1client "github.com/openshift/client-go/template/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -44,6 +45,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	pkgtls "github.com/opendatahub-io/odh-model-controller/pkg/tls"
 
 	corecontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/core"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/nim"
@@ -87,8 +90,6 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
-	var enableHTTP2 bool
-	var tlsOpts []func(*tls.Config)
 	var monitoringNS string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metrics endpoint binds to. "+
@@ -97,10 +98,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&secureMetrics, "metrics-secure", false, // TODO: restore to true by default.
+	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
-	flag.BoolVar(&enableHTTP2, "enable-http2", false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&monitoringNS, "monitoring-namespace", "",
 		"The Namespace where the monitoring stack's Prometheus resides.")
 	opts := zap.Options{
@@ -111,24 +110,15 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	if !enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
-	}
-
 	// Create the manager
 	var err error
 	cfg := ctrl.GetConfigOrDie()
+	tlsResult, err := pkgtls.Resolve(context.Background(), cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+	tlsOpts := tlsResult.TLSOpts
 	mgr := createManager(cfg, metricsAddr, probeAddr, enableLeaderElection, secureMetrics, tlsOpts)
 
 	kubeClient, kubeClientErr := kubernetes.NewForConfig(cfg)
@@ -172,13 +162,30 @@ func main() {
 		setupLog.Error(tempClientErr, "unable to create template clientset")
 		os.Exit(1)
 	}
-	signalHandlerCtx := log.IntoContext(ctrl.SetupSignalHandler(), setupLog)
+	signalCtx, cancel := context.WithCancel(log.IntoContext(ctrl.SetupSignalHandler(), setupLog))
+	defer cancel()
+
+	if tlsResult.ProfileFetched && !xksMode {
+		watcher := &pkgtls.ProfileWatcher{
+			Client:             mgr.GetClient(),
+			InitialProfileSpec: tlsResult.ProfileSpec,
+			OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
+				setupLog.Info("TLS profile changed, initiating shutdown to reload")
+				cancel()
+			},
+		}
+		if err := watcher.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to set up TLS profile watcher")
+			os.Exit(1)
+		}
+	}
+
 	if !xksMode {
-		setupNim(mgr, signalHandlerCtx, kubeClient, templateClient)
+		setupNim(mgr, signalCtx, kubeClient, templateClient)
 	}
 
 	setupLog.Info("starting manager")
-	if err = mgr.Start(signalHandlerCtx); err != nil {
+	if err = mgr.Start(signalCtx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
@@ -238,9 +245,7 @@ func createManager(cfg *rest.Config, metricsAddr, probeAddr string,
 		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 
-		// TODO(user): If CertDir, CertName, and KeyName are not specified, controller-runtime will automatically
-		// generate self-signed certificates for the metrics server. While convenient for development and testing,
-		// this setup is not recommended for production.
+		metricsServerOptions.CertDir = "/tmp/k8s-metrics-server/metrics-certs"
 	}
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/config/default/cert_metrics_manager_patch.yaml
+++ b/config/default/cert_metrics_manager_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-model-controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: metrics-certs
+          mountPath: /tmp/k8s-metrics-server/metrics-certs
+          readOnly: true
+      volumes:
+      - name: metrics-certs
+        secret:
+          secretName: odh-model-controller-metrics-tls

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -40,10 +40,42 @@ patches:
   target:
     kind: Deployment
     name: odh-model-controller
+- path: cert_metrics_manager_patch.yaml
+  target:
+    kind: Deployment
+    name: odh-model-controller
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - path: manager_webhook_patch.yaml
+
+replacements:
+- source:
+    kind: Service
+    name: odh-model-controller-metrics-service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: ServiceMonitor
+      name: odh-model-controller-metrics-monitor
+    fieldPaths:
+    - spec.endpoints.0.tlsConfig.serverName
+    options:
+      delimiter: "."
+      index: 0
+- source:
+    kind: Service
+    name: odh-model-controller-metrics-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: ServiceMonitor
+      name: odh-model-controller-metrics-monitor
+    fieldPaths:
+    - spec.endpoints.0.tlsConfig.serverName
+    options:
+      delimiter: "."
+      index: 1
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,5 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint using HTTPS
-# TODO: restore to 8443 port
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8080
+  value: --metrics-bind-address=:8443

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -3,15 +3,15 @@ kind: Service
 metadata:
   labels:
     control-plane: odh-model-controller
-#    app.kubernetes.io/name: odh-model-controller
-#    app.kubernetes.io/managed-by: kustomize
   name: odh-model-controller-metrics-service
   namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: odh-model-controller-metrics-tls
 spec:
   ports:
-  - name: http # TODO: Restore to http
-    port: 8080 # TODO: Use TLS and change to 8443
+  - name: https
+    port: 8443
     protocol: TCP
-    targetPort: 8080 # TODO: Use TLS and change to 8443
+    targetPort: 8443
   selector:
     control-plane: odh-model-controller

--- a/config/overlays/xks/kustomization.yaml
+++ b/config/overlays/xks/kustomization.yaml
@@ -96,6 +96,12 @@ patches:
     kind: Deployment
     name: odh-model-controller
     version: v1
+- path: patches/remove-metrics-cert-volume.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: odh-model-controller
+    version: v1
 - path: patches/mutating-webhooks-xks.yaml
   target:
     group: admissionregistration.k8s.io

--- a/config/overlays/xks/manager_xks_env_patch.yaml
+++ b/config/overlays/xks/manager_xks_env_patch.yaml
@@ -7,6 +7,9 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+        - --metrics-bind-address=:8080
+        - --metrics-secure=false
         env:
         - name: ODH_PLATFORM_TYPE
           value: xKS

--- a/config/overlays/xks/patches/remove-metrics-cert-volume.yaml
+++ b/config/overlays/xks/patches/remove-metrics-cert-volume.yaml
@@ -1,0 +1,4 @@
+- op: remove
+  path: /spec/template/spec/volumes/1
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/1

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -11,20 +11,15 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https # Ensure this is the name of the port that exposes HTTPS metrics
+      port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        # Enabling option insecureSkipVerify is not recommended for production since it disables
-        # certificate verification. This poses a significant security risk by making the system vulnerable to
-        # man-in-the-middle attacks, where an attacker could intercept and manipulate the communication between
-        # Prometheus and the monitored services. This could lead to unauthorized access to sensitive metrics data,
-        # compromising the integrity and confidentiality of the information.
-        # Please use the following options for secure configurations:
-        # caFile: /etc/metrics-certs/ca.crt
-        # certFile: /etc/metrics-certs/tls.crt
-        # keyFile: /etc/metrics-certs/tls.key
-        insecureSkipVerify: false
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: odh-model-controller-metrics-service.NAMESPACE.svc
   selector:
     matchLabels:
       control-plane: odh-model-controller

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - authentications
   verbs:
   - get

--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -85,6 +85,7 @@ func NewInferenceServiceReconciler(setupLog logr.Logger, client client.Client, s
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;list;watch;update;create;patch;delete
 
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;watch;delete

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = ctrl.Log.WithName("tls")
+
+// openSSLToGoCipher maps OpenSSL cipher suite names to Go crypto/tls constants.
+var openSSLToGoCipher = map[string]uint16{
+	"TLS_AES_128_GCM_SHA256":               tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":               tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":         tls.TLS_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":          tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":          tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305-SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305-SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-CHACHA20-POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+// IntermediateCiphers is the Mozilla Intermediate cipher suite set.
+var IntermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var tlsVersionMap = map[configv1.TLSProtocolVersion]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// Result holds the resolved TLS configuration.
+type Result struct {
+	TLSOpts        []func(*tls.Config)
+	ProfileSpec    configv1.TLSProfileSpec
+	ProfileFetched bool
+}
+
+// Resolve reads the cluster TLS profile from apiservers.config.openshift.io/cluster
+// and returns TLS option functions for controller-runtime.
+// On non-OpenShift clusters or when the profile cannot be read, it returns
+// hardened Intermediate defaults. Returns an error only on unexpected failures
+// that should prevent startup (fail-closed).
+func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		return Result{}, fmt.Errorf("installing OpenShift config scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return Result{}, fmt.Errorf("creating bootstrap client for TLS profile: %w", err)
+	}
+
+	resolveCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	return resolve(resolveCtx, k8sClient)
+}
+
+func resolve(ctx context.Context, k8sClient client.Reader) (Result, error) {
+	var result Result
+
+	apiServer := &configv1.APIServer{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		switch {
+		case meta.IsNoMatchError(err):
+			log.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
+		case apierrors.IsNotFound(err):
+			log.Info("APIServer resource not found, using hardened defaults")
+		case apierrors.IsServiceUnavailable(err),
+			apierrors.IsTimeout(err),
+			apierrors.IsServerTimeout(err),
+			apierrors.IsTooManyRequests(err),
+			errors.Is(err, context.DeadlineExceeded):
+			log.Info("Transient error reading APIServer TLS profile, using hardened defaults", "error", err)
+			result.ProfileFetched = true
+		default:
+			return result, fmt.Errorf("failed to read APIServer TLS profile: %w", err)
+		}
+		result.ProfileSpec = *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		result.TLSOpts = append(result.TLSOpts, intermediateWithALPN)
+		return result, nil
+	}
+
+	result.ProfileFetched = true
+	result.ProfileSpec = *resolveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+
+	minVersion, ciphers := parseProfile(apiServer.Spec.TLSSecurityProfile)
+	if ciphers != nil && len(ciphers) == 0 {
+		return result, fmt.Errorf("custom TLS profile specified ciphers but none are supported by Go")
+	}
+
+	result.TLSOpts = append(result.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = minVersion
+		if len(ciphers) > 0 {
+			c.CipherSuites = ciphers
+		}
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+	return result, nil
+}
+
+func intermediateWithALPN(c *tls.Config) {
+	c.MinVersion = tls.VersionTLS12
+	c.CipherSuites = IntermediateCiphers
+	c.NextProtos = []string{"h2", "http/1.1"}
+}
+
+func resolveProfileSpec(profile *configv1.TLSSecurityProfile) *configv1.TLSProfileSpec {
+	if profile == nil {
+		p := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return p
+	}
+	switch profile.Type {
+	case configv1.TLSProfileModernType:
+		p := configv1.TLSProfiles[configv1.TLSProfileModernType]
+		return p
+	case configv1.TLSProfileOldType:
+		p := configv1.TLSProfiles[configv1.TLSProfileOldType]
+		return p
+	case configv1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			return &profile.Custom.TLSProfileSpec
+		}
+		p := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return p
+	default:
+		p := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return p
+	}
+}
+
+func parseProfile(profile *configv1.TLSSecurityProfile) (uint16, []uint16) {
+	if profile == nil {
+		return tls.VersionTLS12, IntermediateCiphers
+	}
+
+	switch profile.Type {
+	case configv1.TLSProfileIntermediateType, "":
+		return tls.VersionTLS12, IntermediateCiphers
+	case configv1.TLSProfileModernType:
+		return tls.VersionTLS13, nil
+	case configv1.TLSProfileOldType:
+		return tls.VersionTLS10, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			log.Info("Custom TLS profile type specified but custom block is nil, falling back to Intermediate")
+			return tls.VersionTLS12, IntermediateCiphers
+		}
+		return parseCustomProfile(profile.Custom)
+	default:
+		log.Info("Unknown TLS profile type, falling back to Intermediate", "type", profile.Type)
+		return tls.VersionTLS12, IntermediateCiphers
+	}
+}
+
+func parseCustomProfile(custom *configv1.CustomTLSProfile) (uint16, []uint16) {
+	minVersion, ok := tlsVersionMap[custom.MinTLSVersion]
+	if !ok {
+		log.Info("Unknown minTLSVersion in custom profile, defaulting to TLS 1.2", "minTLSVersion", custom.MinTLSVersion)
+		minVersion = tls.VersionTLS12
+	}
+
+	if len(custom.Ciphers) == 0 {
+		return minVersion, nil
+	}
+
+	ciphers := make([]uint16, 0, len(custom.Ciphers))
+	for _, name := range custom.Ciphers {
+		if id, ok := openSSLToGoCipher[name]; ok {
+			ciphers = append(ciphers, id)
+		} else {
+			log.Info("Dropping unsupported cipher from custom TLS profile", "cipher", name)
+		}
+	}
+	return minVersion, ciphers
+}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		profile        *configv1.TLSSecurityProfile
+		wantMinVersion uint16
+		wantCiphers    []uint16
+	}{
+		{
+			name:           "nil profile returns Intermediate defaults",
+			profile:        nil,
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name:           "empty profile returns Intermediate defaults",
+			profile:        &configv1.TLSSecurityProfile{},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Intermediate type returns Intermediate defaults",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Modern returns TLS 1.3 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Old returns TLS 1.0 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			wantMinVersion: tls.VersionTLS10,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Custom with valid ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			},
+		},
+		{
+			name: "Custom with unsupported cipher skips it",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"UNSUPPORTED-CIPHER",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			},
+		},
+		{
+			name: "Custom with nil custom block falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Unknown type falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "SuperSecure",
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    IntermediateCiphers,
+		},
+		{
+			name: "Custom with all unsupported ciphers returns empty slice",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers: []string{
+							"DHE-RSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMinVersion, gotCiphers := parseProfile(tt.profile)
+
+			if gotMinVersion != tt.wantMinVersion {
+				t.Errorf("parseProfile() minVersion = %d, want %d", gotMinVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCiphers == nil {
+				if gotCiphers != nil {
+					t.Errorf("parseProfile() ciphers = %v, want nil", gotCiphers)
+				}
+				return
+			}
+
+			if gotCiphers == nil {
+				t.Fatal("expected non-nil empty slice, got nil (fail-closed guard needs non-nil)")
+			}
+			if len(gotCiphers) != len(tt.wantCiphers) {
+				t.Errorf("parseProfile() ciphers length = %d, want %d", len(gotCiphers), len(tt.wantCiphers))
+				return
+			}
+
+			for i, c := range gotCiphers {
+				if c != tt.wantCiphers[i] {
+					t.Errorf("parseProfile() ciphers[%d] = %d, want %d", i, c, tt.wantCiphers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveProfileSpec(t *testing.T) {
+	intermediateSpec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	modernSpec := configv1.TLSProfiles[configv1.TLSProfileModernType]
+	oldSpec := configv1.TLSProfiles[configv1.TLSProfileOldType]
+
+	tests := []struct {
+		name    string
+		profile *configv1.TLSSecurityProfile
+		want    *configv1.TLSProfileSpec
+	}{
+		{
+			name:    "nil profile returns Intermediate",
+			profile: nil,
+			want:    intermediateSpec,
+		},
+		{
+			name:    "Modern profile",
+			profile: &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			want:    modernSpec,
+		},
+		{
+			name:    "Old profile",
+			profile: &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType},
+			want:    oldSpec,
+		},
+		{
+			name: "Custom profile returns custom spec",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS13",
+						Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+					},
+				},
+			},
+			want: &configv1.TLSProfileSpec{
+				MinTLSVersion: "VersionTLS13",
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+			},
+		},
+		{
+			name:    "Custom with nil block returns Intermediate",
+			profile: &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
+			want:    intermediateSpec,
+		},
+		{
+			name:    "Unknown type returns Intermediate",
+			profile: &configv1.TLSSecurityProfile{Type: "Future"},
+			want:    intermediateSpec,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveProfileSpec(tt.profile)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resolveProfileSpec() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = configv1.Install(s)
+	return s
+}
+
+func TestResolve_Success(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+		},
+	}
+
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
+
+	result, err := resolve(context.Background(), fakeClient)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !result.ProfileFetched {
+		t.Error("expected ProfileFetched = true")
+	}
+	if result.ProfileSpec.MinTLSVersion != configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion {
+		t.Errorf("expected Modern profile spec, got %+v", result.ProfileSpec)
+	}
+}
+
+func TestResolve_NotFound(t *testing.T) {
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	result, err := resolve(context.Background(), fakeClient)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, expected graceful fallback", err)
+	}
+	if result.ProfileFetched {
+		t.Error("expected ProfileFetched = false on NotFound")
+	}
+	if len(result.TLSOpts) == 0 {
+		t.Error("expected TLSOpts with Intermediate defaults")
+	}
+	c := &tls.Config{}
+	result.TLSOpts[0](c)
+	if c.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected TLS 1.2 fallback, got %d", c.MinVersion)
+	}
+}
+
+func TestResolve_TransientError_SetsProfileFetched(t *testing.T) {
+	fakeClient := &transientErrorClient{
+		err: apierrors.NewServiceUnavailable("api down"),
+	}
+
+	result, err := resolve(context.Background(), fakeClient)
+	if err != nil {
+		t.Fatalf("resolve() error = %v, expected graceful fallback", err)
+	}
+	if !result.ProfileFetched {
+		t.Error("expected ProfileFetched = true on transient error (for watcher self-healing)")
+	}
+}
+
+func TestResolve_FatalError_Returns(t *testing.T) {
+	gr := schema.GroupResource{Group: "config.openshift.io", Resource: "apiservers"}
+	fakeClient := &transientErrorClient{
+		err: apierrors.NewForbidden(gr, "cluster", nil),
+	}
+
+	_, err := resolve(context.Background(), fakeClient)
+	if err == nil {
+		t.Fatal("expected error on Forbidden, got nil")
+	}
+}
+
+func TestProfileWatcher_DetectsChange(t *testing.T) {
+	initialProfile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	scheme := newTestScheme()
+
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
+
+	changed := false
+	watcher := &ProfileWatcher{
+		Client:             fakeClient,
+		InitialProfileSpec: initialProfile,
+		OnProfileChange: func(_ context.Context, old, new configv1.TLSProfileSpec) {
+			changed = true
+		},
+	}
+	watcher.lastProfile = initialProfile
+
+	_, err := watcher.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "cluster"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !changed {
+		t.Error("expected OnProfileChange to be called when profile differs from initial")
+	}
+}
+
+func TestProfileWatcher_IgnoresNonCluster(t *testing.T) {
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	called := false
+	watcher := &ProfileWatcher{
+		Client: fakeClient,
+		OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
+			called = true
+		},
+	}
+
+	_, err := watcher.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "not-cluster"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if called {
+		t.Error("OnProfileChange should not be called for non-cluster objects")
+	}
+}
+
+func TestProfileWatcher_NoChangeNoCallback(t *testing.T) {
+	intermediateSpec := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	scheme := newTestScheme()
+
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(apiServer).Build()
+
+	called := false
+	watcher := &ProfileWatcher{
+		Client:             fakeClient,
+		InitialProfileSpec: intermediateSpec,
+		OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
+			called = true
+		},
+	}
+	watcher.lastProfile = intermediateSpec
+
+	_, err := watcher.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{Name: "cluster"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if called {
+		t.Error("OnProfileChange should not be called when profile hasn't changed")
+	}
+}
+
+func TestResolve_UnsupportedCiphers_FailsClosed(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"UNSUPPORTED-ONLY"},
+					},
+				},
+			},
+		},
+	}
+
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).WithObjects(apiServer).Build()
+
+	_, err := resolve(context.Background(), fakeClient)
+	if err == nil {
+		t.Fatal("expected fail-closed error for all-unsupported ciphers")
+	}
+}
+
+// transientErrorClient is a fake client that returns a specific error on Get.
+type transientErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c *transientErrorClient) Get(
+	_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption,
+) error {
+	return c.err
+}

--- a/pkg/tls/watcher.go
+++ b/pkg/tls/watcher.go
@@ -1,0 +1,76 @@
+package tls
+
+import (
+	"context"
+	"reflect"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const apiServerName = "cluster"
+
+// ProfileWatcher watches the APIServer CR and triggers a callback when the
+// TLS security profile changes. Modeled after the CRC SecurityProfileWatcher
+// but without the CRC dependency (KEDA version pin blocks CRC adoption).
+type ProfileWatcher struct {
+	client.Client
+	InitialProfileSpec configv1.TLSProfileSpec
+	OnProfileChange    func(ctx context.Context, old, new configv1.TLSProfileSpec)
+
+	lastProfile configv1.TLSProfileSpec
+}
+
+func (w *ProfileWatcher) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	if req.Name != apiServerName {
+		return reconcile.Result{}, nil
+	}
+
+	apiServer := &configv1.APIServer{}
+	if err := w.Get(ctx, req.NamespacedName, apiServer); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	currentProfile := *resolveProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if w.OnProfileChange != nil && !reflect.DeepEqual(w.lastProfile, currentProfile) {
+		old := w.lastProfile
+		w.lastProfile = currentProfile
+		w.OnProfileChange(ctx, old, currentProfile)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (w *ProfileWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	w.lastProfile = w.InitialProfileSpec
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("tls-profile-watcher").
+		WithOptions(controller.Options{NeedLeaderElection: boolPtr(false)}).
+		For(&configv1.APIServer{}, builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return e.Object.GetName() == apiServerName
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return e.ObjectNew.GetName() == apiServerName
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return e.Object.GetName() == apiServerName
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return e.Object.GetName() == apiServerName
+			},
+		})).
+		Complete(w)
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}


### PR DESCRIPTION
## Description

Enable SecureServing on the metrics endpoint, integrate with the cluster TLS security profile, and register a SecurityProfileWatcher to reload on profile changes.

[RHOAIENG-61065](https://redhat.atlassian.net/browse/RHOAIENG-61065) (TLS profile integration)
[RHOAIENG-72821](https://redhat.atlassian.net/browse/RHOAIENG-72821) (SecureServing on metrics)
[RHOAIENG-75338](https://redhat.atlassian.net/browse/RHOAIENG-75338) (SecurityProfileWatcher)

### TLS profile integration (pkg/tls)

- New `pkg/tls` package that reads the APIServer TLS profile at startup and converts it to controller-runtime TLS options
- Handles all profile types: Intermediate, Modern, Old, Custom (with full cipher mapping from OpenSSL to Go names)
- Graceful fallback to hardened Intermediate defaults on non-OpenShift clusters or missing resources
- All 5 transient error cases handled (ServiceUnavailable, Timeout, ServerTimeout, TooManyRequests, DeadlineExceeded)
- Fail-closed on unexpected errors

### SecurityProfileWatcher (pkg/tls/watcher.go)

- Controller-based watcher using `ctrl.NewControllerManagedBy` with predicates filtering to the `cluster` APIServer
- Triggers graceful shutdown on TLS profile changes so the pod restarts with updated configuration
- Runs outside leader election (all replicas detect changes)
- Only registered when the TLS profile was successfully fetched at startup
- Self-heals on transient errors (fallback to Intermediate, watcher detects real profile when API recovers)
- Skipped in xKS mode (non-OpenShift clusters)

### SecureServing on metrics

- `--metrics-secure` defaults to `true`
- `CertDir` set to `/tmp/k8s-metrics-server/metrics-certs` for service-ca provisioned certs
- `FilterProvider: filters.WithAuthenticationAndAuthorization` for authn/authz on metrics endpoint

### Manifest changes

- Service annotation: `service.beta.openshift.io/serving-cert-secret-name: odh-model-controller-metrics-tls`
- Cert volume mount at `/tmp/k8s-metrics-server/metrics-certs`
- ServiceMonitor: `scheme: https` with CA verification via `openshift-service-ca.crt` (replaces `insecureSkipVerify`)
- `serverName` derived via kustomize replacements from Service metadata
- Metrics port changed from 8080 to 8443
- RBAC: `list` + `watch` on `apiservers` for watcher support

## How Has This Been Tested?

- `go build ./...` passes
- `go test ./pkg/tls/...` passes (17 tests):
  - `parseProfile`: 10 tests covering nil, empty, Intermediate, Modern, Old, Custom (valid/unsupported/nil block/unknown), all-unsupported fail-closed
  - `resolveProfileSpec`: 6 tests covering nil, Modern, Old, Custom, Custom nil block, unknown type
  - `Resolve`: 4 tests covering success with ProfileFetched, NotFound graceful fallback, transient error sets ProfileFetched for watcher self-healing, fatal error (Forbidden) returns error
  - `ProfileWatcher`: 3 tests covering profile change detection with callback, non-cluster object filtering, no callback when profile unchanged
- `kubectl kustomize config/default/` renders correctly with cert mount, service-ca annotation, ServiceMonitor HTTPS, and derived serverName

Supersedes #841 (closed due to remote branch corruption).

## Merge criteria

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages
- [x] Testing instructions have been added in the PR body
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-61065]: https://redhat.atlassian.net/browse/RHOAIENG-61065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-72821]: https://redhat.atlassian.net/browse/RHOAIENG-72821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-75338]: https://redhat.atlassian.net/browse/RHOAIENG-75338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ