### PR TITLE
build: derive envtest K8s version from go.mod instead of hardcoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,14 @@ make container-build-server # Build model-serving-api container image
 For faster iteration on a specific package, run `make envtest` once, then:
 
 ```
-KUBEBUILDER_ASSETS="$(bin/setup-envtest use 1.31.0 --bin-dir bin -p path)" POD_NAMESPACE=default \
+KUBEBUILDER_ASSETS="$(make -s print-envtest-assets)" POD_NAMESPACE=default \
+  go test ./internal/controller/serving/... -run TestSpecificName -v
+```
+
+Or equivalently (the version is derived from `go.mod`, not hardcoded):
+
+```
+KUBEBUILDER_ASSETS="$(bin/setup-envtest use $(go list -m -f '{{ if .Replace }}{{ .Replace.Version }}{{ else }}{{ .Version }}{{ end }}' k8s.io/api | awk -F'[v.]' '{printf "1.%d", $3}') --bin-dir bin -p path)" POD_NAMESPACE=default \
   go test ./internal/controller/serving/... -run TestSpecificName -v
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ SERVER_IMG_TAG ?= latest
 SERVER_IMG ?= quay.io/${USER}/odh-model-serving-api:${SERVER_IMG_TAG}
 NAMESPACE ?= opendatahub
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+# Derived from the effective k8s.io/api module version (respecting replace directives in go.mod).
+ENVTEST_K8S_VERSION ?= $(shell go list -m -f '{{ if .Replace }}{{ .Replace.Version }}{{ else }}{{ .Version }}{{ end }}' k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -105,6 +106,10 @@ fmt: ## Run go fmt against code.
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
+
+.PHONY: print-envtest-assets
+print-envtest-assets: envtest ## Print KUBEBUILDER_ASSETS path for use in shell one-liners.
+	@$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path
 
 .PHONY: test
 test: manifests generate fmt vet envtest validate-samples ## Run tests.
@@ -321,7 +326,7 @@ KUBECTL_VALIDATE = $(LOCALBIN)/kubectl-validate
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
-ENVTEST_VERSION ?= release-0.19
+ENVTEST_VERSION ?= $(shell go list -m -f '{{ if .Replace }}{{ .Replace.Version }}{{ else }}{{ .Version }}{{ end }}' sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 GOLANGCI_LINT_VERSION ?= v2.11.3
 KUBECTL_VALIDATE_VERSION ?= v0.0.4
 


### PR DESCRIPTION
## Description

The envtest binary version was pinned to 1.31.0 while the k8s libraries in `go.mod` are pinned to v0.34.x (Kubernetes 1.34). This three-major-version mismatch caused intermittent CRD installation timeouts during parallel test runs - the older apiserver couldn't reliably serve CRDs generated for newer API versions.

Adopts the same approach used by upstream kserve/kserve: both `ENVTEST_K8S_VERSION` and `ENVTEST_VERSION` are now dynamically derived from `go.mod` replace directives, so they stay in sync automatically when dependencies are bumped.

Also adds a `print-envtest-assets` make target for convenient shell one-liners when iterating on a single test package, and updates the `AGENTS.md` fast-iteration snippet to stop hardcoding the stale version.

## How Has This Been Tested?

- `make test` passes all suites (previously flaky `nim`, `serving`, and
  `webhook/nim` suites now pass reliably)
- `make lint` clean (0 issues)
- `make print-envtest-assets` returns the correct path
- Verified dynamic version derivation: `ENVTEST_K8S_VERSION` resolves to
  `1.34` and `ENVTEST_VERSION` resolves to `release-0.19` matching the
  effective `go.mod` versions

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment test tooling to automatically match the Kubernetes API and controller-runtime versions used by the project.
  - Added a command to display the resolved environment test asset path.
  - Updated development guidance with the streamlined command for running targeted controller tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->