### PR TITLE
RHOAIENG-75487: add fast-version annotation to fast-1 and fast-2

### DIFF
--- a/config/runtimes-fast-1/kustomization.yaml
+++ b/config/runtimes-fast-1/kustomization.yaml
@@ -16,6 +16,12 @@ patches:
       - op: add
         path: /objects/0/metadata/annotations/opendatahub.io~1support-status
         value: "unsupported"
+      - op: add
+        path: /metadata/annotations/opendatahub.io~1fast-version
+        value: "1"
+      - op: add
+        path: /objects/0/metadata/annotations/opendatahub.io~1fast-version
+        value: "1"
   - target: { kind: Template, name: vllm-cuda-runtime-template }
     patch: |-
       - op: replace

--- a/config/runtimes-fast-2/kustomization.yaml
+++ b/config/runtimes-fast-2/kustomization.yaml
@@ -16,6 +16,12 @@ patches:
       - op: add
         path: /objects/0/metadata/annotations/opendatahub.io~1support-status
         value: "unsupported"
+      - op: add
+        path: /metadata/annotations/opendatahub.io~1fast-version
+        value: "2"
+      - op: add
+        path: /objects/0/metadata/annotations/opendatahub.io~1fast-version
+        value: "2"
   - target: { kind: Template, name: vllm-cuda-runtime-template }
     patch: |-
       - op: replace


### PR DESCRIPTION
Add a new annotation opendatahub.io/fast-version to the fast ServingRuntime template kustomize overlays.

The dashboard needs this to visually distinguish between multiple fast versions of the same runtime template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the fast runtime templates to include a new `fast-version` annotation for version 1 and version 2.
  * The annotation is applied consistently across the template metadata and generated objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->