### PR TITLE
fix(webhook): reject InferenceService with connection Secret missing connection-type-protocol

### DIFF
--- a/internal/webhook/connectionapi/utils.go
+++ b/internal/webhook/connectionapi/utils.go
@@ -85,9 +85,9 @@ func (ct ConnectionType) String() string {
 //
 // Fetches the referenced Secret once and validates the connection type from its annotations.
 // Returns populated ConnectionInfo and the fetched Secret when a valid connection is found.
-// Returns empty ConnectionInfo and a nil Secret (no error) when no injection should be performed
-// (annotation absent, unknown type, or no type annotation on the Secret).
-// Returns an error when validation fails (e.g., Secret not found, API error).
+// Returns empty ConnectionInfo and a nil Secret (no error) when no annotation is present.
+// Returns an error when validation fails — including when the Secret is not found, the Secret
+// lacks a connection-type-protocol annotation, or the type value is not a supported one.
 //
 // The returned Secret is non-nil only when injection should proceed; callers must pass it to
 // injection helpers (GetURIValue, BuildS3URI) to avoid a second fetch.
@@ -119,12 +119,14 @@ func ValidateConnectionAnnotation(ctx context.Context, apiReader client.Reader, 
 
 	connType, isValid := ValidateConnectionType(secret)
 	if connType == "" {
-		log.Info("connection has no type annotation, skipping injection", "connection", secretName)
-		return ConnectionInfo{}, nil, nil
+		return ConnectionInfo{}, nil, fmt.Errorf(
+			"connection %q referenced by annotation %q must have a %q annotation on the Secret",
+			secretName, AnnotationConnections, AnnotationConnectionTypeProtocol)
 	}
 	if !isValid {
-		log.Info("unknown connection type, skipping injection", "connectionType", connType, "connection", secretName)
-		return ConnectionInfo{}, nil, nil
+		return ConnectionInfo{}, nil, fmt.Errorf(
+			"connection %q has unsupported connection type %q; supported types are s3, uri, oci",
+			secretName, connType)
 	}
 
 	connPath := obj.GetAnnotations()[AnnotationConnectionPath]

--- a/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
+++ b/internal/webhook/serving/v1alpha2/llminferenceservice_webhook_test.go
@@ -130,7 +130,7 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			Expect(llmisvc.Spec.Template).To(BeNil())
 		})
 
-		It("skips injection when secret has no connection type annotation", func() {
+		It("returns error when secret has no connection type annotation", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret1", Namespace: llmNS},
 			}
@@ -141,11 +141,12 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
-			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
-			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
+			err := d.Default(admCtx, llmisvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(connectionapi.AnnotationConnectionTypeProtocol))
 		})
 
-		It("skips injection when secret has an unknown connection type", func() {
+		It("returns error when secret has an unknown connection type", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "secret1",
@@ -162,8 +163,9 @@ var _ = Describe("LLMInferenceService ConnectionsAPI Defaulter", func() {
 			})
 			admCtx := llmAdmissionCtx(admissionv1.Create, nil, false)
 
-			Expect(d.Default(admCtx, llmisvc)).To(Succeed())
-			Expect(llmisvc.Spec.Model.URI.String()).To(BeEmpty())
+			err := d.Default(admCtx, llmisvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exotic"))
 		})
 
 		It("returns error when referenced secret does not exist", func() {

--- a/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
+++ b/internal/webhook/serving/v1beta1/inferenceservice_connectionsapi_test.go
@@ -101,14 +101,15 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 			Expect(isvc.Spec.Predictor.ImagePullSecrets).To(BeEmpty())
 		})
 
-		It("skips injection when secret has no connection type annotation", func() {
+		It("returns error when secret has no connection type annotation", func() {
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: defaultNS}}
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
-			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+			err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(connectionapi.AnnotationConnectionTypeProtocol))
 		})
 
-		It("skips injection when secret has an unknown connection type", func() {
+		It("returns error when secret has an unknown connection type", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "s", Namespace: defaultNS,
@@ -116,8 +117,9 @@ var _ = Describe("InferenceService ConnectionsAPI Defaulter", func() {
 				},
 			}
 			isvc := buildISVC(map[string]string{connectionapi.AnnotationConnections: "s"})
-			Expect(newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)).To(Succeed())
-			Expect(isvc.Spec.Predictor.Model).To(BeNil())
+			err := newISVCDefaulter(newDefaulterFakeClient(secret)).Default(defaultCtx(admissionv1.Create, nil, false), isvc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exotic"))
 		})
 
 		It("returns error when referenced secret does not exist", func() {


### PR DESCRIPTION
## Description

When an InferenceService or LLMInferenceService referenced a connection
Secret that had no opendatahub.io/connection-type-protocol annotation,
the ConnectionsAPI webhook silently skipped injection and admitted the
resource unchanged. This caused models using S3 connections created via
YAML, GitOps, or tutorials (which typically omit the type annotation
from the Secret) to be admitted without spec.predictor.model.storage
populated, so the model would never load from S3.

Additionally, on UPDATE of such an already-broken resource would trigger an
unintended cleanup of fields that were never injected.

The webhook now returns an error in both cases.

Workaround for existing YAML-created Secrets:
  oc annotate secret <name> opendatahub.io/connection-type-protocol=s3

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-69754

## How Has This Been Tested?

Running unit tests.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection configuration now fails validation when a referenced Secret is missing connection-type metadata.
  * Unsupported connection types are reported as errors instead of being silently skipped.
  * Error messages identify the missing or invalid connection-type information to help resolve configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->