### PR TITLE
[RHOAIENG-62462] - TLS infrastructure for transformer-to-predictor co…

### DIFF
--- a/dev_tools/Containerfile.devspace
+++ b/dev_tools/Containerfile.devspace
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8
 USER root
 RUN mkdir /app && mkdir /.cache && chmod -R 777 /app && chmod -R 777 /.cache && chmod -R 777 /usr/local/bin
 RUN mkdir /.vscode-server && chmod 777 /.vscode-server && mkdir /.config && chmod 777 /.config

--- a/dev_tools/devspace.yaml
+++ b/dev_tools/devspace.yaml
@@ -55,7 +55,7 @@ dev:
     labelSelector:
       control-plane: odh-model-controller
     # Replace the container image with this dev-optimized image (allows to skip image building during development)
-    devImage: quay.io/jostrandquay/golang:1.25-devspace-toolset
+    devImage: quay.io/spolti/golang:1.25-odh-devspace-debug
     # Sync files between the local filesystem and the development container
     sync:
       - path: ../:/app
@@ -110,8 +110,8 @@ commands:
 #     path: ./ui        # Path-based dependencies (for monorepos)
 
 profiles:
-  - name: go1.22 
+  - name: go1.25
     patches: # Use patches to modify the base configuration
       - op: replace
         path: dev.app.devImage
-        value: quay.io/rh-ee-allausas/golang:1.22-odh-devspace-debug
+        value: quay.io/spolti/golang:1.25-odh-devspace-debug

--- a/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
@@ -134,7 +134,7 @@ func (r *KserveRawRouteReconciler) createDesiredResource(ctx context.Context, lo
 		return nil, fmt.Errorf("no predictor or transformer Service found for InferenceService %q", isvc.Name)
 	}
 
-	targetPort, err := setRouteTargetPort(enableSSL, &targetService)
+	targetPort, err := setRouteTargetPort(enableSSL && transformerService == nil, &targetService)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,8 @@ func (r *KserveRawRouteReconciler) createDesiredResource(ctx context.Context, lo
 	// Set route timeout
 	utils.SetOpenshiftRouteTimeoutForIsvc(desiredRoute, isvc)
 
-	if enableSSL {
+	if enableSSL && transformerService == nil {
+		// Reencrypt only for predictor (kube-rbac-proxy on port 8443)
 		desiredRoute.Spec.TLS = &v1.TLSConfig{
 			Termination:                   v1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,

--- a/internal/controller/serving/reconcilers/kserve_raw_route_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_route_reconciler_test.go
@@ -213,7 +213,7 @@ var _ = Describe("KserveRawRouteReconciler", func() {
 		})
 
 		When("transformer service exists", func() {
-			It("should target transformer service", func(ctx SpecContext) {
+			It("should target transformer service with edge TLS termination", func(ctx SpecContext) {
 				isvc := createISVC(
 					map[string]string{
 						constants.KserveNetworkVisibility: constants.LabelEnableKserveRawRoute,
@@ -248,6 +248,56 @@ var _ = Describe("KserveRawRouteReconciler", func() {
 				Expect(route).NotTo(BeNil())
 				Expect(route.Spec.To.Name).To(Equal("test-transformer"))
 				Expect(route.Spec.Port.TargetPort.StrVal).To(Equal("http"))
+				Expect(route.Spec.TLS.Termination).To(Equal(routev1.TLSTerminationEdge))
+			})
+		})
+
+		When("transformer service exists and auth is enabled", func() {
+			It("should use edge TLS termination and http port instead of reencrypt", func(ctx SpecContext) {
+				isvc := createISVCWithAnnotations(
+					map[string]string{
+						constants.KserveNetworkVisibility: constants.LabelEnableKserveRawRoute,
+					},
+					map[string]string{
+						constants.EnableAuthODHAnnotation: "true",
+					},
+				)
+
+				transformerSvc := createService("test-transformer",
+					map[string]string{
+						constants.KserveGroupAnnotation: "test",
+						"component":                     "transformer",
+					},
+					[]corev1.ServicePort{
+						{Name: "http", Port: 80},
+						{Name: "https", Port: 443},
+					},
+				)
+
+				predictorSvc := createService("test-predictor",
+					map[string]string{
+						constants.KserveGroupAnnotation: "test",
+						"component":                     "predictor",
+					},
+					[]corev1.ServicePort{
+						{Name: "http", Port: 80},
+						{Name: "https", Port: 443},
+					},
+				)
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(isvc, transformerSvc, predictorSvc).
+					Build()
+
+				reconciler := NewKserveRawRouteReconciler(client)
+				route, err := reconciler.createDesiredResource(ctx, log.Log, isvc)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(route).NotTo(BeNil())
+				Expect(route.Spec.To.Name).To(Equal("test-transformer"))
+				Expect(route.Spec.Port.TargetPort.StrVal).To(Equal("http"))
+				Expect(route.Spec.TLS.Termination).To(Equal(routev1.TLSTerminationEdge))
 			})
 		})
 
@@ -322,11 +372,16 @@ var _ = Describe("KserveRawRouteReconciler", func() {
 })
 
 func createISVC(labels map[string]string) *kservev1beta1.InferenceService {
+	return createISVCWithAnnotations(labels, nil)
+}
+
+func createISVCWithAnnotations(labels, annotations map[string]string) *kservev1beta1.InferenceService {
 	return &kservev1beta1.InferenceService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "ns",
-			Labels:    labels,
+			Name:        "test",
+			Namespace:   "ns",
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: kservev1beta1.InferenceServiceSpec{},
 	}


### PR DESCRIPTION
…mmunication

chore: KServe controller should provision TLS infrastructure for transformer-to-predictor communication when auth is enabled

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected routing for transformer services when SSL is enabled.
  * Transformer routes now use the appropriate non-SSL target port and TLS behavior.
  * Fixed authenticated transformer services to route through HTTP when required.

* **Chores**
  * Updated development tooling images and configuration for Go 1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->