### PR TITLE
RHOAIENG-65224: Fix ISVC finalizer MergePatch dropping concurrent finalizer changes

### DIFF
--- a/internal/controller/serving/inferenceservice_controller.go
+++ b/internal/controller/serving/inferenceservice_controller.go
@@ -19,7 +19,6 @@ package serving
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
@@ -41,7 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/yaml"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/constants"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/serving/reconcilers"
@@ -129,10 +127,9 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 		// registering our finalizer.
 		logger.Info("Adding Finalizer")
 		if !controllerutil.ContainsFinalizer(isvc, constants.InferenceServiceODHFinalizerName) {
+			patch := client.MergeFromWithOptions(isvc.DeepCopy(), client.MergeFromWithOptimisticLock{})
 			controllerutil.AddFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
-			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
-			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
-			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
+			if err := r.Patch(ctx, isvc, patch); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -153,10 +150,9 @@ func (r *InferenceServiceReconciler) ReconcileServing(ctx context.Context, req c
 				logger.Error(merr, "Cleanup failed, keeping finalizer to allow retry")
 				return reconcile.Result{}, merr
 			}
+			patch := client.MergeFromWithOptions(isvc.DeepCopy(), client.MergeFromWithOptimisticLock{})
 			controllerutil.RemoveFinalizer(isvc, constants.InferenceServiceODHFinalizerName)
-			patchYaml := "metadata:\n  finalizers: [" + strings.Join(isvc.ObjectMeta.Finalizers, ",") + "]"
-			patchJson, _ := yaml.YAMLToJSON([]byte(patchYaml))
-			if err := r.Patch(ctx, isvc, client.RawPatch(types.MergePatchType, patchJson)); err != nil {
+			if err := r.Patch(ctx, isvc, patch); err != nil {
 				return reconcile.Result{}, err
 			}
 


### PR DESCRIPTION
## Description

The InferenceService reconciler used `MergePatch` (RFC 7386) to persist finalizer changes, which replaces the entire `finalizers` array server-side. If another controller (e.g. KServe upstream) modifies finalizers between the `Get` and the `Patch`, those changes are silently overwritten. 

Switches to an optimistic-lock merge patch that sends only the finalizer delta while including `resourceVersion` for conflict detection. 

Fixes: [RHOAIENG-65224](https://issues.redhat.com/browse/RHOAIENG-65224)

## How Has This Been Tested?

Existing KServe Raw reconciler tests (12 specs) pass - these exercise both the finalizer add path (ISVC creation) and remove path (ISVC deletion with cleanup).

The race condition itself can't be reliably simulated in envtest (requires two separate controller processes), but the optimistic-lock merge patch is a well-established controller-runtime pattern that guarantees conflict detection via `resourceVersion`.

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-65224]: https://redhat.atlassian.net/browse/RHOAIENG-65224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