### PR TITLE
fix: extend deny-misrouted rule to cover /v1/ paths besides batch

### DIFF
--- a/internal/controller/resources/template/PUBLISHER-PATH-AUTH.md
+++ b/internal/controller/resources/template/PUBLISHER-PATH-AUTH.md
@@ -5,7 +5,7 @@ with model-level SAR authorization and cross-tenant deny.
 
 ## Problem
 
-The current `inference-access` rule extracts namespace/name from `request.path.split("/")[1]`
+The `inference-access` rule extracts namespace/name from `request.path.split("/")[1]`
 and `[2]`. This works for per-participant paths (`/<ns>/<name>/...`) but doesn't cover
 [publisher paths](https://github.com/kserve/kserve/pull/5822)
 (`/publishers/<ns>/models/<name>/...`), which need model-level authorization against
@@ -22,7 +22,7 @@ Two new model-access rules, one deny rule, two existing rules updated.
 
 | Rule | Fires when | Resource | Verb | Priority |
 |---|---|---|---|---|
-| `deny-misrouted-model-header` | not `/v1/`, not publisher, valid model header present | (always deny) | - | 0 |
+| `deny-misrouted-model-header` | not publisher, not batch, valid model header | (always deny) | - | 0 |
 | `model-access-path` | path ~ `^/publishers/[^/]+/models/` | `serving.opendatahub.io/models` | `post` | 1 |
 | `model-access-path-delegate` | same + `x-maas-user` | `serving.opendatahub.io/models/delegate` | `post-delegate` | 1 |
 | `inference-access` | depth >= 2, not `/v1/`, not publisher | `serving.kserve.io/llminferenceservices` | `get` | 1 |
@@ -34,15 +34,33 @@ index-out-of-bounds on short paths like `/health`.
 ## Cross-tenant deny
 
 The `deny-misrouted-model-header` rule fires when:
-1. Path is not `/v1/` (not a BBR endpoint)
-2. Path is not a publisher path
+1. Path is not a publisher path
+2. Path is not a batch path (`/v1/files`, `/v1/batches`)
 3. A valid model routing header is present (`^publishers/[^/]+/models/.+$`)
 
-Uses Authorino's `patternMatching` with `predicate: "false"` - immediate local 403,
-no API server round-trip. Priority 0 ensures it short-circuits before SAR rules.
+This covers both per-participant paths (`/<ns>/<name>/...`) AND `/v1/` inference
+endpoints (`/v1/chat/completions`, `/v1/completions`, etc.) when the model routing
+header is present. Uses Authorino's `patternMatching` with `predicate: "false"` -
+immediate local 403, no API server round-trip. Priority 0 ensures it fires before
+SAR rules.
 
-This closes the routing/authorization identity mismatch: the request is denied before
-`inference-access` can authorize it against the wrong tenant's path segments.
+## Why inference-access excludes all /v1/ paths (not just batch)
+
+The original template used a batch-only exclusion on `inference-access`, which meant
+every `/v1/` path got a SAR check with garbage namespace/name extraction (ns=`v1`,
+name=`chat` for `/v1/chat/completions`). This had two problems:
+
+1. **Broke `/v1/models` discovery** - SAR for ns=v1/name=models denied legitimate
+   model listing requests. A dedicated per-route AuthPolicy for `/v1/models`
+   would be the proper solution for endpoints that need their own authorization
+   posture.
+
+2. **Broke non-inference services** - any service sharing the gateway with `/v1/`
+   paths got SAR checks against `serving.kserve.io/llminferenceservices`.
+
+The `/v1/` exclusion on `inference-access` avoids both issues. The
+`deny-misrouted-model-header` rule handles the model routing header case explicitly,
+scoped to inference traffic by the header format check rather than by path.
 
 ## Model name extraction
 
@@ -53,7 +71,6 @@ model names by capturing everything between `/models/` and the first `/v1/` path
 Model names containing a literal `/v1/` segment (e.g. `my-org/v1/model`) are not supported -
 the extraction would truncate at the first `/v1/`. This is the same limitation as the kserve
 HTTPRoute template, which uses `/v1/` as the API path delimiter after the model identity.
-The ambiguity is structural, not specific to the AuthPolicy.
 
 ## Request flow
 
@@ -62,9 +79,12 @@ The ambiguity is structural, not specific to the AuthPolicy.
 | `/publishers/<ns>/models/<m>/v1/...` | any | model-access-path | Model SAR |
 | `/<ns>/<name>/...` | none | inference-access | Instance SAR |
 | `/<ns>/<name>/...` | valid model header | deny-misrouted | 403 (cross-tenant) |
-| `/v1/...` | any | (no rule fires) | Authn-only |
-| `/v1/files/...`, `/v1/batches/...` | any | (no rule fires) | Authn-only (batch) |
-| `/health`, `/` | any | (no rule fires) | Authn-only (short path) |
+| `/v1/chat/completions` | valid model header | deny-misrouted | 403 (no BBR yet) |
+| `/v1/chat/completions` | none | (no rule) | Authn-only (no route without header) |
+| `/v1/files/...`, `/v1/batches/...` | any | (no rule) | Authn-only (batch bypass) |
+| `/v1/models` | any | (no rule) | Authn-only (discovery) |
+| `/health` | none | (no rule) | Authn-only (depth guard) |
+| `/health` | valid model header | deny-misrouted | 403 |
 
 ## Model routing header
 
@@ -74,42 +94,72 @@ lowercased (Authorino normalizes header keys) and validated as an HTTP token to 
 CEL injection. The GatewayReconciler watches the ConfigMap's `ingress` key for changes.
 
 Currently used only by the `deny-misrouted-model-header` rule. BBR support (normalizing
-`/v1/` + header into publisher format via `resolvedPath` override) is a planned follow-up.
+`/v1/` + header into publisher format via `resolvedPath` override) is a planned follow-up
+that will allow `model-access-path` to authorize BBR traffic instead of denying it.
 
