### PR TITLE
Create Gateway PodMonitor to scrape Istio/Envoy inference metrics

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -191,6 +191,10 @@ func GetGatewayEnvoyFilterName(gatewayName string) string {
 	return kmeta.ChildName(gatewayName, EnvoyFilterNameSuffix)
 }
 
+func GetGatewayPodMonitorName(gatewayName string) string {
+	return kmeta.ChildName(gatewayName, "-metrics")
+}
+
 func GetHTTPRouteName(llmisvcName string) string {
 	return kmeta.ChildName(llmisvcName, HTTPRouteNameSuffix)
 }

--- a/internal/controller/serving/llm/fixture/podmonitor_helpers.go
+++ b/internal/controller/serving/llm/fixture/podmonitor_helpers.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+)
+
+func VerifyGatewayPodMonitorExists(ctx context.Context, c client.Client, gatewayNamespace, gatewayName string) {
+	VerifyResourceExists(ctx, c, gatewayNamespace, constants.GetGatewayPodMonitorName(gatewayName), &monitoringv1.PodMonitor{})
+}
+
+func VerifyGatewayPodMonitorNotExist(ctx context.Context, c client.Client, gatewayNamespace, gatewayName string) {
+	VerifyResourceNotExist(ctx, c, gatewayNamespace, constants.GetGatewayPodMonitorName(gatewayName), &monitoringv1.PodMonitor{})
+}
+
+func VerifyGatewayPodMonitorOwnerRef(ctx context.Context, c client.Client, gatewayNamespace, gatewayName string) {
+	gomega.Eventually(func() error {
+		podMonitor, err := GetResourceByName(ctx, c, gatewayNamespace, constants.GetGatewayPodMonitorName(gatewayName), &monitoringv1.PodMonitor{})
+		if err != nil {
+			return err
+		}
+		ownerRefs := podMonitor.GetOwnerReferences()
+		gomega.Expect(ownerRefs).To(gomega.HaveLen(1))
+		gomega.Expect(ownerRefs[0].Name).To(gomega.Equal(gatewayName))
+		gomega.Expect(ownerRefs[0].Kind).To(gomega.Equal("Gateway"))
+		gomega.Expect(ownerRefs[0].APIVersion).To(gomega.Equal("gateway.networking.k8s.io/v1"))
+		return nil
+	}).WithContext(ctx).Should(gomega.Succeed())
+}

