### PR TITLE
RHOAIENG-64708: Fix raw KServe Route silently skipped when backing Service is missing

### DIFF
--- a/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
@@ -106,9 +106,11 @@ func (r *KserveRawRouteReconciler) createDesiredResource(ctx context.Context, lo
 	serviceList := &corev1.ServiceList{}
 	labelSelector := client.MatchingLabels{constants.KserveGroupAnnotation: isvc.Name}
 	err = r.client.List(ctx, serviceList, client.InNamespace(isvc.Namespace), labelSelector)
-	if err != nil || len(serviceList.Items) == 0 {
-		log.Error(err, "Failed to fetch service for InferenceService", "InferenceService", isvc.Name)
-		return nil, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services for InferenceService %q: %w", isvc.Name, err)
+	}
+	if len(serviceList.Items) == 0 {
+		return nil, fmt.Errorf("no services found for InferenceService %q; the backing Service may not have been created yet", isvc.Name)
 	}
 	var targetService corev1.Service
 	var predictorService, transformerService *corev1.Service

--- a/internal/controller/serving/reconcilers/kserve_raw_route_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_route_reconciler_test.go
@@ -289,6 +289,28 @@ var _ = Describe("KserveRawRouteReconciler", func() {
 			})
 		})
 
+		When("visibility label is set but no matching services exist", func() {
+			It("should return an error so the controller requeues", func(ctx SpecContext) {
+				isvc := createISVC(
+					map[string]string{
+						constants.KserveNetworkVisibility: constants.LabelEnableKserveRawRoute,
+					},
+				)
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(isvc).
+					Build()
+
+				reconciler := NewKserveRawRouteReconciler(client)
+				route, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no services found"))
+				Expect(route).To(BeNil())
+			})
+		})
+
 		When("canonical predictor is missing but another predictor exists", func() {
 			It("should fall back to any component=predictor service", func(ctx SpecContext) {
 				isvc := createISVC(


### PR DESCRIPTION
## Description

When external Route creation is enabled for a raw KServe InferenceService, the reconciler silently skips Route creation if the backing Kubernetes Service doesn't exist yet. The reconcile completes successfully without creating the Route, leaving the InferenceService without the expected external endpoint - and nothing in the logs or status to indicate the problem.

This happens because a missing Service list result (`nil` error, zero items) falls through as `nil, nil`, which the delta processor treats as "nothing to do." The Route is never created and the controller never requeues.

Now returns an explicit error when no matching Services are found, so controller-runtime requeues with backoff until the Service appears. Once the backing Service exists, the next reconciliation creates the Route as expected.

## How Has This Been Tested?

Unit test added for the case where Route creation is enabled but no matching Service exists - verifies the reconciler returns an error (triggering requeue) instead of silently succeeding. Existing tests continue to pass.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when backing services cannot be listed or are not yet available.
  * Controllers now provide clearer errors and can retry reconciliation when no matching service is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->