-## Backward compatibility
-
-- Per-participant paths (`/<ns>/<name>/...`) use `inference-access` (instance SAR), unchanged.
-- Batch paths (`/v1/files`, `/v1/batches`) remain authn-only.
-- Existing `get llminferenceservices` RBAC continues to work.
-- `/v1/` paths without model header remain authn-only.
-
-## Anti-spoofing
+## Anti-spoofing (delegation)
 
 When `x-maas-user` is present, both the base rule and its delegate counterpart fire (AND
-semantics). The delegate rule checks the caller's identity for `post-delegate` or
-`post-delegate`. Regular users lack this and get 403.
+semantics in Authorino - all matched rules must pass). The base rule checks the forwarded
+user's access via `resolvedUser`. The delegate rule checks the caller's own identity for
+`post-delegate`. Regular users lack delegate permission and get 403 - only trusted callers
+like the batch processor SA can forward requests on behalf of others.
 
-## Testing
+## Known limitations
 
-### Unit tests
+- **Namespace `v1`**: if namespace `v1` exists with real LLMInferenceServices, per-participant
+  paths like `/v1/<name>/...` skip instance SAR (authn-only due to `/v1/` exclusion on
+  inference-access). Mitigated by
+  a ValidatingAdmissionPolicy
+  blocking reserved namespace names (`v1`, `v2`, `publishers`).
+- **`/v1/` without BBR**: `/v1/` inference endpoints without the model routing header are
+  authn-only. Safe because no HTTPRoute matches those paths without the header (gateway
+  returns 404). The BBR follow-up will add `resolvedPath` normalization to authorize them.
 
-- 5 authorization rules present in rendered policy
-- `resolvedUser`/`resolvedGroups` overrides rendered
-- Custom model routing header substituted in deny rule
+## Batch processing and dual RBAC domains
 
-### E2E tests (13 publisher-path + 20 batch = 33 total)
+Publisher paths introduce a virtual resource (`models.serving.opendatahub.io`) for
+model-level authorization. This creates two parallel RBAC domains:
 