--- a/internal/controller/serving/llm/fixture/podmonitor_helpers.go
+++ b/internal/controller/serving/llm/fixture/podmonitor_helpers.go
@@ -35,16 +35,13 @@ func VerifyGatewayPodMonitorNotExist(ctx context.Context, c client.Client, gatew
 }
 
 func VerifyGatewayPodMonitorOwnerRef(ctx context.Context, c client.Client, gatewayNamespace, gatewayName string) {
-	gomega.Eventually(func() error {
+	gomega.Eventually(func(g gomega.Gomega) {
 		podMonitor, err := GetResourceByName(ctx, c, gatewayNamespace, constants.GetGatewayPodMonitorName(gatewayName), &monitoringv1.PodMonitor{})
-		if err != nil {
-			return err
-		}
+		g.Expect(err).NotTo(gomega.HaveOccurred())
 		ownerRefs := podMonitor.GetOwnerReferences()
-		gomega.Expect(ownerRefs).To(gomega.HaveLen(1))
-		gomega.Expect(ownerRefs[0].Name).To(gomega.Equal(gatewayName))
-		gomega.Expect(ownerRefs[0].Kind).To(gomega.Equal("Gateway"))
-		gomega.Expect(ownerRefs[0].APIVersion).To(gomega.Equal("gateway.networking.k8s.io/v1"))
-		return nil
+		g.Expect(ownerRefs).To(gomega.HaveLen(1))
+		g.Expect(ownerRefs[0].Name).To(gomega.Equal(gatewayName))
+		g.Expect(ownerRefs[0].Kind).To(gomega.Equal("Gateway"))
+		g.Expect(ownerRefs[0].APIVersion).To(gomega.Equal("gateway.networking.k8s.io/v1"))
 	}).WithContext(ctx).Should(gomega.Succeed())
 }

--- a/internal/controller/serving/llm/gateway_controller.go
+++ b/internal/controller/serving/llm/gateway_controller.go
@@ -28,6 +28,7 @@ import (
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	kserveutils "github.com/kserve/kserve/pkg/utils"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istioclientv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,6 +87,7 @@ func NewGatewayReconciler(client client.Client, scheme *runtime.Scheme, recorder
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=podmonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -135,6 +137,18 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else {
 		if err := r.deleteAuthPolicyIfManaged(ctx, logger, gateway); err != nil && !meta.IsNoMatchError(err) {
 			r.Recorder.Eventf(gateway, corev1.EventTypeWarning, "ReconcileError", "Failed to delete AuthPolicy: %v", err)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if scrape := gateway.GetLabels()[constants.RhoaiObservabilityLabel]; referencedByLLMService && scrape != "false" {
+		if err := r.reconcileGatewayPodMonitor(ctx, logger, gateway); err != nil && !meta.IsNoMatchError(err) {
+			r.Recorder.Eventf(gateway, corev1.EventTypeWarning, "ReconcileError", "Failed to reconcile gateway PodMonitor: %v", err)
+			return ctrl.Result{}, err
+		}
+	} else {
+		if err := r.deleteGatewayPodMonitorIfManaged(ctx, logger, gateway); err != nil && !meta.IsNoMatchError(err) {
+			r.Recorder.Eventf(gateway, corev1.EventTypeWarning, "ReconcileError", "Failed to delete gateway PodMonitor: %v", err)
 			return ctrl.Result{}, err
 		}
 	}
@@ -319,6 +333,142 @@ func (r *GatewayReconciler) deleteAuthPolicyIfManaged(ctx context.Context, logge
 	}
 
 	return nil
+}
+
+func (r *GatewayReconciler) reconcileGatewayPodMonitor(ctx context.Context, logger logr.Logger, gateway *gatewayapiv1.Gateway) error {
+	logger.V(1).Info("Reconciling PodMonitor for Gateway")
+
+	podMonitorName := constants.GetGatewayPodMonitorName(gateway.Name)
+	existing := &monitoringv1.PodMonitor{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      podMonitorName,
+		Namespace: gateway.Namespace,
+	}, existing)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get existing PodMonitor: %w", err)
+	}
+	if err != nil {
+		existing = nil
+	}
+
+	if existing != nil && !utils.IsManagedByOpenDataHub(existing) {
+		logger.V(1).Info("Skipping PodMonitor reconciliation - not managed by odh-model-controller", "name", podMonitorName)
+		return nil
+	}
+
+	desired := r.desiredGatewayPodMonitor(gateway)
+
+	comparator := comparators.GetPodMonitorComparator()
+	delta := r.deltaProcessor.ComputeDelta(comparator, desired, existing)
+
+	if !delta.HasChanges() {
+		logger.V(1).Info("No changes detected for PodMonitor", "name", podMonitorName)
+		return nil
+	}
+
+	if delta.IsAdded() {
+		logger.Info("Creating PodMonitor", "name", podMonitorName)
+		if err := controllerutil.SetControllerReference(gateway, desired, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+		if err := r.Client.Create(ctx, desired); err != nil {
+			return fmt.Errorf("failed to create PodMonitor: %w", err)
+		}
+	} else if delta.IsUpdated() {
+		logger.Info("Updating PodMonitor", "name", podMonitorName)
+		if err := controllerutil.SetControllerReference(gateway, desired, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference: %w", err)
+		}
+		rp := existing.DeepCopy()
+		rp.Spec = desired.Spec
+		if err := r.Client.Update(ctx, rp); err != nil {
+			return fmt.Errorf("failed to update PodMonitor: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *GatewayReconciler) deleteGatewayPodMonitorIfManaged(ctx context.Context, logger logr.Logger, gateway *gatewayapiv1.Gateway) error {
+	podMonitorName := constants.GetGatewayPodMonitorName(gateway.Name)
+
+	existing := &monitoringv1.PodMonitor{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Name:      podMonitorName,
+		Namespace: gateway.Namespace,
+	}, existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get existing PodMonitor: %w", err)
+	}
+
+	if !utils.IsManagedByOpenDataHub(existing) {
+		logger.V(1).Info("Skipping PodMonitor deletion - not managed by odh-model-controller", "name", podMonitorName)
+		return nil
+	}
+
+	logger.Info("Deleting PodMonitor", "name", podMonitorName)
+	if err := r.Client.Delete(ctx, existing); err != nil {
+		return fmt.Errorf("failed to delete PodMonitor: %w", err)
+	}
+
+	return nil
+}
+
+// desiredGatewayPodMonitor returns the desired PodMonitor for scraping Istio/Envoy metrics
+// from inference gateway pods. The llm_isvc_gateway="true" sentinel label is added via
+// relabeling to disambiguate these metrics from unrelated gateways in dashboard queries.
+func (r *GatewayReconciler) desiredGatewayPodMonitor(gateway *gatewayapiv1.Gateway) *monitoringv1.PodMonitor {
+	metricsPort := "metrics"
+	metricsPath := "/stats/prometheus"
+
+	return &monitoringv1.PodMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.GetGatewayPodMonitorName(gateway.Name),
+			Namespace: gateway.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/component":      "llm-monitoring",
+				"app.kubernetes.io/part-of":        "llminferenceservice",
+				"app.kubernetes.io/managed-by":     "odh-model-controller",
+				"monitoring.opendatahub.io/scrape": "true",
+			},
+		},
+		Spec: monitoringv1.PodMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"gateway.networking.k8s.io/gateway-name": gateway.Name,
+				},
+			},
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
+				{
+					Port: &metricsPort,
+					Path: metricsPath,
+					// Istio exposes stats on port 15020 via plain HTTP regardless of
+					// whether the gateway listeners use TLS or not.
+					Scheme: ptr.To(monitoringv1.Scheme("http")),
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_label_gateway_networking_k8s_io_gateway_name"},
+							Action:       "replace",
+							TargetLabel:  "gateway_name",
+						},
+						{
+							Replacement: ptr.To("true"),
+							TargetLabel: "llm_isvc_gateway",
+						},
+					},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Regex:        "istio_requests_total|istio_request_duration_milliseconds_(bucket|sum|count)|istio_request_bytes_(bucket|sum|count)|istio_response_bytes_(bucket|sum|count)",
+							Action:       "keep",
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // isGatewayReferencedByLLMService checks whether the given gateway is the default gateway
@@ -772,8 +922,15 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Log
 		return err
 	}
 
+	isPodMonitorAvailable, err := utils.IsCrdAvailable(mgr.GetConfig(), monitoringv1.SchemeGroupVersion.String(), "PodMonitor")
+	if err != nil {
+		setupLog.V(1).Error(err, "could not determine if PodMonitor CRD is available")
+		return err
+	}
+
 	setupLog.Info("Setting up Gateway controller for EnvoyFilter/AuthPolicy bootstrap",
-		"envoyFilterCRD", isEnvoyFilterAvailable, "authPolicyCRD", isAuthPolicyAvailable)
+		"envoyFilterCRD", isEnvoyFilterAvailable, "authPolicyCRD", isAuthPolicyAvailable,
+		"podMonitorCRD", isPodMonitorAvailable)
 
 	gatewayPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -814,6 +971,9 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Log
 	}
 	if isAuthPolicyAvailable {
 		builder = builder.Owns(&kuadrantv1.AuthPolicy{}, ctrlbuilder.WithPredicates(managedPredicate))
+	}
+	if isPodMonitorAvailable {
+		builder = builder.Owns(&monitoringv1.PodMonitor{}, ctrlbuilder.WithPredicates(managedPredicate))
 	}
 
 	return builder.

