### PR TITLE
feat: add publisher-path authorization rules and cross-tenant deny to gateway AuthPolicy

### DIFF
--- a/.github/workflows/test-authpolicy-e2e.yml
+++ b/.github/workflows/test-authpolicy-e2e.yml
@@ -1,0 +1,221 @@
+name: AuthPolicy E2E Tests
+
+on:
+  pull_request:
+    branches: [incubating]
+    paths:
+      - 'internal/controller/resources/template/authpolicy_*.yaml'
+      - 'internal/controller/resources/authpolicy.go'
+      - 'internal/controller/resources/options.go'
+      - 'internal/controller/test/e2e/**'
+      - 'internal/controller/serving/llm/gateway_controller.go'
+      - 'internal/controller/utils/utils.go'
+      - 'internal/controller/constants/constants.go'
+      - '.github/workflows/test-authpolicy-e2e.yml'
+      - 'hack/setup-authpolicy-e2e.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ISTIO_VERSION: "1.28.1"
+  KUADRANT_VERSION: "1.5.0"
+  CERT_MANAGER_VERSION: "v1.17.0"
+  GATEWAY_API_VERSION: "v1.4.1"
+  METALLB_VERSION: "v0.14.9"
+  KIND_CLUSTER_NAME: authpolicy-e2e
+  GATEWAY_NAME: e2e-gateway
+  GATEWAY_NAMESPACE: e2e-authpolicy
+
+permissions:
+  contents: read
+
+jobs:
+  test-authpolicy-e2e:
+    name: AuthPolicy E2E (kind)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+
+      - name: Create kind cluster
+        run: |
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64"
+          echo "a6875aaea358acf0ac07786b1a6755d08fd640f4c79b7a2e46681cc13f49a04b  ./kind" | sha256sum -c
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+          cat <<EOF | kind create cluster --name "$KIND_CLUSTER_NAME" --config=-
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+            - role: worker
+          EOF
+
+      - name: Install MetalLB
+        run: |
+          kubectl apply -f "https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+          kubectl wait --timeout=120s -n metallb-system deployment/controller --for=condition=Available
+          kubectl wait --timeout=120s -n metallb-system pod -l component=speaker --for=condition=Ready
+
+          subnet=$(docker network inspect kind \
+            -f '{{range .IPAM.Config}}{{.Subnet}}{{"\n"}}{{end}}' | grep -v ':' | head -1)
+          base=$(echo "${subnet:-172.18.0.0/16}" | cut -d. -f1-2)
+
+          kubectl apply -f - <<EOF
+          apiVersion: metallb.io/v1beta1
+          kind: IPAddressPool
+          metadata:
+            name: kind-pool
+            namespace: metallb-system
+          spec:
+            addresses:
+              - ${base}.255.200-${base}.255.250
+          ---
+          apiVersion: metallb.io/v1beta1
+          kind: L2Advertisement
+          metadata:
+            name: kind-l2
+            namespace: metallb-system
+          EOF
+
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+          kubectl wait --timeout=120s -n cert-manager deployment/cert-manager-webhook --for=condition=Available
+
+      - name: Install Gateway API CRDs
+        run: |
+          kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+
+      - name: Install Istio
+        run: |
+          helm repo add istio https://istio-release.storage.googleapis.com/charts
+          helm repo update istio
+
+          kubectl create namespace istio-system
+          helm upgrade -i istio-base istio/base \
+            --namespace istio-system \
+            --version "${ISTIO_VERSION}" \
+            --wait
+          helm upgrade -i istiod istio/istiod \
+            --namespace istio-system \
+            --version "${ISTIO_VERSION}" \
+            --set resources.requests.cpu=5m \
+            --set resources.requests.memory=32Mi \
+            --wait
+          kubectl wait --timeout=120s -n istio-system deployment/istiod --for=condition=Available
+
+      - name: Install Kuadrant
+        run: |
+          helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+          helm upgrade -i kuadrant-operator kuadrant/kuadrant-operator \
+            --version "${KUADRANT_VERSION}" \
+            --create-namespace --namespace kuadrant-system \
+            --wait --timeout 300s
+
+          for crd in authpolicies.kuadrant.io kuadrants.kuadrant.io; do
+            kubectl wait --for=condition=established --timeout=60s "crd/${crd}"
+          done
+
+          kubectl apply -f - <<EOF
+          apiVersion: kuadrant.io/v1beta1
+          kind: Kuadrant
+          metadata:
+            name: kuadrant
+            namespace: kuadrant-system
+          spec: {}
+          EOF
+
+          kubectl wait kuadrant/kuadrant -n kuadrant-system \
+            --for=condition=Ready --timeout=180s
+
+      - name: Create Gateway
+        run: |
+          kubectl create namespace "$GATEWAY_NAMESPACE"
+
+          kubectl apply -f - <<EOF
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: GatewayClass
+          metadata:
+            name: istio
+          spec:
+            controllerName: istio.io/gateway-controller
+          ---
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: Gateway
+          metadata:
+            name: ${GATEWAY_NAME}
+            namespace: ${GATEWAY_NAMESPACE}
+          spec:
+            gatewayClassName: istio
+            listeners:
+              - name: http
+                port: 80
+                protocol: HTTP
+                allowedRoutes:
+                  namespaces:
+                    from: All
+          EOF
+
+          echo "Waiting for gateway address..."
+          for i in $(seq 1 30); do
+            gw_addr=$(kubectl get gateway "$GATEWAY_NAME" -n "$GATEWAY_NAMESPACE" \
+              -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "")
+            if [[ -n "$gw_addr" ]]; then
+              echo "Gateway address: ${gw_addr}"
+              echo "GATEWAY_URL=http://${gw_addr}" >> "$GITHUB_ENV"
+              break
+            fi
+            sleep 2
+          done
+          [[ -n "$gw_addr" ]] || { echo "Gateway has no address after 60s"; exit 1; }
+
+      - name: Deploy AuthPolicy
+        run: |
+          sed \
+            -e 's/{{.Name}}/e2e-authpolicy-authn/g' \
+            -e 's/{{.Namespace}}/'"${GATEWAY_NAMESPACE}"'/g' \
+            -e 's/{{.TargetKind}}/Gateway/g' \
+            -e 's/{{.TargetName}}/'"${GATEWAY_NAME}"'/g' \
+            -e 's/{{.ModelRoutingHeader}}/x-gateway-model-name/g' \
+            internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml \
+            | kubectl apply -f -
+
+          kubectl wait authpolicy/e2e-authpolicy-authn -n "$GATEWAY_NAMESPACE" \
+            --for=condition=Accepted --timeout=120s
+
+      - name: Run AuthPolicy E2E tests
+        run: |
+          go test -tags e2e ./internal/controller/test/e2e/... \
+            -v -count=1 -timeout 8m
+        env:
+          GATEWAY_NAME: ${{ env.GATEWAY_NAME }}
+          GATEWAY_NAMESPACE: ${{ env.GATEWAY_NAMESPACE }}
+          GATEWAY_URL: ${{ env.GATEWAY_URL }}
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== AuthPolicy status ==="
+          kubectl get authpolicy -n "$GATEWAY_NAMESPACE" -o yaml 2>/dev/null || true
+          echo ""
+          echo "=== Authorino logs ==="
+          kubectl logs -n kuadrant-system -l app=authorino --tail=100 2>/dev/null || true
+          echo ""
+          echo "=== Istiod logs ==="
+          kubectl logs -n istio-system -l app=istiod --tail=50 2>/dev/null || true
+          echo ""
+          echo "=== Gateway pod logs ==="
+          kubectl logs -n "$GATEWAY_NAMESPACE" -l gateway.networking.k8s.io/gateway-name="$GATEWAY_NAME" --tail=50 2>/dev/null || true

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/net v0.52.0
 	google.golang.org/protobuf v1.36.11
 	istio.io/api v1.27.8
 	istio.io/client-go v1.27.8
@@ -152,7 +153,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250808145144-a408d31f581a // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -185,6 +185,8 @@ const (
 	// DefaultObjectiveExpression is the default CEL expression for computing the objective value.
 	// For ServiceAccount tokens, it extracts the namespace; for other users, it returns "authenticated".
 	DefaultObjectiveExpression = "auth.identity.user.username.startsWith('system:serviceaccount:') ? auth.identity.user.username.split(':')[2] : 'authenticated'"