-| Category | Tests |
-|---|---|
-| Model-access rules | publisher path with/without RBAC, multi-segment model name |
-| Cross-RBAC type | model-user on participant path (wrong RBAC type) |
-| Namespace collision | ns=publishers participant path, ns=publishers publisher route |
-| Cross-tenant deny | participant path + valid model header -> 403 |
-| Exclusion boundaries | /v1/models authn-only, /v1/ excluded, /health depth guard, empty header |
-| Delegation | delegated model-access (post-delegate), spoofed (lacks post-delegate) |
+| Access pattern | SAR resource | Verb |
+|---|---|---|
+| Per-participant (`/<ns>/<name>/...`) | `serving.kserve.io/llminferenceservices` | `get` |
+| Publisher (`/publishers/<ns>/models/<m>/...`) | `serving.opendatahub.io/models` | `post` |
 
-### CI workflow
+The batch processor (see [BATCH.md](BATCH.md) section 3) currently delegates via
+per-participant paths using `post-delegate` on `llminferenceservices/delegate`. For
+controlled deployment (canary), the batch processor should use the stable model identity
+(publisher path or BBR) instead of version-specific instances. This requires new RBAC:
+- Batch processor SA: `post-delegate` on `serving.opendatahub.io/models/delegate`
+- Users: `post` on `serving.opendatahub.io/models` (via aggregated ClusterRole)
 
