### PR TITLE
fix: flaky auth posture and ReconcileError event tests

### DIFF
--- a/internal/controller/serving/llm/auth_posture_test.go
+++ b/internal/controller/serving/llm/auth_posture_test.go
@@ -17,13 +17,12 @@ limitations under the License.
 package llm_test
 
 import (
-	"context"
+	"strings"
 	"time"
 
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,22 +49,18 @@ var _ = Describe("Auth Posture Enforcement", func() {
 		}
 	})
 
-	countAuthPostureMismatchEvents := func(ctx context.Context, namespace string) (int32, error) {
-		eventList := &corev1.EventList{}
-		if err := envTest.Client.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
-			return 0, err
-		}
-		var total int32
-		for _, ev := range eventList.Items {
-			if ev.Reason == "AuthPostureMismatch" {
-				if ev.Count > 0 {
-					total += ev.Count
-				} else {
-					total++
+	drainEvents := func(reason string) []string {
+		var matched []string
+		for {
+			select {
+			case ev := <-eventRecorder.Events:
+				if strings.Contains(ev, reason) {
+					matched = append(matched, ev)
 				}
+			default:
+				return matched
 			}
 		}
-		return total, nil
 	}
 
 	Context("routing group auth posture consistency", func() {
@@ -83,14 +78,12 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
 			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
 
-			Consistently(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeZero())
+			Consistently(func() []string {
+				return drainEvents("AuthPostureMismatch")
 			}).WithContext(ctx).
 				WithTimeout(2 * time.Second).
 				WithPolling(300 * time.Millisecond).
-				Should(Succeed())
+				Should(BeEmpty())
 		})
 
 		It("should emit Warning events when two members have different auth posture", func(ctx SpecContext) {
@@ -107,11 +100,9 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
 			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically(">=", 1))
-			}).WithContext(ctx).Should(Succeed())
+			Eventually(func() []string {
+				return drainEvents("AuthPostureMismatch")
+			}).WithContext(ctx).ShouldNot(BeEmpty())
 		})
 
 		It("should not emit events for standalone services without a routing group", func(ctx SpecContext) {
@@ -121,14 +112,12 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			)
 			Expect(envTest.Client.Create(ctx, svc)).Should(Succeed())
 
-			Consistently(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeZero())
+			Consistently(func() []string {
+				return drainEvents("AuthPostureMismatch")
 			}).WithContext(ctx).
 				WithTimeout(2 * time.Second).
 				WithPolling(300 * time.Millisecond).
-				Should(Succeed())
+				Should(BeEmpty())
 		})
 
 		It("should emit Warning events when multiple members have mixed auth postures", func(ctx SpecContext) {
@@ -147,11 +136,9 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			)
 			Expect(envTest.Client.Create(ctx, svc4)).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically(">=", 1))
-			}).WithContext(ctx).Should(Succeed())
+			Eventually(func() []string {
+				return drainEvents("AuthPostureMismatch")
+			}).WithContext(ctx).ShouldNot(BeEmpty())
 		})
 
 		It("should stop emitting events when annotation is fixed to match", func(ctx SpecContext) {
@@ -168,11 +155,9 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
 			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically(">=", 1))
-			}).WithContext(ctx).Should(Succeed())
+			Eventually(func() []string {
+				return drainEvents("AuthPostureMismatch")
+			}).WithContext(ctx).ShouldNot(BeEmpty())
 
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())
@@ -181,17 +166,14 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			snapshotCount, err := countAuthPostureMismatchEvents(ctx, testNs)
-			Expect(err).NotTo(HaveOccurred())
+			drainEvents("AuthPostureMismatch")
 
-			Consistently(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically("<=", snapshotCount))
+			Consistently(func() []string {
+				return drainEvents("AuthPostureMismatch")
 			}).WithContext(ctx).
 				WithTimeout(2 * time.Second).
 				WithPolling(300 * time.Millisecond).