+
+	DefaultModelRoutingHeader = "x-gateway-model-name"
 )
 
 func GetAuthPolicyName(targetName string) string {

--- a/internal/controller/resources/authpolicy.go
+++ b/internal/controller/resources/authpolicy.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	"golang.org/x/net/http/httpguts"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -46,17 +47,19 @@ type AuthPolicyDetector interface {
 }
 
 type AuthPolicyTarget struct {
-	Kind      string // Currently only "Gateway" or "HTTPRoute" is supported
-	Name      string
-	Namespace string
-	AuthType  constants.AuthType
+	Kind               string // Currently only "Gateway" or "HTTPRoute" is supported
+	Name               string
+	Namespace          string
+	AuthType           constants.AuthType
+	ModelRoutingHeader string
 }
 
 type authPolicyTemplateData struct {
-	Name       string
-	Namespace  string
-	TargetKind string
-	TargetName string
+	Name               string
+	Namespace          string
+	TargetKind         string
+	TargetName         string
+	ModelRoutingHeader string
 }
 
 type AuthPolicyTemplateLoader interface {
@@ -119,11 +122,20 @@ func (k *kserveAuthPolicyTemplateLoader) Load(_ context.Context, target AuthPoli
 		return nil, fmt.Errorf("unsupported auth type %s", target.AuthType)
 	}
 
+	modelRoutingHeader := target.ModelRoutingHeader
+	if modelRoutingHeader == "" {
+		modelRoutingHeader = constants.DefaultModelRoutingHeader
+	}
+	if !httpguts.ValidHeaderFieldName(modelRoutingHeader) || strings.ContainsAny(modelRoutingHeader, "'\"`\\") {
+		return nil, fmt.Errorf("invalid model routing header name %q: must be a valid HTTP token safe for CEL interpolation", modelRoutingHeader)
+	}
+
 	authPolicy, err := k.renderTemplate(tmpl, authPolicyTemplateData{
-		Name:       kmeta.ChildName(target.Name, constants.AuthPolicyNameSuffix),
-		Namespace:  target.Namespace,
-		TargetKind: target.Kind,
-		TargetName: target.Name,
+		Name:               kmeta.ChildName(target.Name, constants.AuthPolicyNameSuffix),
+		Namespace:          target.Namespace,
+		TargetKind:         target.Kind,
+		TargetName:         target.Name,
+		ModelRoutingHeader: modelRoutingHeader,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/controller/resources/authpolicy_test.go
+++ b/internal/controller/resources/authpolicy_test.go
@@ -303,6 +303,63 @@ var _ = Describe("AuthPolicyTemplateLoader", func() {
 			Expect(publicAuth.Overrides).To(HaveKey("fairness"))
 			Expect(string(publicAuth.Overrides["fairness"].Value.Raw)).To(Equal(`"unauthenticated"`))
 		})
+		It("should have 4 authorization rules in UserDefined template", func(ctx SpecContext) {
+			authPolicy, err := loader.Load(ctx, resources.AuthPolicyTarget{
+				Kind:      "Gateway",
+				Name:      "openshift-ai-inference",
+				Namespace: "openshift-ingress",
+				AuthType:  constants.UserDefined,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveLen(5))
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("deny-misrouted-model-header"))
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("model-access-path"))
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("model-access-path-delegate"))
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("inference-access"))
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("inference-access-delegate"))
+		})
+
+		It("should have resolvedPath override with default model routing header", func(ctx SpecContext) {
+			authPolicy, err := loader.Load(ctx, resources.AuthPolicyTarget{
+				Kind:      "Gateway",
+				Name:      "openshift-ai-inference",
+				Namespace: "openshift-ingress",
+				AuthType:  constants.UserDefined,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			kubernetesUserAuth := authPolicy.Spec.AuthScheme.Authentication["kubernetes-user"]
+			Expect(kubernetesUserAuth.Overrides).To(HaveKey("resolvedUser"))
+			Expect(kubernetesUserAuth.Overrides).To(HaveKey("resolvedGroups"))
+		})
+
+		It("should substitute custom model routing header in deny rule", func(ctx SpecContext) {
+			authPolicy, err := loader.Load(ctx, resources.AuthPolicyTarget{
+				Kind:               "Gateway",
+				Name:               "openshift-ai-inference",
+				Namespace:          "openshift-ingress",
+				AuthType:           constants.UserDefined,
+				ModelRoutingHeader: "x-custom-model-header",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(authPolicy.Spec.AuthScheme.Authorization).To(HaveKey("deny-misrouted-model-header"))
+		})
+
+		It("should reject model routing header with single quotes", func(ctx SpecContext) {
+			_, err := loader.Load(ctx, resources.AuthPolicyTarget{
+				Kind:               "Gateway",
+				Name:               "openshift-ai-inference",
+				Namespace:          "openshift-ingress",
+				AuthType:           constants.UserDefined,
+				ModelRoutingHeader: "x-model'name",
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid model routing header"))
+		})
+
 	})
 })
 

--- a/internal/controller/resources/template/PUBLISHER-PATH-AUTH.md
+++ b/internal/controller/resources/template/PUBLISHER-PATH-AUTH.md
@@ -1,0 +1,115 @@
+# Publisher-Path Authorization Rules
+
+Extend `authpolicy_llm_isvc_userdefined.yaml` to handle publisher-path routing
+with model-level SAR authorization and cross-tenant deny.
+
+## Problem
+
+The current `inference-access` rule extracts namespace/name from `request.path.split("/")[1]`
+and `[2]`. This works for per-participant paths (`/<ns>/<name>/...`) but doesn't cover
+[publisher paths](https://github.com/kserve/kserve/pull/5822)
+(`/publishers/<ns>/models/<name>/...`), which need model-level authorization against
+`serving.opendatahub.io/models`.
+
+Additionally, the kserve HTTPRoute template's `v1-catch-all-model-routing` rule matches
+on the model routing header alone (no path constraint). A per-participant path with a
+valid model header would be routed by the header (tenant-B) but authorized by the path
+(tenant-A) - a cross-tenant authorization bypass.
+
+## Authorization rules (5 total)
+
+Two new model-access rules, one deny rule, two existing rules updated.
+
+| Rule | Fires when | Resource | Verb | Priority |
+|---|---|---|---|---|
+| `deny-misrouted-model-header` | not `/v1/`, not publisher, valid model header present | (always deny) | - | 0 |
+| `model-access-path` | path ~ `^/publishers/[^/]+/models/` | `serving.opendatahub.io/models` | `post` | 1 |
+| `model-access-path-delegate` | same + `x-maas-user` | `serving.opendatahub.io/models/delegate` | `post-delegate` | 1 |
+| `inference-access` | depth >= 2, not `/v1/`, not publisher | `serving.kserve.io/llminferenceservices` | `get` | 1 |
+| `inference-access-delegate` | same + `x-maas-user` | `serving.kserve.io/llminferenceservices/delegate` | `post-delegate` | 1 |
+
+A `patternRef` (`has-ns-and-name`: regex `^/[^/]+/[^/]+`) guards against CEL
+index-out-of-bounds on short paths like `/health`.
+
+## Cross-tenant deny
+
+The `deny-misrouted-model-header` rule fires when:
+1. Path is not `/v1/` (not a BBR endpoint)
+2. Path is not a publisher path
+3. A valid model routing header is present (`^publishers/[^/]+/models/.+$`)
+
+Uses Authorino's `patternMatching` with `predicate: "false"` - immediate local 403,
+no API server round-trip. Priority 0 ensures it short-circuits before SAR rules.
+
+This closes the routing/authorization identity mismatch: the request is denied before
+`inference-access` can authorize it against the wrong tenant's path segments.
+
+## Model name extraction
+
+Model name is extracted from `request.path` using `split('/models/')[1].split('/v1/')[0]`.
+This handles both single-segment (`llama-70b`) and multi-segment (`facebook/opt-125m`)
+model names by capturing everything between `/models/` and the first `/v1/` path segment.
+
+Model names containing a literal `/v1/` segment (e.g. `my-org/v1/model`) are not supported -
+the extraction would truncate at the first `/v1/`. This is the same limitation as the kserve
+HTTPRoute template, which uses `/v1/` as the API path delimiter after the model identity.
+The ambiguity is structural, not specific to the AuthPolicy.
+
+## Request flow
+
+| Path | Header | Rule | Effect |
+|---|---|---|---|
+| `/publishers/<ns>/models/<m>/v1/...` | any | model-access-path | Model SAR |
+| `/<ns>/<name>/...` | none | inference-access | Instance SAR |
+| `/<ns>/<name>/...` | valid model header | deny-misrouted | 403 (cross-tenant) |
+| `/v1/...` | any | (no rule fires) | Authn-only |
+| `/v1/files/...`, `/v1/batches/...` | any | (no rule fires) | Authn-only (batch) |
+| `/health`, `/` | any | (no rule fires) | Authn-only (short path) |
+
+## Model routing header
+
+The header name (`x-gateway-model-name` by default) is configurable via
+`modelBasedRoutingHeaderName` in the `inferenceservice-config` ConfigMap. The value is
+lowercased (Authorino normalizes header keys) and validated as an HTTP token to prevent
+CEL injection. The GatewayReconciler watches the ConfigMap's `ingress` key for changes.
+
+Currently used only by the `deny-misrouted-model-header` rule. BBR support (normalizing
+`/v1/` + header into publisher format via `resolvedPath` override) is a planned follow-up.
+
+## Backward compatibility
+
+- Per-participant paths (`/<ns>/<name>/...`) use `inference-access` (instance SAR), unchanged.
+- Batch paths (`/v1/files`, `/v1/batches`) remain authn-only.
+- Existing `get llminferenceservices` RBAC continues to work.
+- `/v1/` paths without model header remain authn-only.
+
+## Anti-spoofing
+
+When `x-maas-user` is present, both the base rule and its delegate counterpart fire (AND
+semantics). The delegate rule checks the caller's identity for `post-delegate` or
+`post-delegate`. Regular users lack this and get 403.
+
+## Testing
+
+### Unit tests
+
+- 5 authorization rules present in rendered policy
+- `resolvedUser`/`resolvedGroups` overrides rendered
+- Custom model routing header substituted in deny rule
+
+### E2E tests (13 publisher-path + 20 batch = 33 total)
+
+| Category | Tests |
+|---|---|
+| Model-access rules | publisher path with/without RBAC, multi-segment model name |
+| Cross-RBAC type | model-user on participant path (wrong RBAC type) |
+| Namespace collision | ns=publishers participant path, ns=publishers publisher route |
+| Cross-tenant deny | participant path + valid model header -> 403 |
+| Exclusion boundaries | /v1/models authn-only, /v1/ excluded, /health depth guard, empty header |
+| Delegation | delegated model-access (post-delegate), spoofed (lacks post-delegate) |
+
+### CI workflow
+
+Kind-based CI (`.github/workflows/test-authpolicy-e2e.yml`): kind + MetalLB + cert-manager +
+Gateway API CRDs + Istio + Kuadrant. Renders the template via `sed` with default values.
+Triggered on PR when auth-related files change.

--- a/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
@@ -8,6 +8,17 @@ spec:
     group: gateway.networking.k8s.io
     kind: {{.TargetKind}}
     name: {{.TargetName}}
+  patterns:
+    has-ns-and-name:
+      allOf:
+        - selector: context.request.http.path
+          operator: matches
+          value: "^/[^/]+/[^/]+"
+    is-publisher-path:
+      allOf:
+        - selector: context.request.http.path
+          operator: matches
+          value: "^/publishers/[^/]+/models/"
   rules:
     authentication:
       kubernetes-user:
@@ -19,15 +30,100 @@ spec:
             value: "https://kubernetes.default.svc"
           objective:
             expression: "auth.identity.user.username.startsWith('system:serviceaccount:') ? auth.identity.user.username.split(':')[2] : 'authenticated'"
+          resolvedUser:
+            expression: >-
+              'x-maas-user' in request.headers
+              ? request.headers['x-maas-user']
+              : auth.identity.user.username
+          resolvedGroups:
+            expression: >-
+              'x-maas-user' in request.headers
+              ? ('x-maas-groups' in request.headers
+                ? request.headers['x-maas-groups'].split(',')
+                : [])
+              : auth.identity.user.groups
     authorization:
-      inference-access:
+      model-access-path:
         when:
-          - predicate: "!(request.path == '/v1/files' || request.path.startsWith('/v1/files/') || request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))"
+          - patternRef: is-publisher-path
         kubernetesSubjectAccessReview:
           user:
-            expression: "'x-maas-user' in request.headers ? request.headers['x-maas-user'] : auth.identity.user.username"
+            expression: "auth.identity.resolvedUser"
           authorizationGroups:
-            expression: "'x-maas-user' in request.headers ? ('x-maas-groups' in request.headers ? request.headers['x-maas-groups'].split(',') : []) : auth.identity.user.groups"
+            expression: "auth.identity.resolvedGroups"
+          resourceAttributes:
+            group:
+              value: serving.opendatahub.io
+            resource:
+              value: models
+            namespace:
+              expression: "request.path.split('/')[2]"
+            # Model name: everything between /models/ and the first /v1/ segment.
+            # Supports multi-segment names (e.g. facebook/opt-125m). Model names
+            # containing a literal /v1/ segment are not supported - same limitation
+            # as the kserve HTTPRoute template which uses /v1/ as the API path delimiter.
+            name:
+              expression: >-
+                'publishers/'
+                + request.path.split('/')[2]
+                + '/models/'
+                + request.path.split('/models/')[1].split('/v1/')[0]
+            verb:
+              value: post
+        priority: 1
+      model-access-path-delegate:
+        when:
+          - patternRef: is-publisher-path
+          - predicate: "'x-maas-user' in request.headers"
+        kubernetesSubjectAccessReview:
+          user:
+            expression: "auth.identity.user.username"
+          authorizationGroups:
+            expression: "auth.identity.user.groups"
+          resourceAttributes:
+            group:
+              value: serving.opendatahub.io
+            resource:
+              value: models/delegate
+            namespace:
+              expression: "request.path.split('/')[2]"
+            name:
+              expression: >-
+                'publishers/'
+                + request.path.split('/')[2]
+                + '/models/'
+                + request.path.split('/models/')[1].split('/v1/')[0]
+            verb:
+              value: post-delegate
+        priority: 1
+      # Deny requests where routing identity (header) and authorization identity
+      # (path) would diverge. A per-participant path with a valid model header
+      # would be routed by the header (tenant-B) but authorized by the path
+      # (tenant-A). patternMatching with predicate "false" is an immediate local
+      # deny - no API server call.
+      deny-misrouted-model-header:
+        when:
+          - predicate: "!request.path.startsWith('/v1/')"
+          - predicate: >-
+              !request.path.matches('^/publishers/[^/]+/models/')
+          - predicate: >-
+              '{{.ModelRoutingHeader}}' in request.headers
+              && request.headers['{{.ModelRoutingHeader}}'].matches('^publishers/[^/]+/models/.+$')
+        patternMatching:
+          patterns:
+            - predicate: "false"
+        priority: 0
+      inference-access:
+        when:
+          - patternRef: has-ns-and-name
+          - predicate: "!request.path.startsWith('/v1/')"
+          - predicate: >-
+              !request.path.matches('^/publishers/[^/]+/models/')
+        kubernetesSubjectAccessReview:
+          user:
+            expression: "auth.identity.resolvedUser"
+          authorizationGroups:
+            expression: "auth.identity.resolvedGroups"
           resourceAttributes:
             group:
               value: serving.kserve.io
@@ -42,7 +138,10 @@ spec:
         priority: 1
       inference-access-delegate:
         when:
-          - predicate: "!(request.path == '/v1/files' || request.path.startsWith('/v1/files/') || request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))"
+          - patternRef: has-ns-and-name
+          - predicate: "!request.path.startsWith('/v1/')"
+          - predicate: >-
+              !request.path.matches('^/publishers/[^/]+/models/')
           - predicate: "'x-maas-user' in request.headers"
         kubernetesSubjectAccessReview:
           user:

--- a/internal/controller/serving/llm/gateway_controller.go
+++ b/internal/controller/serving/llm/gateway_controller.go
@@ -233,10 +233,11 @@ func (r *GatewayReconciler) reconcileAuthPolicy(ctx context.Context, logger logr
 	}
 
 	desired, err := r.authPolicyLoader.Load(ctx, resources.AuthPolicyTarget{
-		Kind:      "Gateway",
-		Name:      gateway.Name,
-		Namespace: gateway.Namespace,
-		AuthType:  constants.UserDefined,
+		Kind:               "Gateway",
+		Name:               gateway.Name,
+		Namespace:          gateway.Namespace,
+		AuthType:           constants.UserDefined,
+		ModelRoutingHeader: utils.GetModelRoutingHeader(ctx, r.Client),
 	},
 		resources.WithLabels(map[string]string{"app.kubernetes.io/name": "llminferenceservice-auth"}),
 		resources.WithAudiences(audiences),
@@ -782,6 +783,36 @@ func hasSelectorListeners(gw *gatewayapiv1.Gateway) bool {
 	return false
 }
 
+// enqueueGatewaysFromConfigMap returns an event handler that enqueues all
+// Gateways when the inferenceservice-config ConfigMap's ingress section changes.
+// This ensures AuthPolicies are re-reconciled on all gateways when
+// modelBasedRoutingHeaderName or the default gateway reference changes.
+func (r *GatewayReconciler) enqueueGatewaysFromConfigMap() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+		podNS := os.Getenv("POD_NAMESPACE")
+		if object.GetName() != constants.InferenceServiceConfigMapName || object.GetNamespace() != podNS {
+			return nil
+		}
+
+		gwList := &gatewayapiv1.GatewayList{}
+		if err := r.Client.List(ctx, gwList); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to list Gateways for ConfigMap change")
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(gwList.Items))
+		for _, gw := range gwList.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      gw.Name,
+					Namespace: gw.Namespace,
+				},
+			})
+		}
+		return requests
+	})
+}
+
 func getConfigGatewayRefs(cfg *kservev1alpha2.LLMInferenceServiceConfig) []kservev1alpha2.GatewayObjectReference {
 	if cfg.Spec.Router != nil && cfg.Spec.Router.Gateway.HasRefs() {
 		return cfg.Spec.Router.Gateway.Refs
@@ -1023,6 +1054,27 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Log
 				},
 				UpdateFunc: func(e event.UpdateEvent) bool {
 					return !maps.Equal(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels())
+				},
+				DeleteFunc: func(_ event.DeleteEvent) bool {
+					return false
+				},
+			})).
+		Watches(&corev1.ConfigMap{},
+			r.enqueueGatewaysFromConfigMap(),
+			ctrlbuilder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(_ event.CreateEvent) bool {
+					return false
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					if e.ObjectNew.GetName() != constants.InferenceServiceConfigMapName {
+						return false
+					}
+					if podNS := os.Getenv("POD_NAMESPACE"); podNS != "" && e.ObjectNew.GetNamespace() != podNS {
+						return false
+					}
+					oldCM := e.ObjectOld.(*corev1.ConfigMap)
+					newCM := e.ObjectNew.(*corev1.ConfigMap)
+					return oldCM.Data["ingress"] != newCM.Data["ingress"]
 				},
 				DeleteFunc: func(_ event.DeleteEvent) bool {
 					return false

--- a/internal/controller/test/e2e/authpolicy_test_env.go
+++ b/internal/controller/test/e2e/authpolicy_test_env.go
@@ -49,8 +49,8 @@ const (
 	defaultEchoServerImage = "docker.io/ealen/echo-server:0.9.2@sha256:006b92e1d6682442e29d1d0d73c34a61166d42f8a5bf1ea10c318f07ad4790e2"
 )
 
-// batchTestEnv holds shared clients and configuration for e2e tests.
-type batchTestEnv struct {
+// authPolicyTestEnv holds shared clients and configuration for e2e tests.
+type authPolicyTestEnv struct {
 	gatewayURL       string
 	gatewayName      string
 	gatewayNamespace string
@@ -64,9 +64,9 @@ type batchTestEnv struct {
 	sharedBatchNS string
 }
 
-// close cleans up resources held by batchTestEnv, such as port-forward tunnels
+// close cleans up resources held by authPolicyTestEnv, such as port-forward tunnels
 // and shared namespaces.
-func (e *batchTestEnv) close() {
+func (e *authPolicyTestEnv) close() {
 	if e.sharedBatchNS != "" {
 		log.Printf("deleting shared batch namespace %s", e.sharedBatchNS)
 		_ = e.clientset.CoreV1().Namespaces().Delete(context.Background(), e.sharedBatchNS, metav1.DeleteOptions{})
@@ -78,10 +78,10 @@ func (e *batchTestEnv) close() {
 }
 
 // newTestEnv reads environment variables, creates Kubernetes clients, discovers
-// the gateway URL from the Gateway resource status, and returns a ready-to-use batchTestEnv.
+// the gateway URL from the Gateway resource status, and returns a ready-to-use authPolicyTestEnv.
 // If the gateway address is cluster-internal, a port-forward tunnel is set up
 // automatically. Call close() when done to release resources.
-func newTestEnv() (*batchTestEnv, error) {
+func newTestEnv() (*authPolicyTestEnv, error) {
 	log.Println("initializing e2e test environment")
 
 	gwName := os.Getenv("GATEWAY_NAME")
@@ -130,48 +130,53 @@ func newTestEnv() (*batchTestEnv, error) {
 		},
 	}
 
-	// Discover gateway address from the Gateway resource status.
-	log.Printf("discovering gateway address from %s/%s status...", gwNamespace, gwName)
-	gw := &gatewayapiv1.Gateway{}
-	if err := k8sClient.Get(context.Background(), client.ObjectKey{
-		Name:      gwName,
-		Namespace: gwNamespace,
-	}, gw); err != nil {
-		return nil, fmt.Errorf("get gateway %s/%s: %w", gwNamespace, gwName, err)
-	}
-
-	if len(gw.Status.Addresses) == 0 {
-		return nil, fmt.Errorf("gateway %s/%s has no addresses in status", gwNamespace, gwName)
-	}
-
-	gwAddr := gw.Status.Addresses[0].Value
-	gwPort := gatewayListenerPort(gw)
-	log.Printf("gateway address: %s, listener port: %d", gwAddr, gwPort)
-
 	var gatewayURL string
 	var portForwardStop chan struct{}
 
-	if isInternalAddress(gwAddr) {
-		log.Printf("gateway address %s is cluster-internal, setting up port-forward...", gwAddr)
-		localPort, stopCh, pfErr := portForwardToGateway(cfg, clientset, gwNamespace, gwAddr, gwPort)
-		if pfErr != nil {
-			return nil, fmt.Errorf("gateway address %s is cluster-internal, port-forward failed: %w", gwAddr, pfErr)
-		}
-		portForwardStop = stopCh
-		gatewayURL = fmt.Sprintf("http://localhost:%d", localPort)
-		log.Printf("port-forward established: %s -> localhost:%d", gwAddr, localPort)
+	if envURL := os.Getenv("GATEWAY_URL"); envURL != "" {
+		gatewayURL = envURL
+		log.Printf("using GATEWAY_URL from environment: %s", gatewayURL)
 	} else {
-		log.Printf("gateway address %s is externally reachable, using directly", gwAddr)
-		if gwPort == 80 {
-			gatewayURL = "http://" + gwAddr
+		// Discover gateway address from the Gateway resource status.
+		log.Printf("discovering gateway address from %s/%s status...", gwNamespace, gwName)
+		gw := &gatewayapiv1.Gateway{}
+		if err := k8sClient.Get(context.Background(), client.ObjectKey{
+			Name:      gwName,
+			Namespace: gwNamespace,
+		}, gw); err != nil {
+			return nil, fmt.Errorf("get gateway %s/%s: %w", gwNamespace, gwName, err)
+		}
+
+		if len(gw.Status.Addresses) == 0 {
+			return nil, fmt.Errorf("gateway %s/%s has no addresses in status", gwNamespace, gwName)
+		}
+
+		gwAddr := gw.Status.Addresses[0].Value
+		gwPort := gatewayListenerPort(gw)
+		log.Printf("gateway address: %s, listener port: %d", gwAddr, gwPort)
+
+		if isInternalAddress(gwAddr) {
+			log.Printf("gateway address %s is cluster-internal, setting up port-forward...", gwAddr)
+			localPort, stopCh, pfErr := portForwardToGateway(cfg, clientset, gwNamespace, gwAddr, gwPort)
+			if pfErr != nil {
+				return nil, fmt.Errorf("gateway address %s is cluster-internal, port-forward failed: %w", gwAddr, pfErr)
+			}
+			portForwardStop = stopCh
+			gatewayURL = fmt.Sprintf("http://localhost:%d", localPort)
+			log.Printf("port-forward established: %s -> localhost:%d", gwAddr, localPort)
 		} else {
-			gatewayURL = fmt.Sprintf("http://%s", net.JoinHostPort(gwAddr, fmt.Sprintf("%d", gwPort)))
+			log.Printf("gateway address %s is externally reachable, using directly", gwAddr)
+			if gwPort == 80 {
+				gatewayURL = "http://" + gwAddr
+			} else {
+				gatewayURL = fmt.Sprintf("http://%s", net.JoinHostPort(gwAddr, fmt.Sprintf("%d", gwPort)))
+			}
 		}
 	}
 
 	log.Printf("e2e environment ready, gateway URL: %s", gatewayURL)
 
-	env := &batchTestEnv{
+	env := &authPolicyTestEnv{
 		gatewayURL:       gatewayURL,
 		gatewayName:      gwName,
 		gatewayNamespace: gwNamespace,
@@ -193,7 +198,7 @@ func newTestEnv() (*batchTestEnv, error) {
 // setupSharedBatchRoutes creates the shared namespace, echo server, and
 // HTTPRoutes for /v1/batches and /v1/files. Called once during env init
 // (not bound to any test's lifecycle).
-func (e *batchTestEnv) setupSharedBatchRoutes() error {
+func (e *authPolicyTestEnv) setupSharedBatchRoutes() error {
 	log.Println("setting up shared batch routes...")
 
 	ctx := context.Background()
@@ -202,7 +207,7 @@ func (e *batchTestEnv) setupSharedBatchRoutes() error {
 	ns, err := e.clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "e2e-batch-shared-",
-			Labels:       map[string]string{"batchTestEnv": "odh-test"},
+			Labels:       map[string]string{"authPolicyTestEnv": "odh-test"},
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
@@ -267,10 +272,14 @@ func (e *batchTestEnv) setupSharedBatchRoutes() error {
 		return fmt.Errorf("echo-server not ready in %s: %w", ns.Name, err)
 	}
 
-	// Create HTTPRoutes for batch paths.
+	// Create HTTPRoutes for batch paths and a catch-all for paths that don't
+	// have a test-specific route (/health, /v1/models, etc.). The catch-all
+	// lives here (not per-test) to avoid races when parallel tests create and
+	// delete competing PathPrefix "/" routes.
 	for _, r := range []struct{ name, path string }{
 		{"batch-routes-batches", "/v1/batches"},
 		{"batch-routes-files", "/v1/files"},
+		{"catch-all", "/"},
 	} {
 		if err := e.createHTTPRouteRaw(ctx, ns.Name, r.name, r.path); err != nil {
 			return err
@@ -284,7 +293,10 @@ func (e *batchTestEnv) setupSharedBatchRoutes() error {
 	}
 	expSeconds := int64(3600)
 	tokenResult, err := e.clientset.CoreV1().ServiceAccounts(ns.Name).CreateToken(ctx, "route-checker",
-		&authenticationv1.TokenRequest{Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: &expSeconds}},
+		&authenticationv1.TokenRequest{Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expSeconds,
+			Audiences:         []string{"https://kubernetes.default.svc"},
+		}},
 		metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("request route-checker token: %w", err)
@@ -297,7 +309,7 @@ func (e *batchTestEnv) setupSharedBatchRoutes() error {
 			if reqErr != nil {
 				return false, nil
 			}
-			return resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable, nil
+			return resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable && resp.StatusCode != http.StatusNotFound, nil
 		}); err != nil {
 		return fmt.Errorf("batch routes not reachable: %w", err)
 	}
@@ -307,7 +319,7 @@ func (e *batchTestEnv) setupSharedBatchRoutes() error {
 }
 
 // createHTTPRouteRaw creates an HTTPRoute without test helpers (for use in init).
-func (e *batchTestEnv) createHTTPRouteRaw(ctx context.Context, ns, name, pathPrefix string) error {
+func (e *authPolicyTestEnv) createHTTPRouteRaw(ctx context.Context, ns, name, pathPrefix string) error {
 	log.Printf("creating HTTPRoute %s/%s for path prefix %s", ns, name, pathPrefix)
 	gwNS := gatewayapiv1.Namespace(e.gatewayNamespace)
 	route := &gatewayapiv1.HTTPRoute{
@@ -528,10 +540,10 @@ func findGatewayService(clientset *kubernetes.Clientset, gwNS, gwAddr string) (*
 
 // createNamespace creates a namespace with a generated name based on the given
 // prefix. The namespace is deleted on test cleanup unless the test failed.
-func (e *batchTestEnv) createNamespace(t *testing.T, prefix string, labels map[string]string) string {
+func (e *authPolicyTestEnv) createNamespace(t *testing.T, prefix string, labels map[string]string) string {
 	t.Helper()
 
-	merged := map[string]string{"batchTestEnv": "odh-test"}
+	merged := map[string]string{"authPolicyTestEnv": "odh-test"}
 	for k, v := range labels {
 		merged[k] = v
 	}
@@ -562,7 +574,7 @@ func (e *batchTestEnv) createNamespace(t *testing.T, prefix string, labels map[s
 }
 
 // createServiceAccount creates a ServiceAccount in the given namespace.
-func (e *batchTestEnv) createServiceAccount(t *testing.T, ns, name string) {
+func (e *authPolicyTestEnv) createServiceAccount(t *testing.T, ns, name string) {
 	t.Helper()
 	t.Logf("creating service account %s/%s", ns, name)
 	sa := &corev1.ServiceAccount{
@@ -581,7 +593,9 @@ func (e *batchTestEnv) createServiceAccount(t *testing.T, ns, name string) {
 }
 
 // requestToken creates a short-lived token for the given ServiceAccount.
-func (e *batchTestEnv) requestToken(t *testing.T, ns, saName string) string {
+// The token includes the Kubernetes default audience required by the AuthPolicy's
+// kubernetesTokenReview configuration.
+func (e *authPolicyTestEnv) requestToken(t *testing.T, ns, saName string) string {
 	t.Helper()
 	t.Logf("requesting token for %s/%s", ns, saName)
 	expSeconds := int64(3600)
@@ -591,6 +605,7 @@ func (e *batchTestEnv) requestToken(t *testing.T, ns, saName string) string {
 		&authenticationv1.TokenRequest{
 			Spec: authenticationv1.TokenRequestSpec{
 				ExpirationSeconds: &expSeconds,
+				Audiences:         []string{"https://kubernetes.default.svc"},
 			},
 		},
 		metav1.CreateOptions{},
@@ -603,7 +618,7 @@ func (e *batchTestEnv) requestToken(t *testing.T, ns, saName string) string {
 
 // grantInferenceAccess creates a Role and RoleBinding in targetNS that grants
 // the ServiceAccount permission to get llminferenceservices.
-func (e *batchTestEnv) grantInferenceAccess(t *testing.T, targetNS, saNamespace, saName string) {
+func (e *authPolicyTestEnv) grantInferenceAccess(t *testing.T, targetNS, saNamespace, saName string) {
 	t.Helper()
 	e.grantAccess(t, targetNS, saNamespace, saName,
 		saName+"-inference-access",
@@ -617,7 +632,7 @@ func (e *batchTestEnv) grantInferenceAccess(t *testing.T, targetNS, saNamespace,
 
 // grantDelegateAccess creates a Role and RoleBinding in targetNS that grants
 // the ServiceAccount permission to post-delegate llminferenceservices/delegate.
-func (e *batchTestEnv) grantDelegateAccess(t *testing.T, targetNS, saNamespace, saName string) {
+func (e *authPolicyTestEnv) grantDelegateAccess(t *testing.T, targetNS, saNamespace, saName string) {
 	t.Helper()
 	e.grantAccess(t, targetNS, saNamespace, saName,
 		saName+"-delegate-access",
@@ -629,7 +644,50 @@ func (e *batchTestEnv) grantDelegateAccess(t *testing.T, targetNS, saNamespace, 
 	)
 }
 
-func (e *batchTestEnv) grantAccess(t *testing.T, targetNS, saNamespace, saName, roleName string, rules []rbacv1.PolicyRule) {
+// grantModelAccess creates a Role and RoleBinding in targetNS that grants
+// the ServiceAccount permission to post models (serving.opendatahub.io/models).
+func (e *authPolicyTestEnv) grantModelAccess(t *testing.T, targetNS, saNamespace, saName string) {
+	t.Helper()
+	e.grantAccess(t, targetNS, saNamespace, saName,
+		saName+"-model-access",
+		[]rbacv1.PolicyRule{{
+			APIGroups: []string{"serving.opendatahub.io"},
+			Resources: []string{"models"},
+			Verbs:     []string{"post"},
+		}},
+	)
+}
+
+// grantScopedModelAccess creates a Role and RoleBinding in targetNS that grants
+// the ServiceAccount permission to post a specific named model.
+func (e *authPolicyTestEnv) grantScopedModelAccess(t *testing.T, targetNS, saNamespace, saName, resourceName string) {
+	t.Helper()
+	e.grantAccess(t, targetNS, saNamespace, saName,
+		saName+"-scoped-model-access",
+		[]rbacv1.PolicyRule{{
+			APIGroups:     []string{"serving.opendatahub.io"},
+			Resources:     []string{"models"},
+			ResourceNames: []string{resourceName},
+			Verbs:         []string{"serve"},
+		}},
+	)
+}
+
+// grantModelDelegateAccess creates a Role and RoleBinding in targetNS that grants
+// the ServiceAccount permission to post-delegate models/delegate.
+func (e *authPolicyTestEnv) grantModelDelegateAccess(t *testing.T, targetNS, saNamespace, saName string) {
+	t.Helper()
+	e.grantAccess(t, targetNS, saNamespace, saName,
+		saName+"-model-delegate-access",
+		[]rbacv1.PolicyRule{{
+			APIGroups: []string{"serving.opendatahub.io"},
+			Resources: []string{"models/delegate"},
+			Verbs:     []string{"post-delegate"},
+		}},
+	)
+}
+
+func (e *authPolicyTestEnv) grantAccess(t *testing.T, targetNS, saNamespace, saName, roleName string, rules []rbacv1.PolicyRule) {
 	t.Helper()
 	t.Logf("granting RBAC %s to %s/%s in namespace %s", roleName, saNamespace, saName, targetNS)
 
@@ -676,7 +734,7 @@ func (e *batchTestEnv) grantAccess(t *testing.T, targetNS, saNamespace, saName, 
 
 // deployEchoServer creates an echo server Deployment and Service in the given
 // namespace and waits for it to become ready.
-func (e *batchTestEnv) deployEchoServer(t *testing.T, ns string) {
+func (e *authPolicyTestEnv) deployEchoServer(t *testing.T, ns string) {
 	t.Helper()
 	t.Logf("deploying echo server in namespace %s (image: %s)", ns, e.echoServerImage)
 
@@ -767,7 +825,7 @@ func (e *batchTestEnv) deployEchoServer(t *testing.T, ns string) {
 }
 
 // createHTTPRoute creates an HTTPRoute pointing to the echo-server Service.
-func (e *batchTestEnv) createHTTPRoute(t *testing.T, ns, name, pathPrefix string) {
+func (e *authPolicyTestEnv) createHTTPRoute(t *testing.T, ns, name, pathPrefix string) {
 	t.Helper()
 	t.Logf("creating HTTPRoute %s/%s for path prefix %s", ns, name, pathPrefix)
 
@@ -815,7 +873,7 @@ func (e *batchTestEnv) createHTTPRoute(t *testing.T, ns, name, pathPrefix string
 // waitForAuthPolicyAffected polls the HTTPRoute status until the Kuadrant policy
 // controller reports the route is affected by an AuthPolicy. This ensures the
 // AuthPolicy ext-authz filter is active before tests send requests.
-func (e *batchTestEnv) waitForAuthPolicyAffected(t *testing.T, ns, name string) {
+func (e *authPolicyTestEnv) waitForAuthPolicyAffected(t *testing.T, ns, name string) {
 	t.Helper()
 	t.Logf("waiting for AuthPolicy to be enforced on HTTPRoute %s/%s...", ns, name)
 
@@ -857,7 +915,7 @@ func (e *batchTestEnv) waitForAuthPolicyAffected(t *testing.T, ns, name string) 
 
 // gatewayDo performs a single HTTP GET through the gateway. Returns the response,
 // body, and any error. Callers are responsible for handling errors.
-func (e *batchTestEnv) gatewayDo(path, token string, extraHeaders map[string]string) (*http.Response, []byte, error) {
+func (e *authPolicyTestEnv) gatewayDo(path, token string, extraHeaders map[string]string) (*http.Response, []byte, error) {
 	url := e.gatewayURL + path
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 	if err != nil {
@@ -889,7 +947,7 @@ func (e *batchTestEnv) gatewayDo(path, token string, extraHeaders map[string]str
 // gatewayGet performs an HTTP GET through the gateway with bearer token and
 // optional extra headers. Retries on transient errors (502, 503, connection
 // failures) up to requestRetries times. Returns the response and body bytes.
-func (e *batchTestEnv) gatewayGet(t *testing.T, path, token string, extraHeaders map[string]string) (*http.Response, []byte) {
+func (e *authPolicyTestEnv) gatewayGet(t *testing.T, path, token string, extraHeaders map[string]string) (*http.Response, []byte) {
 	t.Helper()
 
 	var lastResp *http.Response
@@ -923,7 +981,7 @@ func (e *batchTestEnv) gatewayGet(t *testing.T, path, token string, extraHeaders
 
 // waitForGatewayRoute polls the gateway until the given path returns a non-502/503
 // response, indicating the HTTPRoute has been accepted and the backend is reachable.
-func (e *batchTestEnv) waitForGatewayRoute(t *testing.T, path, token string) {
+func (e *authPolicyTestEnv) waitForGatewayRoute(t *testing.T, path, token string) {
 	t.Helper()
 	t.Logf("waiting for gateway route %s to become reachable...", path)
 	err := wait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true,
@@ -932,7 +990,7 @@ func (e *batchTestEnv) waitForGatewayRoute(t *testing.T, path, token string) {
 			if reqErr != nil {
 				return false, nil // transient — keep polling
 			}
-			return resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable, nil
+			return resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable && resp.StatusCode != http.StatusNotFound, nil
 		})
 	if err != nil {
 		t.Fatalf("timed out waiting for gateway route %s to become ready", path)

--- a/internal/controller/test/e2e/batch_authpolicy_test.go
+++ b/internal/controller/test/e2e/batch_authpolicy_test.go
@@ -27,26 +27,26 @@ type testFixture struct {
 // ServiceAccounts, and RBAC bindings needed by the batch AuthPolicy tests.
 //
 // Shared batch HTTPRoutes (/v1/batches, /v1/files) are created once in TestMain
-// via batchEnv.setupSharedBatchRoutes().
+// via authEnv.setupSharedBatchRoutes().
 //
 // The inference HTTPRoute (/{ns}/echo-server/...) is unique per namespace.
 func setupFixture(t *testing.T) *testFixture {
 	t.Helper()
 
-	ns := batchEnv.createNamespace(t, "e2e-batch", nil)
-	batchEnv.deployEchoServer(t, ns)
-	batchEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	ns := authEnv.createNamespace(t, "e2e-batch", nil)
+	authEnv.deployEchoServer(t, ns)
+	authEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
 
-	batchEnv.createServiceAccount(t, ns, saTestUser)
-	batchEnv.createServiceAccount(t, ns, saTestDelegate)
-	batchEnv.grantInferenceAccess(t, ns, ns, saTestUser)
-	batchEnv.grantInferenceAccess(t, ns, ns, saTestDelegate)
-	batchEnv.grantDelegateAccess(t, ns, ns, saTestDelegate)
+	authEnv.createServiceAccount(t, ns, saTestUser)
+	authEnv.createServiceAccount(t, ns, saTestDelegate)
+	authEnv.grantInferenceAccess(t, ns, ns, saTestUser)
+	authEnv.grantInferenceAccess(t, ns, ns, saTestDelegate)
+	authEnv.grantDelegateAccess(t, ns, ns, saTestDelegate)
 
-	testUserToken := batchEnv.requestToken(t, ns, saTestUser)
-	testDelegateToken := batchEnv.requestToken(t, ns, saTestDelegate)
+	testUserToken := authEnv.requestToken(t, ns, saTestUser)
+	testDelegateToken := authEnv.requestToken(t, ns, saTestDelegate)
 
-	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), testUserToken)
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), testUserToken)
 	t.Log("fixture setup complete")
 
 	return &testFixture{
@@ -70,7 +70,7 @@ func TestBatchPathAuthnOnly(t *testing.T) {
 	t.Parallel()
 	f := setupFixture(t)
 
-	resp, body := batchEnv.gatewayGet(t, "/v1/batches", f.testUserToken, nil)
+	resp, body := authEnv.gatewayGet(t, "/v1/batches", f.testUserToken, nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -90,7 +90,7 @@ func TestFilesPathAuthnOnly(t *testing.T) {
 	t.Parallel()
 	f := setupFixture(t)
 
-	resp, body := batchEnv.gatewayGet(t, "/v1/files", f.testUserToken, nil)
+	resp, body := authEnv.gatewayGet(t, "/v1/files", f.testUserToken, nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -111,7 +111,7 @@ func TestFilesPathSpoofedHeader(t *testing.T) {
 	headers := map[string]string{
 		"x-maas-user": "spoofed-user",
 	}
-	resp, _ := batchEnv.gatewayGet(t, "/v1/files", f.testUserToken, headers)
+	resp, _ := authEnv.gatewayGet(t, "/v1/files", f.testUserToken, headers)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -122,7 +122,7 @@ func TestFilesPathSpoofedHeader(t *testing.T) {
 func TestNoTokenReturns401(t *testing.T) {
 	t.Parallel()
 
-	resp, _ := batchEnv.gatewayGet(t, "/v1/batches", "", nil)
+	resp, _ := authEnv.gatewayGet(t, "/v1/batches", "", nil)
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", resp.StatusCode)
 	}
@@ -134,18 +134,18 @@ func TestNoTokenReturns401(t *testing.T) {
 func TestInferencePathNoRBAC(t *testing.T) {
 	t.Parallel()
 
-	ns := batchEnv.createNamespace(t, "e2e-batch", nil)
-	batchEnv.deployEchoServer(t, ns)
-	batchEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	ns := authEnv.createNamespace(t, "e2e-batch", nil)
+	authEnv.deployEchoServer(t, ns)
+	authEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
 
 	// Create SA with no RBAC at all.
-	batchEnv.createServiceAccount(t, ns, "no-rbac-user")
-	token := batchEnv.requestToken(t, ns, "no-rbac-user")
+	authEnv.createServiceAccount(t, ns, "no-rbac-user")
+	token := authEnv.requestToken(t, ns, "no-rbac-user")
 
-	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), token)
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), token)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", ns)
-	resp, _ := batchEnv.gatewayGet(t, path, token, nil)
+	resp, _ := authEnv.gatewayGet(t, path, token, nil)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
@@ -160,7 +160,7 @@ func TestInferencePathStandardSAR(t *testing.T) {
 	f := setupFixture(t)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", f.ns)
-	resp, _ := batchEnv.gatewayGet(t, path, f.testUserToken, nil)
+	resp, _ := authEnv.gatewayGet(t, path, f.testUserToken, nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -180,7 +180,7 @@ func TestInferencePathDelegatedSAR(t *testing.T) {
 		"x-maas-user": saIdentity(f.ns, saTestUser),
 	}
 	// Caller is test-user-delegate (has post-delegate), forwarded user is test-user (has get).
-	resp, _ := batchEnv.gatewayGet(t, path, f.testDelegateToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, f.testDelegateToken, headers)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -198,7 +198,7 @@ func TestBatchPathSpoofedHeader(t *testing.T) {
 	headers := map[string]string{
 		"x-maas-user": "spoofed-user",
 	}
-	resp, _ := batchEnv.gatewayGet(t, "/v1/batches", f.testUserToken, headers)
+	resp, _ := authEnv.gatewayGet(t, "/v1/batches", f.testUserToken, headers)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -218,7 +218,7 @@ func TestInferencePathSpoofedNoRBAC(t *testing.T) {
 		"x-maas-user": "nonexistent-user",
 	}
 	// Caller is test-user-delegate (has post-delegate), forwarded user has no RBAC.
-	resp, _ := batchEnv.gatewayGet(t, path, f.testDelegateToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, f.testDelegateToken, headers)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
@@ -240,7 +240,7 @@ func TestInferencePathDelegatedNoDelegate(t *testing.T) {
 		"x-maas-user": saIdentity(f.ns, saTestDelegate),
 	}
 	// Caller is test-user (no post-delegate), forwarded user is test-user-delegate (has get).
-	resp, _ := batchEnv.gatewayGet(t, path, f.testUserToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, f.testUserToken, headers)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
@@ -253,28 +253,28 @@ func TestInferencePathDelegatedNoDelegate(t *testing.T) {
 func TestInferencePathDelegateVerbWrongResource(t *testing.T) {
 	t.Parallel()
 
-	ns := batchEnv.createNamespace(t, "e2e-batch", nil)
-	batchEnv.deployEchoServer(t, ns)
-	batchEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	ns := authEnv.createNamespace(t, "e2e-batch", nil)
+	authEnv.deployEchoServer(t, ns)
+	authEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
 
 	// Create caller SA with post-delegate on llminferenceservices (wrong resource —
 	// should be llminferenceservices/delegate).
 	const saCaller = "wrong-resource-caller"
-	batchEnv.createServiceAccount(t, ns, saCaller)
-	batchEnv.grantInferenceAccess(t, ns, ns, saCaller)
-	batchEnv.grantAccess(t, ns, ns, saCaller, saCaller+"-wrong-resource", []rbacv1.PolicyRule{{
+	authEnv.createServiceAccount(t, ns, saCaller)
+	authEnv.grantInferenceAccess(t, ns, ns, saCaller)
+	authEnv.grantAccess(t, ns, ns, saCaller, saCaller+"-wrong-resource", []rbacv1.PolicyRule{{
 		APIGroups: []string{"serving.kserve.io"},
 		Resources: []string{"llminferenceservices"},
 		Verbs:     []string{"post-delegate"},
 	}})
-	callerToken := batchEnv.requestToken(t, ns, saCaller)
+	callerToken := authEnv.requestToken(t, ns, saCaller)
 
 	// Create forwarded user SA with standard inference access (rule 1 passes).
 	const saForwarded = "forwarded-user"
-	batchEnv.createServiceAccount(t, ns, saForwarded)
-	batchEnv.grantInferenceAccess(t, ns, ns, saForwarded)
+	authEnv.createServiceAccount(t, ns, saForwarded)
+	authEnv.grantInferenceAccess(t, ns, ns, saForwarded)
 
-	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), callerToken)
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), callerToken)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", ns)
 	headers := map[string]string{
@@ -282,7 +282,7 @@ func TestInferencePathDelegateVerbWrongResource(t *testing.T) {
 	}
 	// Rule 1: forwarded-user has get → pass. Rule 2: caller has post-delegate on
 	// wrong resource (llminferenceservices, not llminferenceservices/delegate) → fail.
-	resp, _ := batchEnv.gatewayGet(t, path, callerToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, callerToken, headers)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
@@ -295,7 +295,7 @@ func TestInferencePathNoToken(t *testing.T) {
 	f := setupFixture(t)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", f.ns)
-	resp, _ := batchEnv.gatewayGet(t, path, "", nil)
+	resp, _ := authEnv.gatewayGet(t, path, "", nil)
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", resp.StatusCode)
 	}
@@ -308,29 +308,29 @@ func TestInferencePathNoToken(t *testing.T) {
 func TestDelegatedForwardedUserDelegateOnlyNoGet(t *testing.T) {
 	t.Parallel()
 
-	ns := batchEnv.createNamespace(t, "e2e-batch", nil)
-	batchEnv.deployEchoServer(t, ns)
-	batchEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	ns := authEnv.createNamespace(t, "e2e-batch", nil)
+	authEnv.deployEchoServer(t, ns)
+	authEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
 
 	// Caller SA with both get and post-delegate (rule 2 passes).
 	const saCaller = "delegate-caller"
-	batchEnv.createServiceAccount(t, ns, saCaller)
-	batchEnv.grantInferenceAccess(t, ns, ns, saCaller)
-	batchEnv.grantDelegateAccess(t, ns, ns, saCaller)
-	callerToken := batchEnv.requestToken(t, ns, saCaller)
+	authEnv.createServiceAccount(t, ns, saCaller)
+	authEnv.grantInferenceAccess(t, ns, ns, saCaller)
+	authEnv.grantDelegateAccess(t, ns, ns, saCaller)
+	callerToken := authEnv.requestToken(t, ns, saCaller)
 
 	// Forwarded user SA with post-delegate but NO get (rule 1 fails).
 	const saForwarded = "delegate-only-user"
-	batchEnv.createServiceAccount(t, ns, saForwarded)
-	batchEnv.grantDelegateAccess(t, ns, ns, saForwarded)
+	authEnv.createServiceAccount(t, ns, saForwarded)
+	authEnv.grantDelegateAccess(t, ns, ns, saForwarded)
 
-	batchEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), callerToken)
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), callerToken)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", ns)
 	headers := map[string]string{
 		"x-maas-user": saIdentity(ns, saForwarded),
 	}
-	resp, _ := batchEnv.gatewayGet(t, path, callerToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, callerToken, headers)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
@@ -351,7 +351,7 @@ func TestBatchSubpathAuthnOnly(t *testing.T) {
 	}
 	for _, sp := range subpaths {
 		t.Run(sp, func(t *testing.T) {
-			resp, _ := batchEnv.gatewayGet(t, sp, f.testUserToken, nil)
+			resp, _ := authEnv.gatewayGet(t, sp, f.testUserToken, nil)
 			if resp.StatusCode != http.StatusOK {
 				t.Fatalf("expected 200, got %d", resp.StatusCode)
 			}
@@ -373,7 +373,7 @@ func TestDelegatedSelfDelegation(t *testing.T) {
 	// Caller is test-user-delegate, forwarded user is also test-user-delegate.
 	// Rule 1: forwarded user (test-user-delegate) has get → pass.
 	// Rule 2: caller (test-user-delegate) has post-delegate → pass.
-	resp, _ := batchEnv.gatewayGet(t, path, f.testDelegateToken, headers)
+	resp, _ := authEnv.gatewayGet(t, path, f.testDelegateToken, headers)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -387,7 +387,7 @@ func TestInferencePathNoBatchHeaders(t *testing.T) {
 	f := setupFixture(t)
 
 	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", f.ns)
-	resp, body := batchEnv.gatewayGet(t, path, f.testUserToken, nil)
+	resp, body := authEnv.gatewayGet(t, path, f.testUserToken, nil)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}

--- a/internal/controller/test/e2e/publisher_path_authpolicy_test.go
+++ b/internal/controller/test/e2e/publisher_path_authpolicy_test.go
@@ -1,0 +1,244 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// publisherFixture holds per-test resources for publisher-path authorization tests.
+type publisherFixture struct {
+	ns                string
+	modelUserToken    string
+	noAccessToken     string
+	delegateToken     string
+	instanceUserToken string
+}
+
+// setupPublisherFixture creates a namespace with an echo server, HTTPRoutes for
+// publisher and per-participant paths, and ServiceAccounts with model-level and
+// instance-level RBAC.
+func setupPublisherFixture(t *testing.T) *publisherFixture {
+	t.Helper()
+
+	ns := authEnv.createNamespace(t, "e2e-publisher", nil)
+	authEnv.deployEchoServer(t, ns)
+
+	// Per-participant inference route (backward compat).
+	authEnv.createHTTPRoute(t, ns, "echo-inference", fmt.Sprintf("/%s/echo-server", ns))
+	// Publisher route: /publishers/<ns>/models/echo-server
+	authEnv.createHTTPRoute(t, ns, "echo-publisher", fmt.Sprintf("/publishers/%s/models/echo-server", ns))
+
+	// model-user: has model-level serve access on ALL models (publisher paths).
+	authEnv.createServiceAccount(t, ns, "model-user")
+	authEnv.grantModelAccess(t, ns, ns, "model-user")
+
+	// no-access: authenticated but no RBAC at all.
+	authEnv.createServiceAccount(t, ns, "no-access")
+
+	// delegate-user: has model serve + serve-delegate (for delegation tests).
+	authEnv.createServiceAccount(t, ns, "delegate-user")
+	authEnv.grantModelAccess(t, ns, ns, "delegate-user")
+	authEnv.grantModelDelegateAccess(t, ns, ns, "delegate-user")
+
+	// instance-user: has instance-level get access only (per-participant paths).
+	authEnv.createServiceAccount(t, ns, "instance-user")
+	authEnv.grantInferenceAccess(t, ns, ns, "instance-user")
+
+	modelUserToken := authEnv.requestToken(t, ns, "model-user")
+	noAccessToken := authEnv.requestToken(t, ns, "no-access")
+	delegateToken := authEnv.requestToken(t, ns, "delegate-user")
+	instanceUserToken := authEnv.requestToken(t, ns, "instance-user")
+
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/%s/echo-server/test", ns), instanceUserToken)
+	authEnv.waitForGatewayRoute(t, fmt.Sprintf("/publishers/%s/models/echo-server/test", ns), modelUserToken)
+	t.Log("publisher fixture setup complete")
+
+	return &publisherFixture{
+		ns:                ns,
+		modelUserToken:    modelUserToken,
+		noAccessToken:     noAccessToken,
+		delegateToken:     delegateToken,
+		instanceUserToken: instanceUserToken,
+	}
+}
+
+// --- Publisher-path model-access rules ---
+
+func TestPublisherPathModelAccess(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestPublisherPathNoModelRBAC(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	resp, _ := authEnv.gatewayGet(t, path, f.noAccessToken, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestPublisherPathMultiSegmentModelName(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// Multi-segment model name via direct publisher path. model-user has broad
+	// (unscoped) serve on all models, so this should pass.
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/variant/v1/chat/completions", f.ns)
+	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (broad RBAC covers multi-segment model), got %d", resp.StatusCode)
+	}
+}
+
+// --- Cross-RBAC type ---
+
+func TestModelUserOnParticipantPathNoInstanceRBAC(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// model-user has model RBAC but not instance RBAC. Per-participant path
+	// uses inference-access which checks instance SAR -> 403.
+	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", f.ns)
+	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+// --- Namespace collision: ns=publishers ---
+
+func TestNsPublishersParticipantPath(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// /publishers/some-model/v1/... has /v1/ not /models/ after the namespace
+	// segment. Regex requires /publishers/<ns>/models/ so model-access-path
+	// does NOT fire. inference-access fires -> instance SAR -> no RBAC -> 403.
+	resp, _ := authEnv.gatewayGet(t, "/publishers/some-model/v1/chat/completions", f.instanceUserToken, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestNsPublishersPublisherRouteWrongNamespace(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// model-access-path fires but extracts namespace='publishers' which
+	// doesn't match the RBAC namespace.
+	path := "/publishers/publishers/models/echo-server/v1/chat/completions"
+	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+// --- Cross-tenant deny ---
+
+func TestPerParticipantPathWithHeaderDenied(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// Per-participant path + valid model header = routing/authorization identity
+	// mismatch. deny-misrouted-model-header fires -> 403.
+	path := fmt.Sprintf("/%s/echo-server/v1/chat/completions", f.ns)
+	headers := map[string]string{
+		"x-gateway-model-name": fmt.Sprintf("publishers/%s/models/echo-server", f.ns),
+	}
+	resp, _ := authEnv.gatewayGet(t, path, f.instanceUserToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (deny-misrouted blocks cross-tenant mismatch), got %d", resp.StatusCode)
+	}
+}
+
+// --- Exclusion boundaries ---
+
+func TestV1ModelsAuthnOnly(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	resp, _ := authEnv.gatewayGet(t, "/v1/models", f.noAccessToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (authn-only), got %d", resp.StatusCode)
+	}
+}
+
+func TestV1PathExcludedFromInferenceAccess(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", f.noAccessToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (authn-only, inference-access excluded from /v1/), got %d", resp.StatusCode)
+	}
+}
+
+func TestHealthPathDepthGuard(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	resp, _ := authEnv.gatewayGet(t, "/health", f.noAccessToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (short path, patternRef guard), got %d", resp.StatusCode)
+	}
+}
+
+func TestEmptyModelHeaderAuthnOnlyFallthrough(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// Empty model header: CEL 'header in request.headers' matches empty string,
+	// but the regex doesn't match empty -> deny rule doesn't fire, no model-access
+	// rule fires, authn-only.
+	headers := map[string]string{
+		"x-gateway-model-name": "",
+	}
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", f.modelUserToken, headers)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (empty header, authn-only fallthrough), got %d", resp.StatusCode)
+	}
+}
+
+// --- Delegation on publisher paths ---
+
+func TestDelegatedModelAccess(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	headers := map[string]string{
+		"x-maas-user": saIdentity(f.ns, "model-user"),
+	}
+	// Caller (delegate-user) has serve-delegate, forwarded user (model-user) has serve.
+	resp, _ := authEnv.gatewayGet(t, path, f.delegateToken, headers)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestSpoofedModelAccessCallerLacksDelegate(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	headers := map[string]string{
+		"x-maas-user": saIdentity(f.ns, "delegate-user"),
+	}
+	// Caller (model-user) lacks serve-delegate, so model-access-path-delegate fails.
+	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}

--- a/internal/controller/test/e2e/suite_test.go
+++ b/internal/controller/test/e2e/suite_test.go
@@ -8,17 +8,17 @@ import (
 	"testing"
 )
 
-var batchEnv *batchTestEnv
+var authEnv *authPolicyTestEnv
 
 func TestMain(m *testing.M) {
 	var err error
-	batchEnv, err = newTestEnv()
+	authEnv, err = newTestEnv()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "failed to initialize e2e environment: %v\n", err)
 		os.Exit(1)
 	}
 
 	code := m.Run()
-	batchEnv.close()
+	authEnv.close()
 	os.Exit(code)
 }

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/net/http/httpguts"
+
 	ocpconfigv1 "github.com/openshift/api/config/v1"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -323,6 +325,45 @@ func GetDefaultGatewayRef(ctx context.Context, cli client.Client) (namespace, na
 	}
 
 	return "", "", fmt.Errorf("failed to parse gateway info from configmap")
+}
+
+// GetModelRoutingHeader returns the model-based routing header name from the
+// inferenceservice-config ConfigMap (ingress.modelBasedRoutingHeaderName),
+// falling back to DefaultModelRoutingHeader if unavailable or not set.
+// The value is lowercased to match Authorino's header key normalization and
+// validated as an HTTP token (RFC 7230) to prevent CEL injection via the
+// template.
+func GetModelRoutingHeader(ctx context.Context, cli client.Client) string {
+	configMap, err := GetInferenceServiceConfigMap(ctx, cli)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("inferenceservice-config unavailable, using default model routing header", "error", err)
+		return constants.DefaultModelRoutingHeader
+	}
+
+	if ingressData := configMap.Data["ingress"]; ingressData != "" {
+		var config map[string]any
+		if err := json.Unmarshal([]byte(ingressData), &config); err != nil {
+			log.FromContext(ctx).V(0).Info("failed to parse inferenceservice-config ingress section", "error", err)
+		} else {
+			if header, ok := config["modelBasedRoutingHeaderName"].(string); ok && header != "" {
+				lower := strings.ToLower(header)
+				if isCELSafeHeaderName(lower) {
+					return lower
+				}
+				log.FromContext(ctx).V(0).Info("invalid modelBasedRoutingHeaderName, using default", "value", header)
+			}
+		}
+	}
+
+	return constants.DefaultModelRoutingHeader
+}
+
+// isCELSafeHeaderName reports whether name is a valid HTTP header token (RFC 7230)
+// that is also safe to interpolate into CEL string literals. Rejects quotes,
+// backticks, and backslashes which could break or inject into CEL expressions
+// like '{{.ModelRoutingHeader}}' in request.headers.
+func isCELSafeHeaderName(name string) bool {
+	return httpguts.ValidHeaderFieldName(name) && !strings.ContainsAny(name, "'\"`\\")
 }
 
 // MergeUserLabelsAndAnnotations merges user-added labels and annotations from existing resource

--- a/internal/controller/utils/utils_test.go
+++ b/internal/controller/utils/utils_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -626,5 +628,65 @@ var _ = Describe("ShouldCreateEnvoyFilterForGateway", func() {
 			},
 		}
 		Expect(ShouldCreateEnvoyFilterForGateway(gateway)).To(BeFalse())
+	})
+})
+
+var _ = Describe("GetModelRoutingHeader", func() {
+	var cli client.Client
+
+	makeConfigMap := func(headerName string) *corev1.ConfigMap {
+		data := map[string]string{}
+		if headerName != "" {
+			data["ingress"] = `{"modelBasedRoutingHeaderName":"` + headerName + `"}`
+		}
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      KserveConfigMapName,
+				Namespace: "test-ns",
+			},
+			Data: data,
+		}
+	}
+
+	BeforeEach(func() {
+		GinkgoT().Setenv("POD_NAMESPACE", "test-ns")
+	})
+
+	It("should return configured header name", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().WithObjects(makeConfigMap("x-custom-header")).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal("x-custom-header"))
+	})
+
+	It("should lowercase the configured header name", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().WithObjects(makeConfigMap("X-Gateway-Model-Name")).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal("x-gateway-model-name"))
+	})
+
+	It("should return default when ConfigMap is missing", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal(constants.DefaultModelRoutingHeader))
+	})
+
+	It("should return default when ingress key is missing", func(ctx SpecContext) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: KserveConfigMapName, Namespace: "test-ns"},
+		}
+		cli = fake.NewClientBuilder().WithObjects(cm).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal(constants.DefaultModelRoutingHeader))
+	})
+
+	It("should return default when header name contains single quotes", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().WithObjects(makeConfigMap("x-model'name")).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal(constants.DefaultModelRoutingHeader))
+	})
+
+	It("should return default when header name contains spaces", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().WithObjects(makeConfigMap("x model")).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal(constants.DefaultModelRoutingHeader))
+	})
+
+	It("should return default when header name contains template injection", func(ctx SpecContext) {
+		cli = fake.NewClientBuilder().WithObjects(makeConfigMap("x-model{{.Name}}")).Build()
+		Expect(GetModelRoutingHeader(ctx, cli)).To(Equal(constants.DefaultModelRoutingHeader))
 	})
 })


### PR DESCRIPTION
## Description

The gateway-level AuthPolicy only had `inference-access` rules that work for per-participant paths but don't cover [publisher paths](https://github.com/kserve/kserve/pull/5822) (`/publishers/<ns>/models/<name>/...`), which need model-level authorization against `serving.opendatahub.io/models`.

Adds `model-access-path` and `model-access-path-delegate` authorization rules for direct publisher-path traffic. Supports multi-segment model names (e.g. `facebook/opt-125m`) via `split('/models/')[1].split('/v1/')[0]` extraction. Model names containing a literal `/v1/` segment are not supported - same structural limitation as the kserve HTTPRoute template.

Adds a `deny-misrouted-model-header` rule that blocks requests where the routing identity (model header) and authorization identity (request path) diverge. Without this, a per-participant path with a valid model routing header would be authorized against the path (tenant-A) but routed via the header to a different tenant's backend (tenant-B). The deny rule uses Authorino's `patternMatching` with `predicate: "false"` for an immediate local 403 with no API server round-trip.

The model routing header name is read from the `inferenceservice-config` ConfigMap (`modelBasedRoutingHeaderName`), lowercased to match Authorino's key normalization, and validated as an HTTP token. The GatewayReconciler watches the ConfigMap's `ingress` key for changes.

BBR support (`resolvedPath` normalization for `/v1/` + header traffic) is a planned follow-up.

## How Has This Been Tested?

- Unit tests verify template rendering: 5 authorization rules, overrides
- E2E tests (13 publisher-path + 20 batch = 33 total) against a kind cluster with Kuadrant: publisher-path access, delegation, anti-spoofing, namespace collisions, cross-tenant deny, multi-segment model names
- Kind-based CI workflow triggered on auth-related file changes
- All existing batch AuthPolicy e2e tests pass

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model-routing header support, including validation and a default header.
  * Added authorization for publisher model paths, multi-segment model names, and delegated access.
  * Added safeguards against cross-tenant model misrouting and identity spoofing.
  * Auth policies now refresh when ingress routing configuration changes.

* **Bug Fixes**
  * Improved path handling for inference, publisher, `/v1/`, and short health-check requests.
  * Added safer fallback behavior for missing or invalid routing configuration.

* **Tests**
  * Expanded unit and end-to-end coverage for authorization, routing, delegation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->