-Kind-based CI (`.github/workflows/test-authpolicy-e2e.yml`): kind + MetalLB + cert-manager +
-Gateway API CRDs + Istio + Kuadrant. Renders the template via `sed` with default values.
-Triggered on PR when auth-related files change.
+### Known tradeoff: virtual resource
+
+The `models` resource has no backing CRD - it's a SAR-only authorization contract.
+This means:
+- `kubectl get models.serving.opendatahub.io` returns "not found"
+- Operators can't discover what model resources exist by inspecting the cluster
+- The `resourceNames` values are path-shaped strings (`publishers/ns/models/name`),
+  not standard Kubernetes names
+- Debugging authorization spans two API groups and two resource types
+
+The virtual resource is a pragmatic workaround for Kubernetes RBAC not supporting
+model-level grouping natively. In practice, most deployments use namespace-scoped
+RBAC (`view`/`edit` roles) rather than per-model `resourceNames`, so the dual
+domain is transparent - the
+[aggregate ClusterRoles](https://github.com/opendatahub-io/kserve/pull/1744)
+(`kserve-models-view`/`kserve-models-edit`) ensure namespace viewers/editors
+automatically get model access alongside instance access.
+
+For deployments that need per-model RBAC granularity, alternatives considered:
+- **Namespace-scoped wildcard SAR**: check `get llminferenceservices` without
+  `resourceName` - single call, existing RBAC, but grants access to all models
+  in the namespace rather than a specific one. The aggregate ClusterRoles from
+  [opendatahub-io/kserve#1744](https://github.com/opendatahub-io/kserve/pull/1744)
+  already provide this level of granularity.
+- **RBAC reconciler**: a controller watches routing groups and reconciles
+  aggregated Roles covering all group members, making model-level SAR resolvable
+  via a single call at request time. Moves the O(N) cost to reconciliation.
+- **Informer-based ext-authz**: custom gRPC service with warm group membership
+  cache (similar to EPP's model routing). O(1) lookup + N concurrent SAR calls.
+  Overkill unless auth latency becomes a bottleneck.

--- a/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
+++ b/internal/controller/resources/template/authpolicy_llm_isvc_userdefined.yaml
@@ -96,16 +96,19 @@ spec:
             verb:
               value: post-delegate
         priority: 1
-      # Deny requests where routing identity (header) and authorization identity
-      # (path) would diverge. A per-participant path with a valid model header
-      # would be routed by the header (tenant-B) but authorized by the path
-      # (tenant-A). patternMatching with predicate "false" is an immediate local
-      # deny - no API server call.
+      # Deny requests where a valid model routing header is present on a path
+      # that isn't a publisher path or a batch API path. Without BBR's resolvedPath
+      # normalization, /v1/ paths can't be authorized via model-access-path, and
+      # per-participant paths would be authorized by path (tenant-A) but routed by
+      # header (tenant-B). patternMatching with predicate "false" is an immediate
+      # local deny - no API server call.
       deny-misrouted-model-header:
         when:
-          - predicate: "!request.path.startsWith('/v1/')"
           - predicate: >-
               !request.path.matches('^/publishers/[^/]+/models/')
+          - predicate: >-
+              !(request.path == '/v1/files' || request.path.startsWith('/v1/files/')
+              || request.path == '/v1/batches' || request.path.startsWith('/v1/batches/'))
           - predicate: >-
               '{{.ModelRoutingHeader}}' in request.headers
               && request.headers['{{.ModelRoutingHeader}}'].matches('^publishers/[^/]+/models/.+$')

--- a/internal/controller/test/e2e/publisher_path_authpolicy_test.go
+++ b/internal/controller/test/e2e/publisher_path_authpolicy_test.go
@@ -3,9 +3,15 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // publisherFixture holds per-test resources for publisher-path authorization tests.
@@ -211,6 +217,111 @@ func TestEmptyModelHeaderAuthnOnlyFallthrough(t *testing.T) {
 	}
 }
 
+// --- /v1/ + model header gap ---
+
+func TestV1PathWithModelHeaderDenied(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// /v1/chat/completions + valid model header: no resolvedPath (BBR not enabled),
+	// so model-access-path doesn't fire. deny-misrouted should block this to
+	// prevent authn-only access when a model routing header is present.
+	headers := map[string]string{
+		"x-gateway-model-name": fmt.Sprintf("publishers/%s/models/echo-server", f.ns),
+	}
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", f.noAccessToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (/v1/ + model header should be denied without BBR), got %d", resp.StatusCode)
+	}
+}
+
+func TestV1PathWithNonPublisherHeaderAuthnOnly(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// /v1/chat/completions + non-publisher header: the header doesn't match the
+	// publisher format regex, so it shouldn't trigger the deny rule. But it also
+	// shouldn't grant access - without BBR, /v1/ paths are authn-only regardless.
+	// This test documents the current behavior (authn-only) vs the ideal (denied).
+	headers := map[string]string{
+		"x-gateway-model-name": "some-random-model",
+	}
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", f.noAccessToken, headers)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (non-publisher header on /v1/ = authn-only), got %d", resp.StatusCode)
+	}
+}
+
+func TestV1PathWithCrossTenantHeaderDenied(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// /v1/chat/completions + valid model header pointing to a different tenant.
+	// The routing layer would use the header to route to the other tenant's
+	// backend, but no authorization rule checks the header on /v1/ paths.
+	headers := map[string]string{
+		"x-gateway-model-name": "publishers/other-tenant/models/secret-model",
+	}
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", f.noAccessToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (/v1/ + cross-tenant model header should be denied), got %d", resp.StatusCode)
+	}
+}
+
+// --- ns=v1 collision: user with RBAC for garbage SAR identity ---
+
+func TestV1NamespaceCollisionWithRBAC(t *testing.T) {
+	t.Parallel()
+
+	// Create namespace "v1" and grant get llminferenceservices for name=chat.
+	// The original template would run SAR for ns=v1/name=chat on /v1/chat/completions
+	// and this user would pass. The current template should NOT authorize based on
+	// this garbage path extraction.
+	ns := "v1"
+	_, err := authEnv.clientset.CoreV1().Namespaces().Create(
+		context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Logf("namespace v1 may already exist: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = authEnv.clientset.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+	})
+
+	// Create SA in v1 namespace with get llminferenceservices for name=chat
+	authEnv.createServiceAccount(t, ns, "v1-collision-user")
+	authEnv.grantAccess(t, ns, ns, "v1-collision-user", "v1-collision-chat-access", []rbacv1.PolicyRule{{
+		APIGroups:     []string{"serving.kserve.io"},
+		Resources:     []string{"llminferenceservices"},
+		ResourceNames: []string{"chat"},
+		Verbs:         []string{"get"},
+	}})
+
+	token := authEnv.requestToken(t, ns, "v1-collision-user")
+
+	// /v1/chat/completions without header: in the original template, inference-access
+	// would fire and SAR for ns=v1/name=chat would PASS (user has that RBAC).
+	// The current template should NOT let this through as an authorized request.
+	resp, _ := authEnv.gatewayGet(t, "/v1/chat/completions", token, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 (authn-only, no header on /v1/), got %d", resp.StatusCode)
+	}
+
+	// /v1/chat/completions with model header pointing elsewhere
+	headers := map[string]string{
+		"x-gateway-model-name": "publishers/other-ns/models/secret-model",
+	}
+	resp2, _ := authEnv.gatewayGet(t, "/v1/chat/completions", token, headers)
+	t.Logf("ns=v1 collision: /v1/chat/completions + cross-tenant header = %d", resp2.StatusCode)
+
+	// With header: deny-misrouted must block regardless of ns=v1 RBAC
+	if resp2.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (deny-misrouted must block cross-tenant even with ns=v1 RBAC), got %d", resp2.StatusCode)
+	}
+}
+
 // --- Delegation on publisher paths ---
 
 func TestDelegatedModelAccess(t *testing.T) {
@@ -240,5 +351,73 @@ func TestSpoofedModelAccessCallerLacksDelegate(t *testing.T) {
 	resp, _ := authEnv.gatewayGet(t, path, f.modelUserToken, headers)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestDelegatedModelAccessForwardedUserNoRBAC(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	headers := map[string]string{
+		"x-maas-user": "nonexistent-user",
+	}
+	// Caller (delegate-user) has post-delegate, but forwarded user has no model RBAC.
+	resp, _ := authEnv.gatewayGet(t, path, f.delegateToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (forwarded user lacks model RBAC), got %d", resp.StatusCode)
+	}
+}
+
+func TestDelegatedModelAccessForwardedUserDelegateOnly(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	// Forwarded user (no-access) has no model RBAC at all. Even though the caller
+	// (delegate-user) has both post and post-delegate, rule 1 checks the forwarded
+	// user's model access and should reject.
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	headers := map[string]string{
+		"x-maas-user": saIdentity(f.ns, "no-access"),
+	}
+	resp, _ := authEnv.gatewayGet(t, path, f.delegateToken, headers)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 (forwarded user has no model access), got %d", resp.StatusCode)
+	}
+}
+
+// --- Authentication layer ---
+
+func TestPublisherPathNoToken(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	resp, _ := authEnv.gatewayGet(t, path, "", nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (no token), got %d", resp.StatusCode)
+	}
+}
+
+// --- Response headers ---
+
+func TestPublisherPathNoBatchHeaders(t *testing.T) {
+	t.Parallel()
+	f := setupPublisherFixture(t)
+
+	path := fmt.Sprintf("/publishers/%s/models/echo-server/v1/chat/completions", f.ns)
+	resp, body := authEnv.gatewayGet(t, path, f.modelUserToken, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// x-maas-user and x-maas-groups should NOT appear on publisher paths -
+	// they are only injected for batch paths.
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "x-maas-user") {
+		t.Errorf("publisher path response should not contain x-maas-user header")
+	}
+	if strings.Contains(bodyStr, "x-maas-groups") {
+		t.Errorf("publisher path response should not contain x-maas-groups header")
 	}
 }


### PR DESCRIPTION
## Description

Follow-up to #881. The `deny-misrouted-model-header` rule excluded all `/v1/` paths from its when-condition, which was intended for the BBR follow-up where `resolvedPath` normalization would handle `/v1/` + header authorization. Without that normalization in place, `/v1/` inference endpoints with a valid model routing header had no authorization rule covering them.

Restores the original batch-path bypass (`/v1/files`, `/v1/batches`) as the deny rule's exclusion instead of the broad `/v1/` exclusion. Batch paths remain authn-only as designed.

Also adds publisher-path test coverage for delegation edge cases (forwarded user without RBAC, forwarded user with only delegate access), authentication layer (no token on publisher path), and response header scoping (batch headers not injected on publisher paths).

Part of [RHOAIENG-69638](https://redhat.atlassian.net/browse/RHOAIENG-69638)

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-69638]: https://redhat.atlassian.net/browse/RHOAIENG-69638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened authorization for publisher model routes to prevent cross-tenant access and block misrouted model headers.
  - Corrected deny vs auth-only handling across chat, files, batches, models, and health endpoints (including proper 403 behavior when applicable).
  - Ensured publisher-path requests without a token return `401` and do not include batch-specific response headers.
  - Fixed namespace-collision and delegated-access cases where required model permissions were missing.
- **Documentation**
  - Updated publisher-path authorization guidance with clarified request-flow behaviors and known limitations.
- **Tests**
  - Expanded end-to-end coverage for the new routing, header, delegation, and namespace collision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->