### PR TITLE
fix: update go-toolset and ubi-minimal base images for CVE fixes

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG SOURCE_CODE=.
 
 # Build the manager binary
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:799cc027d5ad58cdc156b65286eb6389993ec14c496cf748c09834b7251e78dc as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.
@@ -27,7 +27,7 @@ COPY internal/ internal/
 USER root
 RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -a -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:2f06ae0e6d3d9c4f610d32c480338eef474867f435d8d28625f2985e8acde6e8 AS runtime
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:48fa5d8cda7fc00d270d8747c3eaa54ae196f0820d8540074a9c8c61d5e3056f AS runtime
 
 ARG USER=2000
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-model-controller
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
- Update `go-toolset:1.25` base image to latest patched version
- Update `ubi-minimal` base image to latest patched version
- Bump Go version to 1.25.9 for stdlib CVE fixes
- Fix casing of `AS` keyword in multi-stage build

https://redhat.atlassian.net/browse/RHOAIENG-74668

## Test plan
- [ ] Verify Dockerfile.konflux builds successfully
- [ ] Verify runtime image includes Go 1.25.9
- [ ] Verify FIPS mode still enabled with strictfipsruntime

🤖 Generated with [Claude Code](https://claude.ai/claude-code)