### PR TITLE
feat: add MLServer NVIDIA GPU (CUDA) ServingRuntime template

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -208,12 +208,12 @@ jobs:
           
           # Define patterns based on repository
           if repo_name == "odh-model-controller":
-            # Only update odh-model-controller, odh-model-serving-api, and mlserver images.
+            # Only update odh-model-controller, odh-model-serving-api, mlserver, and mlserver-cuda images.
             # The optional (odh-model-serving-api-) tag prefix handles the case where
             # odh-model-serving-api is published under the odh-model-controller image repo
             # (e.g. quay.io/opendatahub/odh-model-controller:odh-model-serving-api-fast)
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver)):((?:odh-model-serving-api-)?)(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver(?:-cuda)?)):((?:odh-model-serving-api-)?)(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           else:
             # For kserve and others: update all matching images except llm-d-* images

--- a/architecture.md
+++ b/architecture.md
@@ -218,6 +218,7 @@ Pre-built ServingRuntime templates for supported model servers live in `config/r
 | `vllm-multinode-template.yaml` | vLLM multi-node (Ray) |
 | `ovms-kserve-template.yaml` | OpenVINO Model Server |
 | `mlserver-template.yaml` | Seldon MLServer |
+| `mlserver-cuda-template.yaml` | Seldon MLServer (NVIDIA GPU) |
 | `autogluon-template.yaml` | AutoGluon (tabular & time-series) |
 | `hf-detector-template.yaml` | HuggingFace detector |
 

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -65,6 +65,17 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.mlserver-cuda-image
+    targets:
+      - select:
+          kind: Template
+          name: mlserver-cuda-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.vllm-cuda-image
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -8,6 +8,7 @@ modelregistry-state=removed
 tgis-image=quay.io/opendatahub/text-generation-inference:fast
 ovms-image=quay.io/opendatahub/openvino_model_server:2025.1-release
 mlserver-image=quay.io/opendatahub/mlserver:fast
+mlserver-cuda-image=quay.io/opendatahub/mlserver-cuda:fast
 autogluon-image=quay.io/opendatahub/odh-kserve-autogluon-server:odh-stable
 vllm-cuda-image=quay.io/vllm/vllm-cuda:latest
 vllm-cuda-image-fast-1=quay.io/vllm/vllm-cuda:latest

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -8,6 +8,7 @@ labels:
 resources:
   - ovms-kserve-template.yaml
   - mlserver-template.yaml
+  - mlserver-cuda-template.yaml
   - vllm/
   - hf-detector-template.yaml
   - autogluon-template.yaml

--- a/config/runtimes/mlserver-cuda-template.yaml
+++ b/config/runtimes/mlserver-cuda-template.yaml
@@ -5,23 +5,24 @@ metadata:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
   annotations:
-    description: MLServer is a lightweight, extensible inference server for serving machine learning models across multiple frameworks.
-    openshift.io/display-name: MLServer ServingRuntime for KServe
+    description: MLServer ServingRuntime with NVIDIA CUDA support (for NVIDIA GPUs)
+    openshift.io/display-name: MLServer NVIDIA GPU ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/MLServer
-    template.openshift.io/long-description: This template defines resources needed to deploy MLServer ServingRuntime with KServe in Red Hat OpenShift AI
+    template.openshift.io/long-description: This template defines resources needed to deploy MLServer NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
     opendatahub.io/model-type: '["predictive"]'
-  name: mlserver-runtime-template
+  name: mlserver-cuda-runtime-template
 objects:
   - apiVersion: serving.kserve.io/v1alpha1
     kind: ServingRuntime
     metadata:
-      name: mlserver-runtime
+      name: mlserver-cuda-runtime
       annotations:
-        openshift.io/display-name: MLServer ServingRuntime for KServe
+        openshift.io/display-name: MLServer NVIDIA GPU ServingRuntime for KServe
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
         opendatahub.io/runtime-version: '1.7.1'
         serving.kserve.io/server-type: mlserver
       labels:
@@ -34,7 +35,7 @@ objects:
         monitoring.opendatahub.io/scrape: 'true'
       containers:
         - name: kserve-container
-          image: $(mlserver-image)
+          image: $(mlserver-cuda-image)
           env:
             - name: MLSERVER_MODEL_IMPLEMENTATION
               value: '{{.Labels.modelClass}}'
@@ -63,7 +64,7 @@ objects:
           livenessProbe:
             initialDelaySeconds: 20
             periodSeconds: 10
-            failureThreshold: 6
+            failureThreshold: 10
             timeoutSeconds: 5
             httpGet:
               path: /v2/models/{{.Name}}/ready
@@ -71,10 +72,10 @@ objects:
           resources:
             requests:
               cpu: "1"
-              memory: 2Gi
-            limits:
-              cpu: "2"
               memory: 4Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -89,17 +90,5 @@ objects:
         - v2
       multiModel: false
       supportedModelFormats:
-        - name: sklearn
-          version: '0'
-        - name: sklearn
-          version: '1'
-        - name: xgboost
-          version: '1'
-        - name: xgboost
-          version: '2'
-        - name: lightgbm
-          version: '3'
-        - name: lightgbm
-          version: '4'
         - name: onnx
           version: '1'


### PR DESCRIPTION


Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a new ServingRuntime template for GPU-accelerated predictive ML inference using MLServer with onnxruntime-gpu on NVIDIA CUDA. The template mirrors the existing CPU MLServer template with ONNX-only model format support initially, and uses a separate mlserver-cuda container image built on the aipcc/cuda base.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an NVIDIA GPU MLServer runtime template.
  * Included a new runtime image parameter and wired it into deployment configuration.
  * Registered the new runtime so it appears in runtime listings and documentation.

* **Bug Fixes**
  * Expanded image tag matching in release automation to recognize GPU-based MLServer image tags as well as standard ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->