-				Should(Succeed())
+				Should(BeEmpty())
 		})
 
 		It("should exclude terminating members from mismatch detection", func(ctx SpecContext) {
@@ -208,11 +190,9 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			Expect(envTest.Client.Create(ctx, svc1)).Should(Succeed())
 			Expect(envTest.Client.Create(ctx, svc2)).Should(Succeed())
 
-			Eventually(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically(">=", 1))
-			}).WithContext(ctx).Should(Succeed())
+			Eventually(func() []string {
+				return drainEvents("AuthPostureMismatch")
+			}).WithContext(ctx).ShouldNot(BeEmpty())
 
 			// Mark svc2 with a deletion timestamp by setting a finalizer then deleting
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -240,18 +220,15 @@ var _ = Describe("Auth Posture Enforcement", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			snapshotCount, err := countAuthPostureMismatchEvents(ctx, testNs)
-			Expect(err).NotTo(HaveOccurred())
+			drainEvents("AuthPostureMismatch")
 
 			// With svc2 terminating, svc1 is the only active member - no mismatch possible
-			Consistently(func(g Gomega) {
-				count, err := countAuthPostureMismatchEvents(ctx, testNs)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(count).To(BeNumerically("<=", snapshotCount))
+			Consistently(func() []string {
+				return drainEvents("AuthPostureMismatch")
 			}).WithContext(ctx).
 				WithTimeout(2 * time.Second).
 				WithPolling(300 * time.Millisecond).
-				Should(Succeed())
+				Should(BeEmpty())
 
 			// Clean up finalizer so envtest can fully delete
 			Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(svc2), svc2)).To(Succeed())

--- a/internal/controller/serving/llm/fixture/envtest.go
+++ b/internal/controller/serving/llm/fixture/envtest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 
 	llmcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving/llm"
 	pkgtest "github.com/opendatahub-io/odh-model-controller/internal/controller/testing"
@@ -31,7 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func SetupTestEnv() *pkgtest.Client {
+func SetupTestEnv() (*pkgtest.Client, *record.FakeRecorder) {
 	duration, err := time.ParseDuration(utils.GetEnvOr("ENVTEST_DEFAULT_TIMEOUT", "30s"))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.SetDefaultEventuallyTimeout(duration)
@@ -44,11 +45,13 @@ func SetupTestEnv() *pkgtest.Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	setupLog := ctrl.Log.WithName("setup")
 
+	fakeRecorder := record.NewFakeRecorder(100)
+
 	llmCtrlFunc := func(mgr ctrl.Manager, cfg *rest.Config) error {
 		return llmcontroller.NewLLMInferenceServiceReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
-			mgr.GetEventRecorderFor("OpenDataHubModelController"),
+			fakeRecorder,
 		).SetupWithManager(mgr, setupLog)
 	}
 
@@ -56,7 +59,7 @@ func SetupTestEnv() *pkgtest.Client {
 		return llmcontroller.NewGatewayReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
-			mgr.GetEventRecorderFor("GatewayAuthBootstrap"),
+			fakeRecorder,
 		).SetupWithManager(mgr, setupLog)
 	}
 
@@ -71,5 +74,5 @@ func SetupTestEnv() *pkgtest.Client {
 
 	RequiredResources(ctx, envTest.Client, systemNs)
 
-	return envTest
+	return envTest, fakeRecorder
 }

--- a/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
+++ b/internal/controller/serving/llm/llm_inferenceservice_controller_test.go
@@ -19,7 +19,7 @@ package llm_test
 import (
 	"context"
 	"os"
-
+	"strings"
 	"time"
 
 	kservev1alpha2 "github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -225,9 +225,21 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				fixture.VerifyHTTPRouteAuthPolicyExists(ctx, envTest.Client, testNs, LLMInferenceServiceName)
 
-				// Snapshot current ReconcileError event count so we only
-				// detect NEW errors after the stop annotation is set.
-				initialErrorCount := countReconcileErrors(ctx, envTest.Client, testNs, LLMInferenceServiceName)
+				drainEvents := func(reason string) []string {
+					var matched []string
+					for {
+						select {
+						case ev := <-eventRecorder.Events:
+							if strings.Contains(ev, reason) {
+								matched = append(matched, ev)
+							}
+						default:
+							return matched
+						}
+					}
+				}
+
+				drainEvents("ReconcileError")
 
 				// Delete the HTTPRoute first to simulate kserve stop cleanup.
 				httpRouteName := constants.GetHTTPRouteName(LLMInferenceServiceName)
@@ -243,9 +255,9 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// The controller should not produce ReconcileError events for the
 				// stopped service (the bug's symptom was continuous warning events
 				// because AuthPolicy reconciliation tried to look up the deleted HTTPRoute).
-				Consistently(func() bool {
-					return countReconcileErrors(ctx, envTest.Client, testNs, LLMInferenceServiceName) > initialErrorCount
-				}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(BeFalse())
+				Consistently(func() []string {
+					return drainEvents("ReconcileError")
+				}).WithTimeout(2 * time.Second).WithPolling(100 * time.Millisecond).WithContext(ctx).Should(BeEmpty())
 			})
 		})
 	})
