### PR TITLE
fix: correct JSON field path for HardwareProfile scheduling spec lookup

### DIFF
--- a/internal/webhook/serving/hardwareprofile/resolver.go
+++ b/internal/webhook/serving/hardwareprofile/resolver.go
@@ -57,7 +57,7 @@ type ResolvedProfile struct {
 	NodeSelector map[string]string
 	// Tolerations to prepend to the workload spec.
 	Tolerations []corev1.Toleration
-	// KueueQueueName is the local Kueue queue name; non-empty when schedulingSpec.kueue is set.
+	// KueueQueueName is the local Kueue queue name; non-empty when scheduling.kueue is set.
 	// When non-empty, node scheduling (NodeSelector/Tolerations) is not applied.
 	KueueQueueName string
 }
@@ -164,8 +164,8 @@ func Resolve(ctx context.Context, c client.Client, name, namespace string) (*Res
 
 // parseProfile extracts scheduling and resource stanzas from an unstructured HardwareProfile object.
 //
-// Reads spec.identifiers, spec.schedulingSpec.kueue.localQueueName, spec.schedulingSpec.node.nodeSelector,
-// and spec.schedulingSpec.node.tolerations. Kueue and Node scheduling are mutually exclusive:
+// Reads spec.identifiers, spec.scheduling.kueue.localQueueName, spec.scheduling.node.nodeSelector,
+// and spec.scheduling.node.tolerations. Kueue and Node scheduling are mutually exclusive:
 // when a Kueue queue name is found, node scheduling fields are not populated.
 //
 // Parameters:
@@ -196,17 +196,19 @@ func parseProfile(obj *unstructured.Unstructured) (*ResolvedProfile, error) {
 	}
 
 	// Kueue scheduling takes precedence; when present, node scheduling is not read.
-	queueName, _, _ := unstructured.NestedString(obj.Object, "spec", "schedulingSpec", "kueue", "localQueueName")
+	// Note: the HardwareProfile CRD field is `spec.scheduling` (JSON tag "scheduling"),
+	// not "schedulingSpec" (the Go struct field name).
+	queueName, _, _ := unstructured.NestedString(obj.Object, "spec", "scheduling", "kueue", "localQueueName")
 	if queueName != "" {
 		profile.KueueQueueName = queueName
 		return profile, nil
 	}
 
 	// Node scheduling.
-	nodeSelector, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "schedulingSpec", "node", "nodeSelector")
+	nodeSelector, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "scheduling", "node", "nodeSelector")
 	profile.NodeSelector = nodeSelector
 
-	rawTols, _, _ := unstructured.NestedSlice(obj.Object, "spec", "schedulingSpec", "node", "tolerations")
+	rawTols, _, _ := unstructured.NestedSlice(obj.Object, "spec", "scheduling", "node", "tolerations")
 	for _, rt := range rawTols {
 		tolMap, ok := rt.(map[string]any)
 		if !ok {

--- a/internal/webhook/serving/hardwareprofile/testutil/builders.go
+++ b/internal/webhook/serving/hardwareprofile/testutil/builders.go
@@ -88,7 +88,7 @@ func NodeSpec(nodeSelector map[string]interface{}, tolerations []interface{}) ma
 		node["tolerations"] = tolerations
 	}
 	return map[string]interface{}{
-		"schedulingSpec": map[string]interface{}{"node": node},
+		"scheduling": map[string]interface{}{"node": node},
 	}
 }
 