--- a/internal/controller/serving/llm/gateway_controller.go
+++ b/internal/controller/serving/llm/gateway_controller.go
@@ -376,12 +376,12 @@ func (r *GatewayReconciler) reconcileGatewayPodMonitor(ctx context.Context, logg
 		}
 	} else if delta.IsUpdated() {
 		logger.Info("Updating PodMonitor", "name", podMonitorName)
-		if err := controllerutil.SetControllerReference(gateway, desired, r.Scheme); err != nil {
+		updated := existing.DeepCopy()
+		updated.Spec = desired.Spec
+		if err := controllerutil.SetControllerReference(gateway, updated, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference: %w", err)
 		}
-		rp := existing.DeepCopy()
-		rp.Spec = desired.Spec
-		if err := r.Client.Update(ctx, rp); err != nil {
+		if err := r.Client.Update(ctx, updated); err != nil {
 			return fmt.Errorf("failed to update PodMonitor: %w", err)
 		}
 	}
@@ -950,6 +950,11 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Log
 			oldTLS := e.ObjectOld.GetAnnotations()[constants.AuthorinoTLSBootstrapAnnotation]
 			newTLS := e.ObjectNew.GetAnnotations()[constants.AuthorinoTLSBootstrapAnnotation]
 			if oldTLS != newTLS {
+				return true
+			}
+			oldScrape := e.ObjectOld.GetLabels()[constants.RhoaiObservabilityLabel]
+			newScrape := e.ObjectNew.GetLabels()[constants.RhoaiObservabilityLabel]
+			if oldScrape != newScrape {
 				return true
 			}
 			return utils.ShouldCreateEnvoyFilterForGateway(e.ObjectNew.(*gatewayapiv1.Gateway))

--- a/internal/controller/serving/llm/gateway_controller_test.go
+++ b/internal/controller/serving/llm/gateway_controller_test.go
@@ -23,6 +23,7 @@ import (
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istioclientv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -426,6 +427,67 @@ var _ = Describe("Gateway Controller", func() {
 			// Resources should remain stable
 			fixture.VerifyGatewayEnvoyFilterExists(ctx, envTest.Client, testNs, gatewayName)
 			fixture.VerifyGatewayEnvoyFilterExists(ctx, envTest.Client, testNs, secondGatewayName)
+		})
+	})
+
+	Context("Gateway PodMonitor", func() {
+		It("should create PodMonitor when gateway is referenced by LLMInferenceService", func(ctx SpecContext) {
+			gatewayName := setupReferencedGateway(ctx)
+
+			fixture.VerifyGatewayPodMonitorExists(ctx, envTest.Client, testNs, gatewayName)
+		})
+
+		It("should create PodMonitor with correct owner references", func(ctx SpecContext) {
+			gatewayName := setupReferencedGateway(ctx)
+
+			fixture.VerifyGatewayPodMonitorOwnerRef(ctx, envTest.Client, testNs, gatewayName)
+		})
+
+		It("should NOT create PodMonitor for unreferenced gateway", func(ctx SpecContext) {
+			gatewayName := pkgtest.GenerateUniqueTestName("unreferenced-gateway")
+			createGateway(ctx, gatewayName)
+
+			fixture.VerifyGatewayPodMonitorNotExist(ctx, envTest.Client, testNs, gatewayName)
+		})
+
+		It("should delete PodMonitor when the only referencing LLMInferenceService is stopped", func(ctx SpecContext) {
+			gatewayName := setupReferencedGateway(ctx)
+
+			fixture.VerifyGatewayPodMonitorExists(ctx, envTest.Client, testNs, gatewayName)
+
+			Eventually(func() error {
+				llmSvc := &kservev1alpha2.LLMInferenceService{}
+				if err := envTest.Client.Get(ctx, types.NamespacedName{Name: "test-llmisvc", Namespace: testNs}, llmSvc); err != nil {
+					return err
+				}
+				if llmSvc.Annotations == nil {
+					llmSvc.Annotations = make(map[string]string)
+				}
+				llmSvc.Annotations[kserveconstants.StopAnnotationKey] = "true"
+				return envTest.Client.Update(ctx, llmSvc)
+			}).WithContext(ctx).Should(Succeed())
+
+			fixture.VerifyGatewayPodMonitorNotExist(ctx, envTest.Client, testNs, gatewayName)
+		})
+
+		It("should recreate PodMonitor when deleted", func(ctx SpecContext) {
+			gatewayName := setupReferencedGateway(ctx)
+
+			podMonitor := fixture.WaitForResource(ctx, envTest.Client, testNs, constants.GetGatewayPodMonitorName(gatewayName), &monitoringv1.PodMonitor{})
+			Expect(envTest.Client.Delete(ctx, podMonitor)).Should(Succeed())
+
+			fixture.VerifyGatewayPodMonitorExists(ctx, envTest.Client, testNs, gatewayName)
+		})
+
+		It("should NOT create PodMonitor when scrape label is false", func(ctx SpecContext) {
+			gatewayName := pkgtest.GenerateUniqueTestName("no-scrape-gateway")
+			createGateway(ctx, gatewayName, fixture.WithGatewayLabels(map[string]string{
+				constants.RhoaiObservabilityLabel: "false",
+			}))
+			createLLMServiceForGateway(ctx, gatewayName)
+
+			fixture.VerifyGatewayEnvoyFilterExists(ctx, envTest.Client, testNs, gatewayName)
+			fixture.VerifyGatewayPodMonitorNotExist(ctx, envTest.Client, testNs, gatewayName)
 		})
 	})
 })