@@ -467,28 +479,6 @@ func createCrossNamespaceGateway(ctx context.Context, name, namespace string) {
 		}),
 	)
 	Expect(envTest.Client.Create(ctx, gw)).Should(Succeed())
-}
-
-// countReconcileErrors returns the number of ReconcileError events for the
-// given LLMInferenceService, including aggregated event counts.
-func countReconcileErrors(ctx context.Context, c client.Client, namespace, name string) int32 {
-	eventList := &corev1.EventList{}
-	if err := c.List(ctx, eventList, client.InNamespace(namespace)); err != nil {
-		return 0
-	}
-	var total int32
-	for _, ev := range eventList.Items {
-		if ev.Reason == "ReconcileError" &&
-			ev.InvolvedObject.Name == name &&
-			ev.InvolvedObject.Kind == "LLMInferenceService" {
-			if ev.Count > 0 {
-				total += ev.Count
-			} else {
-				total++
-			}
-		}
-	}
-	return total
 }
 
 // verifyResourcePersistentlyAbsent checks that a resource remains absent (Consistently + IsNotFound).

--- a/internal/controller/serving/llm/suite_test.go
+++ b/internal/controller/serving/llm/suite_test.go
@@ -21,9 +21,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/serving/llm/fixture"
-
 	pkgtest "github.com/opendatahub-io/odh-model-controller/internal/controller/testing"
 )
 
@@ -32,8 +32,11 @@ func TestLLMInferenceServiceController(t *testing.T) {
 	RunSpecs(t, "LLMInferenceService Controller Suite")
 }
 
-var envTest *pkgtest.Client
+var (
+	envTest       *pkgtest.Client
+	eventRecorder *record.FakeRecorder
+)
 
 var _ = SynchronizedBeforeSuite(func() {
-	envTest = fixture.SetupTestEnv()
+	envTest, eventRecorder = fixture.SetupTestEnv()
 }, func() {})


### PR DESCRIPTION
## Description

Eliminates intermittent failures in auth posture and ReconcileError event tests
caused by a race condition between the test assertions and controller-runtime's
async event recorder.

The real event recorder writes events through a buffered channel that drains to
the API server asynchronously. Tests that snapshot the event count right after
fixing a mismatch condition hit a race window - late-draining events from prior
reconcile runs increment the count after the snapshot, causing `Consistently`
assertions to fail unpredictably.

Switches the LLM test suite to `record.FakeRecorder`, so events land on a
channel the tests read directly. No API server write delay, no snapshot races.
The assertion pattern becomes straightforward drain-and-check - `Eventually`
for presence, `Consistently` for absence.

Net result: -27 lines, deterministic event assertions, zero flake window.

## How Has This Been Tested?

- Full LLM test suite passes (56/56 specs)
- Previously-flaky tests (`should stop emitting events when annotation is fixed
  to match` and `should exclude terminating members from mismatch detection`)
  run 3x consecutively with no failures
- `go vet` clean

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work