### PR TITLE
feat: add sync-branches workflow and align tekton pipelines for incubating

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -213,12 +213,12 @@ jobs:
             # odh-model-serving-api is published under the odh-model-controller image repo
             # (e.g. quay.io/opendatahub/odh-model-controller:odh-model-serving-api-fast)
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver)):((?:odh-model-serving-api-)?)(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?:odh-model-controller|odh-model-serving-api|mlserver)):((?:odh-model-serving-api-)?)(odh-incubating|fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           else:
             # For kserve and others: update all matching images except llm-d-* images
             image_pattern = re.compile(
-              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-)[\w.-]+):()(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+              r'([\w.-]+(?:\.[\w.-]+)*/[\w.-]+/(?!llm-d-)[\w.-]+):()(odh-incubating|fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
             )
           
           updated_files = []
@@ -283,7 +283,7 @@ jobs:
           )
 
           image_tag_pattern = re.compile(
-            r'([\w.-]+(?:\.[\w.-]+)*(?:/[\w.-]+)+):(fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
+            r'([\w.-]+(?:\.[\w.-]+)*(?:/[\w.-]+)+):(odh-incubating|fast|odh-stable|v[\d.]+-latest|release-v[\d.]+|odh-v[\d.]+(?:-EA\d)?)'
           )
 
           updated_files = []

--- a/.github/workflows/prow-merge-incubating-with-main.yaml
+++ b/.github/workflows/prow-merge-incubating-with-main.yaml
@@ -1,69 +1,76 @@
-name: "Prow merge incubating to main"
+# Caller workflow for the sync-branches action.
+# Defines the schedule and defaults for syncing incubating -> main.
+
+name: Sync incubating to main
 
 on:
+  schedule:
+    # Weekly sync to keep the release branch reasonably close to incubating,
+    # reducing the size of each merge and catching integration issues early.
+    - cron: '0 8 * * 3'
+    # Every Friday at 06:00 UTC (08:00 CEST). The schedule-gate job checks
+    # whether this Friday falls on a 4-week boundary starting from
+    # CODE_FREEZE_EPOCH, matching the project's code-freeze cadence.
+    - cron: '0 6 * * 5'
   workflow_dispatch:
+    inputs:
+      source_tag:
+        description: 'Image tag used on the source branch'
+        required: false
+        default: 'odh-incubating'
+      release_tag:
+        description: 'Image tag for the release branch'
+        required: false
+        default: 'odh-stable'
 
 concurrency:
   group: sync-incubating-to-main
   cancel-in-progress: false
 
 env:
-  SOURCE_BRANCH: "incubating"
-  TARGET_BRANCH: "main"
-
-permissions:
-  contents: write
-  pull-requests: write
+  # First code-freeze date. The Friday schedule runs every 4 weeks
+  # from this epoch. Update when the cadence shifts.
+  CODE_FREEZE_EPOCH: '2026-07-24'
 
 jobs:
-  auto-merge:
-    if: github.ref == 'refs/heads/incubating'
+  # Cron cannot express "every 4 weeks", so the Friday schedule fires
+  # weekly. This job skips Fridays that don't land on the 4-week
+  # code-freeze cadence. Wednesday runs and manual triggers pass through.
+  schedule-gate:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    permissions: {}
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create sync PR instead of direct push
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check 4-week cadence
+        id: check
+        if: github.event_name == 'schedule'
         run: |
