### PR TITLE
[RHOAIENG-78139] Add xKS smoke negative webhook tests

### DIFF
--- a/test/scripts/kind/setup-odh-model-controller-xks.sh
+++ b/test/scripts/kind/setup-odh-model-controller-xks.sh
@@ -106,6 +106,49 @@ if kubectl get validatingwebhookconfiguration validating.odh-model-controller.op
   fail "expected no OMC validating webhook on xKS"
 fi
 
+expect_admission_denied() {
+  local description="$1"
+  local tmp out rc=0
+  tmp="$(mktemp)"
+  cat >"${tmp}"
+  out="$(kubectl apply -f "${tmp}" 2>&1)" || rc=$?
+  rm -f "${tmp}"
+  if [[ "${rc}" -eq 0 ]]; then
+    fail "expected ${description} to be rejected by webhook, but apply succeeded"
+  fi
+  printf '==> Rejected as expected (%s): %s\n' "${description}" "${out}"
+}
+
+log "Negative test: ConnectionsAPI rejects missing connection Secret"
+expect_admission_denied "ConnectionsAPI missing connection" <<EOF
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: xks-smoke-llmisvc-bad-connection
+  namespace: ${NAMESPACE}
+  annotations:
+    opendatahub.io/connections: dummy
+spec:
+  model:
+    name: test-model
+    uri: s3://test-bucket/test-model
+EOF
+
+log "Negative test: HardwareProfile rejects missing HardwareProfile"
+expect_admission_denied "HardwareProfile missing profile" <<EOF
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: xks-smoke-llmisvc-bad-hwp
+  namespace: ${NAMESPACE}
+  annotations:
+    opendatahub.io/hardware-profile-name: dummy
+spec:
+  model:
+    name: test-model
+    uri: s3://test-bucket/test-model
+EOF
+
 log "Creating LLMInferenceService to verify mutating admission path"
 cat <<EOF | kubectl apply -f -
 apiVersion: serving.kserve.io/v1alpha2
@@ -121,5 +164,13 @@ EOF
 
 kubectl -n "${NAMESPACE}" get llminferenceservice xks-smoke-llmisvc >/dev/null 2>&1 \
   || fail "LLMInferenceService was not created; webhook admission may have failed"
+
+# Negative cases must not have been admitted.
+if kubectl -n "${NAMESPACE}" get llminferenceservice xks-smoke-llmisvc-bad-connection >/dev/null 2>&1; then
+  fail "ConnectionsAPI negative test resource was created; webhook did not reject"
+fi
+if kubectl -n "${NAMESPACE}" get llminferenceservice xks-smoke-llmisvc-bad-hwp >/dev/null 2>&1; then
+  fail "HardwareProfile negative test resource was created; webhook did not reject"
+fi
 
 log "xKS Kind smoke test passed"


### PR DESCRIPTION
## Description

Follow-up to [RHOAIENG-69082](https://redhat.atlassian.net/browse/RHOAIENG-69082) / #872 per [review feedback](https://github.com/opendatahub-io/odh-model-controller/pull/872#discussion_r3581474485).

Extends the xKS Kind smoke test to prove ConnectionsAPI and HardwareProfile mutating webhooks are enforcing:

1. Reject LLMISVC with `opendatahub.io/connections: dummy` (missing Secret)
2. Reject LLMISVC with `opendatahub.io/hardware-profile-name: dummy` (missing HardwareProfile)
3. Keep the existing positive create path
4. Assert the negative resources were not persisted

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-78139

## How Has This Been Tested?

- `bash -n test/scripts/kind/setup-odh-model-controller-xks.sh`
- Logic mirrors the webhook error paths already covered by unit tests (`connection … not found`, `failed fetching HardwareProfile`)
- CI: `test-odh-model-controller-xks-kind` workflow exercises the updated smoke script

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


Made with [Cursor](https://cursor.com)

[RHOAIENG-69082]: https://redhat.atlassian.net/browse/RHOAIENG-69082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added admission-control coverage for invalid `LLMInferenceService` configurations.
  * Added checks confirming resources are rejected when required connection or hardware profile data is missing.
  * Verified rejected resources are not created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->