### PR TITLE
feat(llmisvc): warn on auth posture mismatch across routing group members

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -36,6 +36,10 @@ const (
 	ODHManaged              = "opendatahub.io/managed"
 	EnableAuthODHAnnotation = "security.opendatahub.io/enable-auth"
 
+	// RoutingGroupLabel groups LLMInferenceServices that share weighted traffic distribution.
+	// ponytail: label stand-in for spec.router.route.group until ODH kserve fork picks up the field
+	RoutingGroupLabel = "serving.kserve.io/routing-group"
+
 	LabelEnableKserveRawRoute = "exposed"
 
 	KserveServiceAccountName = "default"

--- a/internal/controller/serving/llm/auth_posture_test.go
+++ b/internal/controller/serving/llm/auth_posture_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm_test
+
+import (
+	"context"
+	"time"
+
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/serving/llm/fixture"
+	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
+)
+
+var _ = Describe("Auth Posture Enforcement", func() {
+	var testNs string
+
+	BeforeEach(func(ctx SpecContext) {
+		testNamespace := testutils.Namespaces.Create(ctx, envTest.Client)
+		testNs = testNamespace.Name
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		llmList := &kservev1alpha2.LLMInferenceServiceList{}
+		if err := envTest.Client.List(ctx, llmList, client.InNamespace(testNs)); err == nil {
+			for i := range llmList.Items {
+				_ = envTest.Client.Delete(ctx, &llmList.Items[i])
+			}
+		}
+	})
+
+	countAuthPostureMismatchEvents := func(ctx context.Context, namespace string) (int32, error) {
+		eventList := &corev1.EventList{}
+		if err := envTest.Client.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
+			return 0, err
+		}
+		var total int32
+		for _, ev := range eventList.Items {
+			if ev.Reason == "AuthPostureMismatch" {
+				if ev.Count > 0 {
+					total += ev.Count
+				} else {
+					total++
+				}
+			}
+		}
+		return total, nil
+	}
+
+	Context("routing group auth posture consistency", func() {
+		It("should not emit events when two members have the same auth posture", func(ctx SpecContext) {
+			svc1 := fixture.LLMInferenceService("llama-v1",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(true),
+			)
+			svc2 := fixture.LLMInferenceService("llama-v2",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(true),
+			)
+			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
+			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeZero())
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+		})
+
+		It("should emit Warning events when two members have different auth posture", func(ctx SpecContext) {
+			svc1 := fixture.LLMInferenceService("llama-v1",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(true),
+			)
+			svc2 := fixture.LLMInferenceService("llama-v2",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(false),
+			)
+			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
+			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically(">=", 1))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not emit events for standalone services without a routing group", func(ctx SpecContext) {
+			svc := fixture.LLMInferenceService("standalone",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithEnableAuth(false),
+			)
+			Expect(envTest.Client.Create(ctx, svc)).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeZero())
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+		})
+
+		It("should emit Warning events when multiple members have mixed auth postures", func(ctx SpecContext) {
+			for _, name := range []string{"llama-v1", "llama-v2", "llama-v3"} {
+				svc := fixture.LLMInferenceService(name,
+					fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+					fixture.WithRoutingGroup("llama"),
+					fixture.WithEnableAuth(true),
+				)
+				Expect(envTest.Client.Create(ctx, svc)).Should(Succeed())
+			}
+			svc4 := fixture.LLMInferenceService("llama-v4",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(false),
+			)
+			Expect(envTest.Client.Create(ctx, svc4)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically(">=", 1))
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should stop emitting events when annotation is fixed to match", func(ctx SpecContext) {
+			svc1 := fixture.LLMInferenceService("llama-v1",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(true),
+			)
+			svc2 := fixture.LLMInferenceService("llama-v2",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(false),
+			)
+			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
+			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically(">=", 1))
+			}).WithContext(ctx).Should(Succeed())
+
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())
+				svc2.Annotations[constants.EnableAuthODHAnnotation] = "true"
+				return envTest.Client.Update(ctx, svc2)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshotCount, err := countAuthPostureMismatchEvents(ctx, testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			Consistently(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically("<=", snapshotCount))
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+		})
+
+		It("should exclude terminating members from mismatch detection", func(ctx SpecContext) {
+			svc1 := fixture.LLMInferenceService("llama-v1",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(true),
+			)
+			svc2 := fixture.LLMInferenceService("llama-v2",
+				fixture.InNamespace[*kservev1alpha2.LLMInferenceService](testNs),
+				fixture.WithRoutingGroup("llama"),
+				fixture.WithEnableAuth(false),
+			)
+			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
+			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically(">=", 1))
+			}).WithContext(ctx).Should(Succeed())
+
+			// Mark svc2 with a deletion timestamp by setting a finalizer then deleting
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())
+				svc2.Finalizers = []string{"test.opendatahub.io/block-delete"}
+				return envTest.Client.Update(ctx, svc2)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(envTest.Client.Delete(ctx, svc2)).To(Succeed())
+
+			// Verify svc2 is now terminating
+			Eventually(func(g Gomega) {
+				g.Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())
+				g.Expect(svc2.DeletionTimestamp.IsZero()).To(BeFalse())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Trigger reconcile on svc1 by touching its annotations
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc1), svc1)).To(Succeed())
+				if svc1.Annotations == nil {
+					svc1.Annotations = map[string]string{}
+				}
+				svc1.Annotations["test.opendatahub.io/trigger"] = metav1.Now().String()
+				return envTest.Client.Update(ctx, svc1)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshotCount, err := countAuthPostureMismatchEvents(ctx, testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			// With svc2 terminating, svc1 is the only active member - no mismatch possible
+			Consistently(func(g Gomega) {
+				count, err := countAuthPostureMismatchEvents(ctx, testNs)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(count).To(BeNumerically("<=", snapshotCount))
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+
+			// Clean up finalizer so envtest can fully delete
+			Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())
+			svc2.Finalizers = nil
+			Expect(envTest.Client.Update(ctx, svc2)).To(Succeed())
+		})
+	})
+})