-          set -euo pipefail
-          git fetch origin "$TARGET_BRANCH"
-          git fetch origin "$SOURCE_BRANCH"
-
-          # Skip if nothing to merge
-          if git merge-base --is-ancestor "origin/$SOURCE_BRANCH" "origin/$TARGET_BRANCH"; then
-            echo "Nothing to merge — $SOURCE_BRANCH is already merged into $TARGET_BRANCH"
-            exit 0
+          DAY_OF_WEEK=$(date +%u)
+          # 5 = Friday: only run on 4-week code-freeze boundaries
+          if [ "$DAY_OF_WEEK" -eq 5 ]; then
+            EPOCH=$(date -d "$CODE_FREEZE_EPOCH" +%s)
+            TODAY=$(date -d "$(date +%Y-%m-%d)" +%s)
+            WEEKS_SINCE=$(( (TODAY - EPOCH) / 604800 ))
+            if (( WEEKS_SINCE < 0 || WEEKS_SINCE % 4 != 0 )); then
+              echo "Not on a 4-week boundary from $CODE_FREEZE_EPOCH, skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
-          # Skip if a sync PR already exists
-          SYNC_BRANCH="sync/merge-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
-          EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$SYNC_BRANCH" --state open --json number -q '.[0].number' || true)
-          if [ -n "$EXISTING_PR" ]; then
-            echo "Sync PR already exists: #$EXISTING_PR"
-            exit 0
-          fi
-
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Create sync branch and merge
-          git checkout -b "$SYNC_BRANCH" "origin/$TARGET_BRANCH"
-          git merge --no-ff "origin/$SOURCE_BRANCH"
-
-          # Push and create PR
-          git push --force origin "$SYNC_BRANCH"
-
-          PR_URL=$(gh pr create \
-            --base "$TARGET_BRANCH" \
-            --head "$SYNC_BRANCH" \
-            --title "Merge $SOURCE_BRANCH to $TARGET_BRANCH" \
-            --body "Automated merge of $SOURCE_BRANCH into $TARGET_BRANCH" \
-            --label "tide/merge-method-merge")
-
-          echo "Created sync PR: $PR_URL"
+  sync:
+    needs: schedule-gate
+    if: needs.schedule-gate.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: opendatahub-io/kserve/.github/actions/sync-branches@master
+        with:
+          source_branch: incubating
+          source_tag: ${{ inputs.source_tag || 'odh-incubating' }}
+          release_branch: main
+          release_tag: ${{ inputs.release_tag || 'odh-stable' }}
+          config_path: config/base

--- a/.github/workflows/verify-odh-model-controller-img-tag.yaml
+++ b/.github/workflows/verify-odh-model-controller-img-tag.yaml
@@ -18,9 +18,9 @@ jobs:
         id: expected-tag
         run: |
           if [ "${{ github.base_ref }}" == "incubating" ]; then
-            EXPECTED_TAG="fast"
+            EXPECTED_TAG="odh-incubating"
           elif [[ "${{ github.base_ref }}" == "main" ]]; then
-            EXPECTED_TAG="stable"
+            EXPECTED_TAG="odh-stable"
           elif [[ "${GITHUB_REF}" == refs/tags/odh-v* ]]; then
             EXPECTED_TAG="${GITHUB_REF#refs/tags/}"
           else
@@ -40,11 +40,8 @@ jobs:
               echo "WARNING: ${IMAGE} not found in params.env, skipping"
               continue
             fi
-            # Strip optional image-name prefix from tag (e.g. odh-model-serving-api-fast -> fast)
-            # to handle images published as tag prefixes under another repo
-            STRIPPED_TAG="${IMAGE_TAG#${IMAGE}-}"
-            if [[ ! "$STRIPPED_TAG" =~ ^"$EXPECTED_TAG"(\.[0-9]+)?$ ]]; then
-              echo "Image tag mismatch for ${IMAGE}! Expected '$EXPECTED_TAG' (or '${IMAGE}-${EXPECTED_TAG}') but found '$IMAGE_TAG'"
+            if [[ ! "$IMAGE_TAG" =~ ^"$EXPECTED_TAG"(\.[0-9]+)?$ ]]; then
+              echo "Image tag mismatch for ${IMAGE}! Expected '$EXPECTED_TAG' but found '$IMAGE_TAG'"
               FAILED=1
             else
               echo "Image tag for ${IMAGE} ('$IMAGE_TAG') is correct."

--- a/.tekton/odh-model-controller-pull-request.yaml
+++ b/.tekton/odh-model-controller-pull-request.yaml
@@ -5,17 +5,18 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-model-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "incubating"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
     appstudio.openshift.io/component: odh-model-controller
     pipelines.appstudio.openshift.io/type: build
