### PR TITLE
RHOAIENG-76656: Update vLLM version from v0.21.0 to v0.24.0 in runtime templates

### DIFF
--- a/config/runtimes/vllm/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm/vllm-cpu-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (ppc64le/s390x) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-cpu-x86-template.yaml
+++ b/config/runtimes/vllm/vllm-cpu-x86-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-x86-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (x86) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-cuda-template.yaml
+++ b/config/runtimes/vllm/vllm-cuda-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-gaudi-template.yaml
+++ b/config/runtimes/vllm/vllm-gaudi-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm/vllm-multinode-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'false'
     spec:

--- a/config/runtimes/vllm/vllm-rocm-template.yaml
+++ b/config/runtimes/vllm/vllm-rocm-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-ppc64le-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-ppc64le-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre ppc64le ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-s390x-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre s390x ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-x86-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-x86-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre on x86 ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION
## Description

Update vLLM runtime version string from `v0.21.0` to `v0.24.0` across all vLLM runtime templates for RHOAI 3.5 GA.

Related downstream PR: https://github.com/red-hat-data-services/odh-model-controller/pull/1634

## How Has This Been Tested?

Verified the version string update in all 9 vLLM runtime template YAML files. Downstream equivalent PR raised and validated as part of vllm-cpu rebase PR #568.

## Related:

-  JIRA(s) are linked in the PR description — [RHOAIENG-76656](https://redhat.atlassian.net/browse/RHOAIENG-76656)


[RHOAIENG-76656]: https://redhat.atlassian.net/browse/RHOAIENG-76656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated all vLLM ServingRuntime templates to version **v0.24.0**, including CPU, CUDA, ROCm, Gaudi, multi-node, and platform-specific variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->