--- a/internal/controller/serving/llm/fixture/llmisvc_builders.go
+++ b/internal/controller/serving/llm/fixture/llmisvc_builders.go
@@ -376,3 +376,7 @@ func WithEnableAuth(enable bool) LLMInferenceServiceOption {
 	}
 	return WithAnnotation(constants.EnableAuthODHAnnotation, value)
 }
+
+func WithRoutingGroup(group string) LLMInferenceServiceOption {
+	return WithLabel(constants.RoutingGroupLabel, group)
+}

--- a/internal/controller/serving/llm/llm_inferenceservice_controller.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller.go
@@ -59,6 +59,7 @@ type LLMInferenceServiceReconciler struct {
 func NewLLMInferenceServiceReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *LLMInferenceServiceReconciler {
 	subResourceReconcilers := []parentreconcilers.LLMSubResourceReconciler{
 		reconcilers.NewKserveAuthPolicyReconciler(client, scheme),
+		reconcilers.NewKserveAuthPostureReconciler(client, recorder),
 	}
 
 	return &LLMInferenceServiceReconciler{

--- a/internal/controller/serving/llm/reconcilers/kserve_auth_posture_reconciler.go
+++ b/internal/controller/serving/llm/reconcilers/kserve_auth_posture_reconciler.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
+	parentreconcilers "github.com/opendatahub-io/odh-model-controller/internal/controller/serving/reconcilers"
+)
+
+var _ parentreconcilers.LLMSubResourceReconciler = (*KserveAuthPostureReconciler)(nil)
+
+type KserveAuthPostureReconciler struct {
+	client   client.Client
+	recorder record.EventRecorder
+}
+
+func NewKserveAuthPostureReconciler(client client.Client, recorder record.EventRecorder) *KserveAuthPostureReconciler {
+	return &KserveAuthPostureReconciler{
+		client:   client,
+		recorder: recorder,
+	}
+}
+
+func (r *KserveAuthPostureReconciler) Reconcile(ctx context.Context, log logr.Logger, llmisvc *kservev1alpha2.LLMInferenceService) error {
+	group := llmisvc.Labels[constants.RoutingGroupLabel]
+	if group == "" {
+		return nil
+	}
+
+	siblings := &kservev1alpha2.LLMInferenceServiceList{}
+	if err := r.client.List(ctx, siblings,
+		client.InNamespace(llmisvc.Namespace),
+		client.MatchingLabels{constants.RoutingGroupLabel: group},
+	); err != nil {
+		return fmt.Errorf("listing routing group %q members: %w", group, err)
+	}
+
+	if len(siblings.Items) < 2 {
+		return nil
+	}
+
+	var withAuth, withoutAuth []string
+	for i := range siblings.Items {
+		s := &siblings.Items[i]
+		if !s.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if authEnabled(s) {
+			withAuth = append(withAuth, s.Name)
+		} else {
+			withoutAuth = append(withoutAuth, s.Name)
+		}
+	}
+
+	if len(withAuth) == 0 || len(withoutAuth) == 0 {
+		return nil
+	}
+
+	sort.Strings(withAuth)
+	sort.Strings(withoutAuth)
+
+	msg := fmt.Sprintf(
+		"auth posture mismatch in group %q: %s have enable-auth=true, %s have enable-auth=false",
+		group, formatNames(withAuth), formatNames(withoutAuth),
+	)
+	log.Info(msg)
+	r.recorder.Event(llmisvc, corev1.EventTypeWarning, "AuthPostureMismatch", msg)
+
+	return nil
+}
+
+func (r *KserveAuthPostureReconciler) Delete(_ context.Context, _ logr.Logger, _ *kservev1alpha2.LLMInferenceService) error {
+	return nil
+}
+
+func (r *KserveAuthPostureReconciler) Cleanup(_ context.Context, _ logr.Logger, _ string) error {
+	return nil
+}
+
+// authEnabled reports whether the LLMInferenceService has auth enabled.
+// Auth is enabled by default; only an explicit "false" annotation disables it.
+func authEnabled(svc *kservev1alpha2.LLMInferenceService) bool {
+	if value, ok := svc.Annotations[constants.EnableAuthODHAnnotation]; ok {
+		return !strings.EqualFold(strings.TrimSpace(value), "false")
+	}
+	return true
+}
+
+func formatNames(names []string) string {
+	return "[" + strings.Join(names, ", ") + "]"
+}


### PR DESCRIPTION
## Description

When LLMInferenceService members of a routing group have inconsistent `enable-auth` annotations, split traffic could land on an unprotected route. No detection mechanism existed until now.

Adds a sub-reconciler that checks annotation unanimity within a routing group and emits a Warning event naming the exact split when members disagree. Event-only, non-blocking - designed as an advisory signal for now. Not blocking nor degrading the group members.

Part of [RHOAIENG-69638](https://redhat.atlassian.net/browse/RHOAIENG-69638)

> [!NOTE]
> Uses a label (`serving.kserve.io/routing-group`) as a stand-in for the upstream `spec.router.route.group` field until the ODH kserve fork picks it up.

## How Has This Been Tested?

- All 56 LLM controller tests pass (envtest), including 6 new auth posture tests:
  - Same posture across group - no event
  - Different posture - Warning event emitted
  - Standalone (no group) - skipped, no event
  - Multiple members with mixed posture - Warning event
  - Fix annotation to match - events stop
  - Terminating member excluded from mismatch detection

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-69638]: https://redhat.atlassian.net/browse/RHOAIENG-69638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing-group support for related LLM inference services.
  * Added validation to detect inconsistent authentication settings among services in the same routing group.
  * Services with conflicting authentication settings now generate a warning event.
  * Authentication is enabled by default and can be explicitly disabled.

* **Bug Fixes**
  * Services that are standalone, terminating, or updated to match their peers are excluded from mismatch warnings.

* **Tests**
  * Added coverage for matching, conflicting, corrected, and terminating routing-group members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->