@@ -100,7 +100,7 @@ func NodeSpec(nodeSelector map[string]interface{}, tolerations []interface{}) ma
 // Returns a spec map suitable for passing to NewHardwareProfile.
 func KueueSpec(localQueueName string) map[string]interface{} {
 	return map[string]interface{}{
-		"schedulingSpec": map[string]interface{}{
+		"scheduling": map[string]interface{}{
 			"kueue": map[string]interface{}{"localQueueName": localQueueName},
 		},
 	}

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_hwp_webhook_test.go
@@ -160,7 +160,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 			// the ResolvedProfile has no NodeSelector. The webhook then sets only the Kueue label
 			// and returns before reaching the node scheduling block.
 			spec := map[string]interface{}{
-				"schedulingSpec": map[string]interface{}{
+				"scheduling": map[string]interface{}{
 					"kueue": map[string]interface{}{"localQueueName": "test-queue"},
 					"node":  map[string]interface{}{"nodeSelector": map[string]interface{}{"zone": "gpu-zone"}},
 				},
@@ -187,7 +187,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 
 		It("LLM-6: containers non-empty but no 'main' — ALL HWP application skipped", func() {
 			spec := hwptestutil.ResourceSpec([]string{"cpu", "8"})
-			spec["schedulingSpec"] = map[string]interface{}{
+			spec["scheduling"] = map[string]interface{}{
 				"node": map[string]interface{}{
 					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
 				},
@@ -219,7 +219,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 		It("LLM-7: absent container list — 'main' created and resources injected", func() {
 			// Build a spec with both resource identifiers (triggers "main" creation) and node scheduling.
 			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
-			spec["schedulingSpec"] = map[string]interface{}{
+			spec["scheduling"] = map[string]interface{}{
 				"node": map[string]interface{}{
 					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
 				},
@@ -455,7 +455,7 @@ var _ = Describe("LLMInferenceService HardwareProfile Webhook", func() {
 
 		It("LLM-17: initial annotation assignment on UPDATE — merge semantics applied", func() {
 			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
-			spec["schedulingSpec"] = map[string]interface{}{
+			spec["scheduling"] = map[string]interface{}{
 				"node": map[string]interface{}{
 					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
 				},

--- a/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_hwp_webhook_test.go
@@ -179,7 +179,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 			// the ResolvedProfile has no NodeSelector. The webhook then sets only the Kueue label
 			// and returns before reaching the node scheduling block.
 			spec := map[string]interface{}{
-				"schedulingSpec": map[string]interface{}{
+				"scheduling": map[string]interface{}{
 					"kueue": map[string]interface{}{"localQueueName": "test-queue"},
 					"node":  map[string]interface{}{"nodeSelector": map[string]interface{}{"zone": "gpu-zone"}},
 				},
@@ -384,7 +384,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 
 		It("isvc-11: same profile on UPDATE — merge semantics applied", func() {
 			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
-			spec["schedulingSpec"] = map[string]interface{}{
+			spec["scheduling"] = map[string]interface{}{
 				"node": map[string]interface{}{
 					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
 				},
@@ -520,7 +520,7 @@ var _ = Describe("InferenceService HardwareProfile Webhook", func() {
 
 		It("isvc-24: initial annotation assignment on UPDATE — merge semantics (no blanket clear)", func() {
 			spec := hwptestutil.ResourceSpec([]string{"cpu", "4"})
-			spec["schedulingSpec"] = map[string]interface{}{
+			spec["scheduling"] = map[string]interface{}{
 				"node": map[string]interface{}{
 					"nodeSelector": map[string]interface{}{"zone": "gpu-zone"},
 				},


### PR DESCRIPTION
## Description

Fix nodeSelector, toleration and Kueue queue name injection of HardwareProfile.
The resolver was reading `spec.schedulingSpec.*` from the unstructured CR
object, but the actual CRD field is `spec.scheduling.*`.

Fixes https://redhat.atlassian.net/browse/RHOAIENG-76305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HardwareProfile scheduling parsing to read the correct `scheduling` fields, including Kueue queue configuration, node selectors, and tolerations.
  * Ensures scheduling settings from the current HardwareProfile specification structure are applied when resolving profiles.
* **Tests**
  * Updated webhook and test-fixture payloads to use the corrected `scheduling` key layout for HardwareProfile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->