--- a/internal/controller/testing/ctrl.go
+++ b/internal/controller/testing/ctrl.go
@@ -22,6 +22,7 @@ import (
 	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -57,6 +58,7 @@ func NewEnvTest(options ...Option) *Config {
 		gatewayapiv1.Install,
 		igwapi.Install,
 		istioclientv1alpha3.AddToScheme,
+		monitoringv1.AddToScheme,
 	)
 
 	return Configure(append(options, testCRDs, schemes)...)

--- a/test/crds/monitoring.coreos.com_podmonitors.yaml
+++ b/test/crds/monitoring.coreos.com_podmonitors.yaml
@@ -1,0 +1,1245 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+    operator.prometheus.io/version: 0.76.2
+  name: podmonitors.monitoring.coreos.com
+spec:
+  group: monitoring.coreos.com
+  names:
+    categories:
+    - prometheus-operator
+    kind: PodMonitor
+    listKind: PodMonitorList
+    plural: podmonitors
+    shortNames:
+    - pmon
+    singular: podmonitor
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The `PodMonitor` custom resource definition (CRD) defines how `Prometheus` and `PrometheusAgent` can scrape metrics from a group of pods.
+          Among other things, it allows to specify:
+          * The pods to scrape via label selectors.
+          * The container ports to scrape.
+          * Authentication credentials to use.
+          * Target and metric relabeling.
+
+
+          `Prometheus` and `PrometheusAgent` objects select `PodMonitor` objects using label and namespace selectors.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of desired Pod selection for target discovery
+              by Prometheus.
+            properties:
+              attachMetadata:
+                description: |-
+                  `attachMetadata` defines additional metadata which is added to the
+                  discovered targets.
+
+
+                  It requires Prometheus >= v2.35.0.
+                properties:
+                  node:
+                    description: |-
+                      When set to true, Prometheus attaches node metadata to the discovered
+                      targets.
+
+
+                      The Prometheus service account must have the `list` and `watch`
+                      permissions on the `Nodes` objects.
+                    type: boolean
+                type: object
+              bodySizeLimit:
+                description: |-
+                  When defined, bodySizeLimit specifies a job level limit on the size
+                  of uncompressed response body that will be accepted by Prometheus.
+
+
+                  It requires Prometheus >= v2.28.0.
+                pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                type: string
+              jobLabel:
+                description: |-
+                  The label to use to retrieve the job name from.
+                  `jobLabel` selects the label from the associated Kubernetes `Pod`
+                  object which will be used as the `job` label for all metrics.
+
+
+                  For example if `jobLabel` is set to `foo` and the Kubernetes `Pod`
+                  object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
+                  label to all ingested metrics.
+
+
+                  If the value of this field is empty, the `job` label of the metrics
+                  defaults to the namespace and name of the PodMonitor object (e.g. `<namespace>/<name>`).
+                type: string
+              keepDroppedTargets:
+                description: |-
+                  Per-scrape limit on the number of targets dropped by relabeling
+                  that will be kept in memory. 0 means no limit.
+
+
+                  It requires Prometheus >= v2.47.0.
+                format: int64
+                type: integer
+              labelLimit:
+                description: |-
+                  Per-scrape limit on number of labels that will be accepted for a sample.
+
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              labelNameLengthLimit:
+                description: |-
+                  Per-scrape limit on length of labels name that will be accepted for a sample.
+
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              labelValueLengthLimit:
+                description: |-
+                  Per-scrape limit on length of labels value that will be accepted for a sample.
+
+
+                  It requires Prometheus >= v2.27.0.
+                format: int64
+                type: integer
+              namespaceSelector:
+                description: |-
+                  `namespaceSelector` defines in which namespace(s) Prometheus should discover the pods.
+                  By default, the pods are discovered in the same namespace as the `PodMonitor` object but it is possible to select pods across different/all namespaces.
+                properties:
+                  any:
+                    description: |-
+                      Boolean describing whether all namespaces are selected in contrast to a
+                      list restricting them.
+                    type: boolean
+                  matchNames:
+                    description: List of namespace names to select from.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              podMetricsEndpoints:
+                description: Defines how to scrape metrics from the selected pods.
+                items:
+                  description: |-
+                    PodMetricsEndpoint defines an endpoint serving Prometheus metrics to be scraped by
+                    Prometheus.
+                  properties:
+                    authorization:
+                      description: |-
+                        `authorization` configures the Authorization header credentials to use when
+                        scraping the target.
+
+
+                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                      properties:
+                        credentials:
+                          description: Selects a key of a Secret in the namespace
+                            that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: |-
+                            Defines the authentication type. The value is case-insensitive.
+
+
+                            "Basic" is not a supported value.
+
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: |-
+                        `basicAuth` configures the Basic Authentication credentials to use when
+                        scraping the target.
+
+
+                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                      properties:
+                        password:
+                          description: |-
+                            `password` specifies a key of a Secret containing the password for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: |-
+                            `username` specifies a key of a Secret containing the username for
+                            authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    bearerTokenSecret:
+                      description: |-
+                        `bearerTokenSecret` specifies a key of a Secret containing the bearer
+                        token for scraping targets. The secret needs to be in the same namespace
+                        as the PodMonitor object and readable by the Prometheus Operator.
+
+
+                        Deprecated: use `authorization` instead.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    enableHttp2:
+                      description: '`enableHttp2` can be used to disable HTTP2 when
+                        scraping the target.'
+                      type: boolean
+                    filterRunning:
+                      description: |-
+                        When true, the pods which are not running (e.g. either in Failed or
+                        Succeeded state) are dropped during the target discovery.
+
+
+                        If unset, the filtering is enabled.
+
+
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+                      type: boolean
+                    followRedirects:
+                      description: |-
+                        `followRedirects` defines whether the scrape requests should follow HTTP
+                        3xx redirects.
+                      type: boolean
+                    honorLabels:
+                      description: |-
+                        When true, `honorLabels` preserves the metric's labels when they collide
+                        with the target's labels.
+                      type: boolean
+                    honorTimestamps:
+                      description: |-
+                        `honorTimestamps` controls whether Prometheus preserves the timestamps
+                        when exposed by the target.
+                      type: boolean
+                    interval:
+                      description: |-
+                        Interval at which Prometheus scrapes the metrics from the target.
+
+
+                        If empty, Prometheus uses the global scrape interval.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    metricRelabelings:
+                      description: |-
+                        `metricRelabelings` configures the relabeling rules to apply to the
+                        samples before ingestion.
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              Action to perform based on the regex matching.
+
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+
+                              Default: "Replace"
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              Modulus to take of the hash of the source label values.
+
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              Replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: Separator is the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              The source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name which may only contain ASCII
+                                letters, numbers, as well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              Label to which the resulting string is written in a replacement.
+
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    oauth2:
+                      description: |-
+                        `oauth2` configures the OAuth2 settings to use when scraping the target.
+
+
+                        It requires Prometheus >= 2.27.0.
+
+
+                        Cannot be set at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: |-
+                            `clientId` specifies a key of a Secret or ConfigMap containing the
+                            OAuth2 client's ID.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: |-
+                            `clientSecret` specifies a key of a Secret containing the OAuth2
+                            client's secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            `endpointParams` configures the HTTP parameters to append to the token
+                            URL.
+                          type: object
+                        noProxy:
+                          description: |-
+                            `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+
+                            It requires Prometheus >= v2.43.0.
+                          type: string
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            ProxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+
+                            It requires Prometheus >= v2.43.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                            If unset, Prometheus uses its default value.
+
+
+                            It requires Prometheus >= v2.43.0.
+                          type: boolean
+                        proxyUrl:
+                          description: |-
+                            `proxyURL` defines the HTTP proxy server to use.
+
+
+                            It requires Prometheus >= v2.43.0.
+                          pattern: ^http(s)?://.+$
+                          type: string
+                        scopes:
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
+                          items:
+                            type: string
+                          type: array
+                        tlsConfig:
+                          description: |-
+                            TLS configuration to use when connecting to the OAuth2 server.
+                            It requires Prometheus >= v2.43.0.
+                          properties:
+                            ca:
+                              description: Certificate authority used when verifying
+                                server certificates.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            cert:
+                              description: Client certificate to present when doing
+                                client-authentication.
+                              properties:
+                                configMap:
+                                  description: ConfigMap containing data to use for
+                                    the targets.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secret:
+                                  description: Secret containing data to use for the
+                                    targets.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            insecureSkipVerify:
+                              description: Disable target certificate validation.
+                              type: boolean
+                            keySecret:
+                              description: Secret containing the client key file for
+                                the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxVersion:
+                              description: |-
+                                Maximum acceptable TLS version.
+
+
+                                It requires Prometheus >= v2.41.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            minVersion:
+                              description: |-
+                                Minimum acceptable TLS version.
+
+
+                                It requires Prometheus >= v2.35.0.
+                              enum:
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                              type: string
+                            serverName:
+                              description: Used to verify the hostname for the targets.
+                              type: string
+                          type: object
+                        tokenUrl:
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    params:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: '`params` define optional HTTP URL parameters.'
+                      type: object
+                    path:
+                      description: |-
+                        HTTP path from which to scrape for metrics.
+
+
+                        If empty, Prometheus uses the default value (e.g. `/metrics`).
+                      type: string
+                    port:
+                      description: |-
+                        Name of the Pod port which this endpoint refers to.
+
+
+                        It takes precedence over `targetPort`.
+                      type: string
+                    proxyUrl:
+                      description: |-
+                        `proxyURL` configures the HTTP Proxy URL (e.g.
+                        "http://proxyserver:2195") to go through when scraping the target.
+                      type: string
+                    relabelings:
+                      description: |-
+                        `relabelings` configures the relabeling rules to apply the target's
+                        metadata labels.
+
+
+                        The Operator automatically adds relabelings for a few standard Kubernetes fields.
+
+
+                        The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
+
+
+                        More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                      items:
+                        description: |-
+                          RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                          scraped samples and remote write samples.
+
+
+                          More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                        properties:
+                          action:
+                            default: replace
+                            description: |-
+                              Action to perform based on the regex matching.
+
+
+                              `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                              `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+
+                              Default: "Replace"
+                            enum:
+                            - replace
+                            - Replace
+                            - keep
+                            - Keep
+                            - drop
+                            - Drop
+                            - hashmod
+                            - HashMod
+                            - labelmap
+                            - LabelMap
+                            - labeldrop
+                            - LabelDrop
+                            - labelkeep
+                            - LabelKeep
+                            - lowercase
+                            - Lowercase
+                            - uppercase
+                            - Uppercase
+                            - keepequal
+                            - KeepEqual
+                            - dropequal
+                            - DropEqual
+                            type: string
+                          modulus:
+                            description: |-
+                              Modulus to take of the hash of the source label values.
+
+
+                              Only applicable when the action is `HashMod`.
+                            format: int64
+                            type: integer
+                          regex:
+                            description: Regular expression against which the extracted
+                              value is matched.
+                            type: string
+                          replacement:
+                            description: |-
+                              Replacement value against which a Replace action is performed if the
+                              regular expression matches.
+
+
+                              Regex capture groups are available.
+                            type: string
+                          separator:
+                            description: Separator is the string between concatenated
+                              SourceLabels.
+                            type: string
+                          sourceLabels:
+                            description: |-
+                              The source labels select values from existing labels. Their content is
+                              concatenated using the configured Separator and matched against the
+                              configured regular expression.
+                            items:
+                              description: |-
+                                LabelName is a valid Prometheus label name which may only contain ASCII
+                                letters, numbers, as well as underscores.
+                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                              type: string
+                            type: array
+                          targetLabel:
+                            description: |-
+                              Label to which the resulting string is written in a replacement.
+
+
+                              It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                              `KeepEqual` and `DropEqual` actions.
+
+
+                              Regex capture groups are available.
+                            type: string
+                        type: object
+                      type: array
+                    scheme:
+                      description: |-
+                        HTTP scheme to use for scraping.
+
+
+                        `http` and `https` are the expected values unless you rewrite the
+                        `__scheme__` label via relabeling.
+
+
+                        If empty, Prometheus uses the default value `http`.
+                      enum:
+                      - http
+                      - https
+                      type: string
+                    scrapeTimeout:
+                      description: |-
+                        Timeout after which Prometheus considers the scrape to be failed.
+
+
+                        If empty, Prometheus uses the global scrape timeout unless it is less
+                        than the target's scrape interval value in which the latter is used.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: |-
+                        Name or number of the target port of the `Pod` object behind the Service, the
+                        port must be specified with container port property.
+
+
+                        Deprecated: use 'port' instead.
+                      x-kubernetes-int-or-string: true
+                    tlsConfig:
+                      description: TLS configuration to use when scraping the target.
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        maxVersion:
+                          description: |-
+                            Maximum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.41.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        minVersion:
+                          description: |-
+                            Minimum acceptable TLS version.
+
+
+                            It requires Prometheus >= v2.35.0.
+                          enum:
+                          - TLS10
+                          - TLS11
+                          - TLS12
+                          - TLS13
+                          type: string
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
+                    trackTimestampsStaleness:
+                      description: |-
+                        `trackTimestampsStaleness` defines whether Prometheus tracks staleness of
+                        the metrics that have an explicit timestamp present in scraped data.
+                        Has no effect if `honorTimestamps` is false.
+
+
+                        It requires Prometheus >= v2.48.0.
+                      type: boolean
+                  type: object
+                type: array
+              podTargetLabels:
+                description: |-
+                  `podTargetLabels` defines the labels which are transferred from the
+                  associated Kubernetes `Pod` object onto the ingested metrics.
+                items:
+                  type: string
+                type: array
+              sampleLimit:
+                description: |-
+                  `sampleLimit` defines a per-scrape limit on the number of scraped samples
+                  that will be accepted.
+                format: int64
+                type: integer
+              scrapeClass:
+                description: The scrape class to apply.
+                minLength: 1
+                type: string
+              scrapeProtocols:
+                description: |-
+                  `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                  protocols supported by Prometheus in order of preference (from most to least preferred).
+
+
+                  If unset, Prometheus uses its default value.
+
+
+                  It requires Prometheus >= v2.49.0.
+                items:
+                  description: |-
+                    ScrapeProtocol represents a protocol used by Prometheus for scraping metrics.
+                    Supported values are:
+                    * `OpenMetricsText0.0.1`
+                    * `OpenMetricsText1.0.0`
+                    * `PrometheusProto`
+                    * `PrometheusText0.0.4`
+                  enum:
+                  - PrometheusProto
+                  - OpenMetricsText0.0.1
+                  - OpenMetricsText1.0.0
+                  - PrometheusText0.0.4
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              selector:
+                description: Label selector to select the Kubernetes `Pod` objects
+                  to scrape metrics from.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              targetLimit:
+                description: |-
+                  `targetLimit` defines a limit on the number of scraped targets that will
+                  be accepted.
+                format: int64
+                type: integer
+            required:
+            - selector
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Add a PodMonitor for gateway pods to collect Istio traffic metrics (request rate, latency, request/response sizes) used by LLM inference dashboards. The monitor selects pods by the standard Gateway API label and uses relabeling to tag metrics with the gateway name and an llm_isvc_gateway sentinel for dashboard filtering.

The metrics endpoint (port 15020 "metrics") is always plain HTTP regardless of whether the gateway listeners use TLS or not, so the scheme is set explicitly to avoid issues with cluster-level monitoring defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateways can now automatically create and reconcile a Prometheus `PodMonitor` to expose metrics when observability is enabled and the gateway is actively referenced.
  * The `PodMonitor` is removed when observability is disabled or the gateway is no longer referenced, and it is recreated if deleted.
  * Added support for the Prometheus `PodMonitor` CustomResourceDefinition.
* **Tests**
  * Expanded controller test coverage for `PodMonitor` lifecycle and ownership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->