-  name: odh-model-controller-on-push
+  name: odh-model-controller-on-pull-request
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -24,15 +25,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-incubating
+    value: quay.io/opendatahub/odh-model-controller:odh-pr
   - name: dockerfile
     value: Containerfile
   - name: path-context
     value: .
   - name: additional-tags
     value:
-    - 'odh-incubating'
-    - 'odh-incubating-{{revision}}'
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-model-serving-api-ci-on-pull-request.yaml
+++ b/.tekton/odh-model-serving-api-ci-on-pull-request.yaml
@@ -5,17 +5,18 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-model-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "incubating"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
-    appstudio.openshift.io/component: odh-model-controller
+    appstudio.openshift.io/component: odh-model-serving-api-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-model-controller-on-push
+  name: odh-model-serving-api-ci-on-pull-request
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -24,15 +25,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-incubating
+    value: quay.io/opendatahub/odh-model-serving-api:odh-pr
   - name: dockerfile
-    value: Containerfile
+    value: Containerfile.server
   - name: path-context
     value: .
   - name: additional-tags
     value:
-    - 'odh-incubating'
-    - 'odh-incubating-{{revision}}'
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
   pipelineRef:
     resolver: git
     params:
@@ -43,7 +45,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-model-controller
+    serviceAccountName: build-pipeline-odh-model-serving-api-ci
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/odh-model-serving-api-ci-on-push.yaml
+++ b/.tekton/odh-model-serving-api-ci-on-push.yaml
@@ -5,7 +5,6 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-model-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
@@ -13,9 +12,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-release
-    appstudio.openshift.io/component: odh-model-controller
+    appstudio.openshift.io/component: odh-model-serving-api-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-model-controller-on-push
+  name: odh-model-serving-api-ci-on-push
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -24,9 +23,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-model-controller:odh-incubating
+    value: quay.io/opendatahub/odh-model-serving-api:odh-incubating
   - name: dockerfile
-    value: Containerfile
+    value: Containerfile.server
   - name: path-context
     value: .
   - name: additional-tags
@@ -43,7 +42,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-model-controller
+    serviceAccountName: build-pipeline-odh-model-serving-api-ci
   workspaces:
   - name: git-auth
     secret:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,6 +1,5 @@
-odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
-# TODO(RHOAIENG-53839): Temporary hack to workaround the yet to happen Konflux onboarding.
-odh-model-serving-api=quay.io/opendatahub/odh-model-controller:odh-model-serving-api-fast
+odh-model-controller=quay.io/opendatahub/odh-model-controller:odh-incubating
+odh-model-serving-api=quay.io/opendatahub/odh-model-serving-api:odh-incubating
 ray-tls-generator-image=registry.redhat.io/ubi9/ubi-minimal:latest
 nim-state=managed
 kserve-state=managed


### PR DESCRIPTION
- Replace the old prow-merge workflow with a caller that uses the reusable sync-branches action from opendatahub-io/kserve, including the weekly and 4-week code-freeze schedules with schedule-gate.

- Rewrite odh-model-controller-push.yaml from inline pipelineSpec to pipelineRef (odh-konflux-central) and switch image tag to odh-incubating with revision-based additional tags.

- Add missing tekton pipelines for incubating: odh-model-serving-api push and pull-request, and odh-model-controller pull-request.

- Update config/base/params.env image coordinates to use odh-incubating tags and fix odh-model-serving-api to point at the correct image repo.

- Add odh-incubating to the release workflow tag-matching regexes so releases can also target the incubating branch.


Related to https://github.com/opendatahub-io/kserve/pull/1734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pull-request and push build pipelines for the model controller and model serving API.
  - Introduced consistent `odh-incubating` image tagging for incubating builds.

- **Improvements**
  - Updated image verification and release automation to recognize incubating tags.
  - Automated scheduled synchronization of incubating changes with the main development branch.
  - Simplified container build pipeline configuration while preserving multi-architecture builds.

- **Configuration**
  - Updated default image references to use the new incubating tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->