### PR TITLE
[RHOAIENG-68299] Fix NIM served model name

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_nim_model_name_test.go
+++ b/internal/controller/serving/reconcilers/kserve_nim_model_name_test.go
@@ -1,0 +1,285 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var _ = Describe("injectNimServedModelName", func() {
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(kservev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(kservev1beta1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	When("ISVC uses NIM runtime with no existing passthrough args", func() {
+		It("should inject NIM_PASSTHROUGH_ARGS with --served-model-name", func(ctx SpecContext) {
+			sr := createServingRuntime("nim-runtime", map[string]string{
+				utils.IsNimRuntimeAnnotation: "true",
+			})
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nim-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("nim-runtime"),
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sr, isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-nim-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			env := updated.Spec.Predictor.Model.Container.Env
+			Expect(env).To(ContainElement(corev1.EnvVar{
+				Name:  utils.NimPassthroughArgsEnv,
+				Value: "--served-model-name my-nim-model",
+			}))
+		})
+	})
+
+	When("ISVC uses NIM runtime with existing passthrough args", func() {
+		It("should prepend --served-model-name to existing args", func(ctx SpecContext) {
+			sr := createServingRuntime("nim-runtime", map[string]string{
+				utils.IsNimRuntimeAnnotation: "true",
+			})
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nim-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("nim-runtime"),
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{Name: utils.NimPassthroughArgsEnv, Value: "--gpu-memory-utilization 0.80 --max-num-seqs 8"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sr, isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-nim-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			env := updated.Spec.Predictor.Model.Container.Env
+			Expect(env).To(ContainElement(corev1.EnvVar{
+				Name:  utils.NimPassthroughArgsEnv,
+				Value: "--served-model-name my-nim-model --gpu-memory-utilization 0.80 --max-num-seqs 8",
+			}))
+		})
+	})
+
+	When("ISVC already has --served-model-name", func() {
+		It("should not modify the ISVC", func(ctx SpecContext) {
+			sr := createServingRuntime("nim-runtime", map[string]string{
+				utils.IsNimRuntimeAnnotation: "true",
+			})
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nim-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("nim-runtime"),
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{Name: utils.NimPassthroughArgsEnv, Value: "--served-model-name custom-name"},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sr, isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-nim-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			env := updated.Spec.Predictor.Model.Container.Env
+			Expect(env).To(ContainElement(corev1.EnvVar{
+				Name:  utils.NimPassthroughArgsEnv,
+				Value: "--served-model-name custom-name",
+			}))
+		})
+	})
+
+	When("ISVC has NIM_PASSTHROUGH_ARGS with ValueFrom", func() {
+		It("should not modify the ISVC", func(ctx SpecContext) {
+			sr := createServingRuntime("nim-runtime", map[string]string{
+				utils.IsNimRuntimeAnnotation: "true",
+			})
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nim-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("nim-runtime"),
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								Container: corev1.Container{
+									Env: []corev1.EnvVar{
+										{
+											Name: utils.NimPassthroughArgsEnv,
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													LocalObjectReference: corev1.LocalObjectReference{Name: "nim-secret"},
+													Key:                  "passthrough-args",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sr, isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-nim-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			env := updated.Spec.Predictor.Model.Container.Env
+			Expect(env).To(HaveLen(1))
+			Expect(env[0].Value).To(BeEmpty())
+			Expect(env[0].ValueFrom).NotTo(BeNil())
+		})
+	})
+
+	When("ISVC uses non-NIM runtime", func() {
+		It("should not modify the ISVC", func(ctx SpecContext) {
+			sr := createServingRuntime("vllm-runtime", map[string]string{})
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-vllm-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("vllm-runtime"),
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sr, isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-vllm-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updated.Spec.Predictor.Model.Container.Env).To(BeEmpty())
+		})
+	})
+
+	When("ISVC references a runtime that does not exist", func() {
+		It("should not modify the ISVC and not return an error", func(ctx SpecContext) {
+			isvc := &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-missing-runtime-model",
+					Namespace: "test-namespace",
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Model: &kservev1beta1.ModelSpec{
+							ModelFormat: kservev1beta1.ModelFormat{Name: "test-format"},
+							Runtime:     ptr.To("nonexistent-runtime"),
+						},
+					},
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(isvc).Build()
+			reconciler := NewKServeRawInferenceServiceReconciler(client)
+
+			err := reconciler.injectNimServedModelName(ctx, log.Log, isvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &kservev1beta1.InferenceService{}
+			err = client.Get(ctx, k8stypes.NamespacedName{Name: "my-missing-runtime-model", Namespace: "test-namespace"}, updated)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updated.Spec.Predictor.Model.Container.Env).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_inferenceservice_reconciler.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
 )
 
 var _ Reconciler = (*KserveRawInferenceServiceReconciler)(nil)
@@ -49,12 +51,34 @@ func NewKServeRawInferenceServiceReconciler(client client.Client) *KserveRawInfe
 }
 
 func (r *KserveRawInferenceServiceReconciler) Reconcile(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	if err := r.injectNimServedModelName(ctx, log, isvc); err != nil {
+		return err
+	}
+
 	var reconcileErrors *multierror.Error
 	for _, reconciler := range r.subResourceReconcilers {
 		reconcileErrors = multierror.Append(reconcileErrors, reconciler.Reconcile(ctx, log, isvc))
 	}
 
 	return reconcileErrors.ErrorOrNil()
+}
+
+// injectNimServedModelName detects NIM ISVCs and prepends --served-model-name
+// to NIM_PASSTHROUGH_ARGS so the vLLM engine inside the NIM container serves
+// under the ISVC resource name instead of the HuggingFace model ID.
+func (r *KserveRawInferenceServiceReconciler) injectNimServedModelName(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {
+	if isvc.Spec.Predictor.Model == nil {
+		return nil
+	}
+	runtime, err := utils.FindSupportingRuntimeForISvc(ctx, r.client, log, isvc)
+	if err != nil || runtime.Annotations[utils.IsNimRuntimeAnnotation] != "true" {
+		return nil
+	}
+	if !utils.EnsureServedModelName(isvc) {
+		return nil
+	}
+	log.Info("Injecting --served-model-name into NIM InferenceService", "name", isvc.Name)
+	return r.client.Update(ctx, isvc)
 }
 
 func (r *KserveRawInferenceServiceReconciler) OnDeletionOfKserveInferenceService(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) error {

--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
 	v1 "github.com/opendatahub-io/odh-model-controller/api/nim/v1"
 	templatev1 "github.com/openshift/api/template/v1"
@@ -113,6 +114,8 @@ const (
 	nimGetNgcToken           = "https://authn.nvidia.com/token?service=ngc&"
 	nimGetNgcModelDataFmt    = "https://api.ngc.nvidia.com/v2/org/%s/team/%s/repos/%s?resolve-labels=true"
 	IsNimRuntimeAnnotation   = "runtimes.opendatahub.io/nvidia-nim"
+	NimPassthroughArgsEnv    = "NIM_PASSTHROUGH_ARGS"
+	ServedModelNameFlag      = "--served-model-name"
 )
 
 var NimHttpClient HttpClient
@@ -135,6 +138,48 @@ func init() {
 			return a.UTC() == b.UTC()
 		},
 	)
+}
+
+// EnsureServedModelName prepends --served-model-name to NIM_PASSTHROUGH_ARGS
+// in the ISVC's predictor model env if not already present. Returns true if
+// the env was modified.
+func EnsureServedModelName(isvc *kservev1beta1.InferenceService) bool {
+	if isvc.Spec.Predictor.Model == nil {
+		return false
+	}
+
+	env := isvc.Spec.Predictor.Model.Container.Env
+	args := isvc.Spec.Predictor.Model.Container.Args
+
+	for _, e := range env {
+		if e.Name == NimPassthroughArgsEnv {
+			if e.ValueFrom != nil {
+				return false
+			}
+			if strings.Contains(e.Value, ServedModelNameFlag) {
+				return false
+			}
+		}
+	}
+	for _, a := range args {
+		if strings.Contains(a, ServedModelNameFlag) {
+			return false
+		}
+	}
+
+	desired := fmt.Sprintf("%s %s", ServedModelNameFlag, isvc.Name)
+	for i, e := range env {
+		if e.Name == NimPassthroughArgsEnv {
+			isvc.Spec.Predictor.Model.Container.Env[i].Value = desired + " " + e.Value
+			return true
+		}
+	}
+
+	isvc.Spec.Predictor.Model.Container.Env = append(
+		isvc.Spec.Predictor.Model.Container.Env,
+		corev1.EnvVar{Name: NimPassthroughArgsEnv, Value: desired},
+	)
+	return true
 }
 
 // IsNimAirGapped returns true when DSC enables NIM air-gapped mode.


### PR DESCRIPTION
## Description

When deploying NIM models via the RHOAI Dashboard, the model name returned by
`/v1/models` doesn't match the InferenceService resource name. Users see one
name in the Dashboard but must use a different name (the HuggingFace model ID)
in API calls, leading to 404s.

**Root cause:** The NIM ServingRuntime created by odh-model-controller has no
`--served-model-name` flag. Every other KServe built-in ServingRuntime sets
`--model_name={{.Name}}` or `--served-model-name={{.Name}}` in container args,
which KServe expands to the ISVC resource name. The NIM runtime is the only
one missing it.

**Why we prepend to the env var instead of overwriting:** Users may already set
`NIM_PASSTHROUGH_ARGS` with other vLLM flags (e.g. `--gpu-memory-utilization
0.80 --max-num-seqs 8`). The reporter in the JIRA was doing exactly this.
KServe merges ServingRuntime and ISVC env vars via strategic merge patch, which
replaces by name -- so setting the env var in the ServingRuntime template would
clobber the user's flags. Instead, we prepend `--served-model-name` to the
existing value in the ISVC reconciler, preserving user-set flags.

**Why we don't use container args:** NIM containers use their own entrypoint
(`nim_llm_sdk.entrypoints.openai.api_server`) which does not forward Kubernetes
container args to the underlying vLLM engine. `NIM_PASSTHROUGH_ARGS` is the
documented mechanism for passing flags through to vLLM.

**Fix:**
- `utils/nim.go`: `EnsureServedModelName()` -- pure function that prepends
  `--served-model-name <isvc-name>` to `NIM_PASSTHROUGH_ARGS` if not already
  present
- `reconcilers/kserve_raw_inferenceservice_reconciler.go`:
  `injectNimServedModelName()` -- detects NIM ISVCs via the
  `runtimes.opendatahub.io/nvidia-nim` annotation, calls the helper, and
  updates the ISVC

JIRA: https://issues.redhat.com/browse/RHOAIENG-68299

## How Has This Been Tested?

- 4 Ginkgo integration tests with fake K8s client covering:
  - NIM ISVC with no existing passthrough args (creates env var)
  - NIM ISVC with existing passthrough args (prepends, preserves user flags)
  - NIM ISVC with `--served-model-name` already set (no-op)
  - Non-NIM ISVC (no-op)
- `go build ./...` passes
- Full reconciler test suite passes (33/33 specs)
- Manual verification on a real NIM deployment pending (requires GPU + NVIDIA auth)

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).

## Repos involved

- https://github.com/opendatahub-io/odh-model-controller (this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NIM-backed inference services now automatically receive a `--served-model-name` setting when needed.
  * Existing passthrough arguments are preserved, with the served model name added at the beginning.
  * If a served model name is already configured, it remains unchanged.

* **Bug Fixes**
  * Non-NIM services and services referencing unsupported or unavailable runtimes are left unchanged during reconciliation.
  * Env entries that reference values (e.g., secret-based `ValueFrom`) are not modified.

* **Tests**
  * Added a new test suite covering injection, preservation, duplicate prevention, secret/value references, and unsupported runtime scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->